### PR TITLE
Initial support for Resource Queries

### DIFF
--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -137,12 +137,12 @@ const setupPreset = (
     // Force re-evaluation to support multiple projects
     try {
       if (presetModule) {
-        delete require.cache[require.resolve(presetModule)];
+        delete require.cache[require.resolve(presetModule.path)];
       }
     } catch (e) {}
 
     // @ts-ignore: `presetModule` can be null?
-    preset = require(presetModule);
+    preset = require(presetModule.path);
   } catch (error) {
     if (error instanceof SyntaxError || error instanceof TypeError) {
       throw createConfigError(
@@ -435,7 +435,7 @@ const normalizeReporters = (options: Config.InitialOptionsWithRootDir) => {
             `  Module name: ${reporterPath}`,
         );
       }
-      normalizedReporterConfig[0] = reporter;
+      normalizedReporterConfig[0] = reporter.path;
     }
     return normalizedReporterConfig;
   });

--- a/packages/jest-config/src/utils.ts
+++ b/packages/jest-config/src/utils.ts
@@ -49,7 +49,7 @@ export const resolve = (
     );
   }
   /// can cast as string since nulls will be thrown
-  return module as string;
+  return module?.path as string;
 };
 
 export const escapeGlobCharacters = (path: Config.Path): Config.Glob =>
@@ -139,7 +139,7 @@ export const resolveWithPrefix = (
     resolver: resolver || undefined,
   });
   if (module) {
-    return module;
+    return module.path;
   }
 
   try {
@@ -151,7 +151,7 @@ export const resolveWithPrefix = (
     resolver: resolver || undefined,
   });
   if (module) {
-    return module;
+    return module.path;
   }
 
   try {

--- a/packages/jest-reporters/src/coverage_worker.ts
+++ b/packages/jest-reporters/src/coverage_worker.ts
@@ -37,7 +37,7 @@ export function worker({
 }: CoverageWorkerData): CoverageWorkerResult | null {
   return generateEmptyCoverage(
     fs.readFileSync(path, 'utf8'),
-    path,
+    {id: path, path},
     globalConfig,
     config,
     options && options.changedFiles && new Set(options.changedFiles),

--- a/packages/jest-reporters/src/generateEmptyCoverage.ts
+++ b/packages/jest-reporters/src/generateEmptyCoverage.ts
@@ -27,7 +27,7 @@ export type CoverageWorkerResult =
 
 export default function (
   source: string,
-  filename: Config.Path,
+  filename: Config.RPth,
   globalConfig: Config.GlobalConfig,
   config: Config.ProjectConfig,
   changedFiles?: Set<Config.Path>,
@@ -40,9 +40,9 @@ export default function (
     coverageProvider: globalConfig.coverageProvider,
   };
   let coverageWorkerResult: CoverageWorkerResult | null = null;
-  if (shouldInstrument(filename, coverageOptions, config)) {
+  if (shouldInstrument(filename.path, coverageOptions, config)) {
     if (coverageOptions.coverageProvider === 'v8') {
-      const stat = fs.statSync(filename);
+      const stat = fs.statSync(filename.path);
       return {
         kind: 'V8Coverage',
         result: {
@@ -60,7 +60,7 @@ export default function (
             },
           ],
           scriptId: '0',
-          url: filename,
+          url: filename.path,
         },
       };
     }

--- a/packages/jest-resolve-dependencies/src/index.ts
+++ b/packages/jest-resolve-dependencies/src/index.ts
@@ -56,7 +56,7 @@ class DependencyResolver {
           file,
           dependency,
           options,
-        );
+        ).path;
       } catch {
         try {
           resolvedDependency = this._resolver.getMockModule(file, dependency);

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -50,9 +50,9 @@ const nodePaths = NODE_PATH
   : undefined;
 
 function parseOutQuery(pathQithQuery: string) {
-  const [path, ...queryParts] = pathQithQuery.split('?')
-  const query = queryParts.join('')
-  return [path, query]
+  const [path, ...queryParts] = pathQithQuery.split('?');
+  const query = queryParts.join('');
+  return [path, query];
 }
 
 /* eslint-disable-next-line no-redeclare */
@@ -118,7 +118,7 @@ class Resolver {
     const paths = options.paths;
 
     try {
-      const [nativePath, query] = parseOutQuery(path)
+      const [nativePath, query] = parseOutQuery(path);
       const realpath = resolver(nativePath, {
         basedir: options.basedir,
         browser: options.browser,
@@ -130,9 +130,9 @@ class Resolver {
       });
 
       return {
+        id: `${realpath}?${query}`,
         path: realpath,
-        id: `${realpath}?${query}`
-      }
+      };
     } catch (e) {
       if (options.throwIfNotFound) {
         throw e;
@@ -176,9 +176,9 @@ class Resolver {
     const hasteModule = this.getModule(nativeName);
     if (hasteModule) {
       const resolvedPath = {
+        id: `haste:${hasteModule}?${query}`,
         path: hasteModule,
-        id: `haste:${hasteModule}?${query}`
-      }
+      };
       this._moduleNameCache.set(key, resolvedPath);
       return resolvedPath;
     }
@@ -206,7 +206,10 @@ class Resolver {
 
     if (!skipResolution) {
       // @ts-ignore: the "pnp" version named isn't in DefinitelyTyped
-      const nodeModule = resolveNodeModule(moduleName, Boolean(process.versions.pnp));
+      const nodeModule = resolveNodeModule(
+        moduleName,
+        Boolean(process.versions.pnp),
+      );
 
       if (nodeModule) {
         this._moduleNameCache.set(key, nodeModule);
@@ -220,12 +223,12 @@ class Resolver {
     const hastePackage = this.getPackage(parts.shift()!);
     if (hastePackage) {
       const requireResolve = (name: string) => {
-        const path = require.resolve(name)
+        const path = require.resolve(name);
         return {
+          id: `haste:${path}?${query}`,
           path,
-          id: `haste:${path}?${query}`
-        }
-      }
+        };
+      };
       try {
         const hastePackageModule = path.join.apply(
           path,
@@ -234,7 +237,8 @@ class Resolver {
         // try resolving with custom resolver first to support extensions,
         // then fallback to require.resolve
         const resolvedModule =
-          resolveNodeModule(hastePackageModule) || requireResolve(hastePackageModule);
+          resolveNodeModule(hastePackageModule) ||
+          requireResolve(hastePackageModule);
         this._moduleNameCache.set(key, resolvedModule);
         return resolvedModule;
       } catch (ignoredError) {}
@@ -454,28 +458,27 @@ class Resolver {
           for (const possibleModuleName of possibleModuleNames) {
             const updatedName = mapModuleName(possibleModuleName);
 
-            const hasteModule = this.getModule(updatedName)
+            const hasteModule = this.getModule(updatedName);
             if (hasteModule) {
               module = {
+                id: `haste:${hasteModule}?${query}`,
                 path: hasteModule,
-                id: `haste:${hasteModule}?${query}`
-              }
-              break
+              };
+              break;
             }
 
-            const nodeModule =
-              Resolver.findNodeModule(updatedName, {
-                basedir: dirname,
-                browser: this._options.browser,
-                extensions,
-                moduleDirectory,
-                paths,
-                resolver,
-                rootDir: this._options.rootDir,
-              });
+            const nodeModule = Resolver.findNodeModule(updatedName, {
+              basedir: dirname,
+              browser: this._options.browser,
+              extensions,
+              moduleDirectory,
+              paths,
+              resolver,
+              rootDir: this._options.rootDir,
+            });
 
             if (nodeModule) {
-              module = nodeModule
+              module = nodeModule;
               break;
             }
           }

--- a/packages/jest-runtime/src/__mocks__/resourceQueryResolver.js
+++ b/packages/jest-runtime/src/__mocks__/resourceQueryResolver.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+module.exports = function userResolver(path, options) {
+  const defaultResolver = require('../__tests__/defaultResolver.js');
+  const [clearPath, query] = path.split('?');
+  return defaultResolver(clearPath, options) + (query ? '?' + query : '');
+};

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -252,6 +252,47 @@ describe('Runtime requireModule', () => {
       expect(hastePackage.isHastePackage).toBe(true);
     }));
 
+  it('supports resolving the same path to multiple modules', () =>
+    createRuntime(__filename, {
+      // using the default resolver as a custom resolver
+      resolver: require.resolve('../__mocks__/resourceQueryResolver.js'),
+    }).then(runtime => {
+      const moduleNoQuery1 = runtime.requireModule(
+        runtime.__mockRootPath,
+        './moduleForResourceQuery.js',
+      );
+      const moduleNoQuery2 = runtime.requireModule(
+        runtime.__mockRootPath,
+        './moduleForResourceQuery.js',
+      );
+      expect(moduleNoQuery1.name).toBe('moduleForResourceQuery');
+      expect(moduleNoQuery1).toBe(moduleNoQuery2);
+
+      const moduleWithQueryA = runtime.requireModule(
+        runtime.__mockRootPath,
+        './moduleForResourceQuery.js?a',
+      );
+      const moduleWithQueryB = runtime.requireModule(
+        runtime.__mockRootPath,
+        './moduleForResourceQuery.js?b',
+      );
+      expect(moduleWithQueryA.name).toBe('moduleForResourceQuery');
+      expect(moduleWithQueryB.name).toBe('moduleForResourceQuery');
+      expect(moduleWithQueryA).not.toBe(moduleWithQueryB);
+
+      const moduleWithSameQuery1 = runtime.requireModule(
+        runtime.__mockRootPath,
+        './moduleForResourceQuery.js?sameQuery',
+      );
+      const moduleWithSameQuery2 = runtime.requireModule(
+        runtime.__mockRootPath,
+        './moduleForResourceQuery.js?sameQuery',
+      );
+      expect(moduleWithSameQuery1.name).toBe('moduleForResourceQuery');
+      expect(moduleWithSameQuery2.name).toBe('moduleForResourceQuery');
+      expect(moduleWithSameQuery1).toBe(moduleWithSameQuery2);
+    }));
+
   it('resolves node modules properly when crawling node_modules', () =>
     // While we are crawling a node module, we shouldn't put package.json
     // files of node modules to resolve to `package.json` but rather resolve

--- a/packages/jest-runtime/src/__tests__/test_root/moduleForResourceQuery.js
+++ b/packages/jest-runtime/src/__tests__/test_root/moduleForResourceQuery.js
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// this object reference should be uniq per each module compilation
+const newObject = {name: 'moduleForResourceQuery'};
+
+module.exports = newObject;

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -675,8 +675,8 @@ class Runtime {
     this._moduleMocker.clearAllMocks();
   }
 
-  private _resolveModule(from: Config.Path, to?: string) {
-    return to ? this._resolver.resolveModule(from, to) : from;
+  private _resolveModule(from: Config.Path, to?: string): string {
+    return to ? this._resolver.resolveModule(from, to).path : from;
   }
 
   private _requireResolve(
@@ -702,7 +702,7 @@ class Runtime {
           {paths: [absolutePath]},
         );
         if (module) {
-          return module;
+          return module.path;
         }
       }
 
@@ -939,6 +939,7 @@ class Runtime {
         filename,
         id: filename,
         loaded: false,
+        rpth: {id: 'InitialModule', path: filename}
       });
     };
 
@@ -978,7 +979,7 @@ class Runtime {
 
   private _generateMock(from: Config.Path, moduleName: string) {
     const modulePath =
-      this._resolver.resolveStubModuleName(from, moduleName) ||
+      this._resolver.resolveStubModuleName(from, moduleName)?.path ||
       this._resolveModule(from, moduleName);
     if (!(modulePath in this._mockMetaDataCache)) {
       // This allows us to handle circular dependencies while generating an

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -55,7 +55,9 @@ type InternalModuleOptions = {
 };
 
 type InitialModule = Partial<Module> &
-  Pick<Module, 'children' | 'exports' | 'filename' | 'id' | 'loaded'>;
+  Pick<Module, 'children' | 'exports' | 'filename' | 'id' | 'loaded'> & {
+    rpth: Config.RPth;
+  };
 type ModuleRegistry = Map<string, InitialModule | Module>;
 type ResolveOptions = Parameters<typeof require.resolve>[1];
 
@@ -352,6 +354,7 @@ class Runtime {
       filename: modulePath,
       id: modulePath,
       loaded: false,
+      rpth: {id: 'InitialModule', path: modulePath},
     };
     moduleRegistry.set(modulePath, localModule);
 
@@ -442,6 +445,7 @@ class Runtime {
         filename: modulePath,
         id: modulePath,
         loaded: false,
+        rpth: {id: 'InitialModule', path: modulePath},
       };
 
       this._loadModule(
@@ -746,7 +750,7 @@ class Runtime {
     localModule: InitialModule,
     options: InternalModuleOptions | undefined,
     moduleRegistry: ModuleRegistry,
-    from: Config.Path | null,
+    from: Config.Path | null, // RPth?
   ) {
     // If the environment was disposed, prevent this module from being executed.
     if (!this._environment.global) {
@@ -775,7 +779,7 @@ class Runtime {
       value: this._createRequireImplementation(localModule, options),
     });
     const transformedFile = this._scriptTransformer.transform(
-      filename,
+      localModule.rpth,
       this._getFullTransformationOptions(options),
       this._cacheFS[filename],
     );

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -939,7 +939,7 @@ class Runtime {
         filename,
         id: filename,
         loaded: false,
-        rpth: {id: 'InitialModule', path: filename}
+        rpth: {id: 'InitialModule', path: filename},
       });
     };
 

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -12,6 +12,20 @@ import chalk = require('chalk');
 type CoverageProvider = 'babel' | 'v8';
 
 export type Path = string;
+export type PathID = string;
+// Keeping RPth of the same length as Path for now, to keep diffs to minimum
+// will rename it later.
+export type RPth = {
+  // the initial path as it was used before this PR
+  // replace it with other properties:
+  // 1. realpath - full path resolved using smth. like _getRealPath()
+  // 2. filename - just the file name w/o the containing directies
+  // 3. extname - just the extension (to speed up a bit)
+  // 4. dirname - just the dir name (to speed up a bit)
+  readonly path: string
+  // prob. the real path + the query string
+  readonly id: PathID,
+};
 
 export type Glob = string;
 

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -22,9 +22,9 @@ export type RPth = {
   // 2. filename - just the file name w/o the containing directies
   // 3. extname - just the extension (to speed up a bit)
   // 4. dirname - just the dir name (to speed up a bit)
-  readonly path: string
+  readonly path: string;
   // prob. the real path + the query string
-  readonly id: PathID,
+  readonly id: PathID;
 };
 
 export type Glob = string;


### PR DESCRIPTION
**UPDATE**: See [this comment](https://github.com/facebook/jest/pull/6282#issuecomment-584327637) for the changes plan and the latest progress.

~~TL;DR; this PR needs an architecture decision for further development 🙏~~ DONE in the comment linked above 🎉

# Backstory

Resource Queries is a relatively recent trend defined by support by [WebPack's import()](https://webpack.js.org/configuration/module/#rule-resourcequery) and in [ES6 import()](https://whatwg.github.io/loader/#loader-import). Having Resource Queries supported in dynamic `import()` means it should be also supported in static `import * from 'module'`. It is expected that developers will build features on top of the web driven semantics of `import`, so it would be of use to have basic support for Resource Query aware plugins in Jest as well.

As decided in #4549 this PR should only demonstrate how minor would be the impact fo the Solution 3 described below. A scope of the final goal is defined in https://github.com/facebook/jest/issues/4181#issuecomment-374895468.

# Description

Firstly, here go file path use cases in the core test running process:

* read / fstat the file;
* use as a part of a cache key;
* getting file extension for transformation;
* matching agains RegExp to ignore.

## Solution 1: Smart filename

Full scale solution satisfying all use cases would be to teach a user defined `resolver()` to return an object `{path, id}` instead of a string, and then refactor all the code which uses type `Path`, as currently the full module path is (expectedly) used as a uniq file identifier across many modules;

Good example is the `getScriptCacheKey()` at [script_transformer.js](https://github.com/facebook/jest/blob/master/packages/jest-runtime/src/script_transformer.js#L474). It needs a module file path to get it's mtime and also the file id to add it to the key, as for the same physical file the modification time will also be the same leading to the same cache keys for two different resources queries. Here is how it might look like:

```js
const getScriptCacheKey = (file, config, instrument: boolean) => {
  const mtime = fs.statSync(file.path).mtime;
  return file.id + '_' + mtime.getTime() + (instrument ? '_instrumented' : '');
};
```

## Solution 2: Smart resolver

Less aggressive approach might be to just teach Jest to transform original file path before use in functions from `fs` and `path` modules with new method of resolver (say, `getFsPath()`). This could enable a native support for Resource Queries by default or any other file path overloading. This will require changing code in few places where Jest runtime touches filesystem or needs a real file name by injecting that `getFsPath()`.

The example with `getScriptCacheKey()` would then look like this:

```js
const getScriptCacheKey = (filename, config, instrument: boolean) => {
  const mtime = fs.statSync(config.resolver.getFsPath(filename)).mtime;
  return filename + '_' + mtime.getTime() + (instrument ? '_instrumented' : '');
};
```

## Solution 3: Too smart fs module

The most general and least intrusive solution (but also kind of hacky) is to make the `fs` module configurable, so that a plugin developer can provide a version of `fs` which tolerates the resource query appendix. This might be a first baby step towards a full Resource Query support. This solution breaks though two use cases. The one where a module file name extension is used to select a transformer (`path.extname('a.out?query')` return `'.out?query'`). The other one is matching a module file path against an ignore RegExp (as `/test/.'/path/to/load.js?ab_test=1'.` returns `true`). This could be partially fixed by prefixing a file path with filters (like webpack does) internally instead of appending.

If you know how to better resolve this architectural challenges, please, help 😊