### PR TITLE
feat: opaque symlink support

### DIFF
--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -19,6 +19,7 @@
     "jest-util": "^24.9.0",
     "jest-worker": "^24.9.0",
     "micromatch": "^3.1.10",
+    "realpath-native": "^1.0.0",
     "sane": "^4.0.3",
     "walker": "^1.0.7"
   },

--- a/packages/jest-haste-map/src/__tests__/index.test.js
+++ b/packages/jest-haste-map/src/__tests__/index.test.js
@@ -102,6 +102,7 @@ jest.mock('graceful-fs', () => ({
     error.code = 'ENOENT';
     throw error;
   }),
+  realpath: jest.fn(path => path),
   writeFileSync: jest.fn((path, data, options) => {
     expect(options).toBe(require('v8').serialize ? undefined : 'utf8');
     mockFs[path] = data;
@@ -224,8 +225,6 @@ describe('HasteMap', () => {
 
   it('creates valid cache file paths', () => {
     jest.resetModuleRegistry();
-    HasteMap = require('../');
-
     expect(
       HasteMap.getCacheFilePath('/', '@scoped/package', 'random-value'),
     ).toMatch(/^\/-scoped-package-(.*)$/);
@@ -241,7 +240,6 @@ describe('HasteMap', () => {
 
   it('creates different cache file paths for different dependency extractor cache keys', () => {
     jest.resetModuleRegistry();
-    const HasteMap = require('../');
     const dependencyExtractor = require('./dependencyExtractor');
     const config = {
       ...defaultConfig,
@@ -256,7 +254,6 @@ describe('HasteMap', () => {
 
   it('creates different cache file paths for different hasteImplModulePath cache keys', () => {
     jest.resetModuleRegistry();
-    const HasteMap = require('../');
     const hasteImpl = require('./haste_impl');
     hasteImpl.setCacheKey('foo');
     const hasteMap1 = new HasteMap(defaultConfig);

--- a/packages/jest-haste-map/src/crawlers/__tests__/__snapshots__/watchman.test.js.snap
+++ b/packages/jest-haste-map/src/crawlers/__tests__/__snapshots__/watchman.test.js.snap
@@ -1,0 +1,363 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`watchman watch does not add directory filters to query when watching a ROOT 1`] = `
+Array [
+  Array [
+    "watch-project",
+    "/root-mock/fruits",
+  ],
+  Array [
+    "watch-project",
+    "/root-mock/vegetables",
+  ],
+  Array [
+    "watch-project",
+    "/root-mock",
+  ],
+  Array [
+    "query",
+    "/root-mock",
+    Object {
+      "expression": Array [
+        "allof",
+        Array [
+          "anyof",
+          Array [
+            "dirname",
+            "fruits",
+          ],
+        ],
+        Array [
+          "allof",
+          Array [
+            "type",
+            "l",
+          ],
+          Array [
+            "anyof",
+            Array [
+              "match",
+              "**/node_modules/*",
+              "wholename",
+              Object {
+                "includedotfiles": true,
+              },
+            ],
+            Array [
+              "match",
+              "**/node_modules/@*/*",
+              "wholename",
+              Object {
+                "includedotfiles": true,
+              },
+            ],
+          ],
+        ],
+      ],
+      "fields": Array [
+        "name",
+        "exists",
+        "mtime_ms",
+        "size",
+        "type",
+      ],
+      "since": undefined,
+    },
+  ],
+  Array [
+    "query",
+    "/root-mock",
+    Object {
+      "expression": Array [
+        "allof",
+        Array [
+          "anyof",
+          Array [
+            "dirname",
+            "vegetables",
+          ],
+        ],
+        Array [
+          "allof",
+          Array [
+            "type",
+            "l",
+          ],
+          Array [
+            "anyof",
+            Array [
+              "match",
+              "**/node_modules/*",
+              "wholename",
+              Object {
+                "includedotfiles": true,
+              },
+            ],
+            Array [
+              "match",
+              "**/node_modules/@*/*",
+              "wholename",
+              Object {
+                "includedotfiles": true,
+              },
+            ],
+          ],
+        ],
+      ],
+      "fields": Array [
+        "name",
+        "exists",
+        "mtime_ms",
+        "size",
+        "type",
+      ],
+      "since": undefined,
+    },
+  ],
+  Array [
+    "query",
+    "/root-mock",
+    Object {
+      "expression": Array [
+        "allof",
+        Array [
+          "type",
+          "l",
+        ],
+        Array [
+          "anyof",
+          Array [
+            "match",
+            "**/node_modules/*",
+            "wholename",
+            Object {
+              "includedotfiles": true,
+            },
+          ],
+          Array [
+            "match",
+            "**/node_modules/@*/*",
+            "wholename",
+            Object {
+              "includedotfiles": true,
+            },
+          ],
+        ],
+      ],
+      "fields": Array [
+        "name",
+        "exists",
+        "mtime_ms",
+        "size",
+        "type",
+      ],
+      "since": undefined,
+    },
+  ],
+  Array [
+    "query",
+    "/root-mock",
+    Object {
+      "expression": Array [
+        "anyof",
+        Array [
+          "type",
+          "l",
+        ],
+        Array [
+          "allof",
+          Array [
+            "type",
+            "f",
+          ],
+          Array [
+            "anyof",
+            Array [
+              "suffix",
+              "js",
+            ],
+            Array [
+              "suffix",
+              "json",
+            ],
+          ],
+        ],
+      ],
+      "fields": Array [
+        "name",
+        "exists",
+        "mtime_ms",
+        "size",
+        "type",
+      ],
+      "since": undefined,
+    },
+  ],
+]
+`;
+
+exports[`watchman watch returns a list of all files when there are no clocks 1`] = `
+Array [
+  Array [
+    "watch-project",
+    "/root-mock/fruits",
+  ],
+  Array [
+    "watch-project",
+    "/root-mock/vegetables",
+  ],
+  Array [
+    "query",
+    "/root-mock",
+    Object {
+      "expression": Array [
+        "allof",
+        Array [
+          "anyof",
+          Array [
+            "dirname",
+            "fruits",
+          ],
+        ],
+        Array [
+          "allof",
+          Array [
+            "type",
+            "l",
+          ],
+          Array [
+            "anyof",
+            Array [
+              "match",
+              "**/node_modules/*",
+              "wholename",
+              Object {
+                "includedotfiles": true,
+              },
+            ],
+            Array [
+              "match",
+              "**/node_modules/@*/*",
+              "wholename",
+              Object {
+                "includedotfiles": true,
+              },
+            ],
+          ],
+        ],
+      ],
+      "fields": Array [
+        "name",
+        "exists",
+        "mtime_ms",
+        "size",
+        "type",
+      ],
+      "since": undefined,
+    },
+  ],
+  Array [
+    "query",
+    "/root-mock",
+    Object {
+      "expression": Array [
+        "allof",
+        Array [
+          "anyof",
+          Array [
+            "dirname",
+            "vegetables",
+          ],
+        ],
+        Array [
+          "allof",
+          Array [
+            "type",
+            "l",
+          ],
+          Array [
+            "anyof",
+            Array [
+              "match",
+              "**/node_modules/*",
+              "wholename",
+              Object {
+                "includedotfiles": true,
+              },
+            ],
+            Array [
+              "match",
+              "**/node_modules/@*/*",
+              "wholename",
+              Object {
+                "includedotfiles": true,
+              },
+            ],
+          ],
+        ],
+      ],
+      "fields": Array [
+        "name",
+        "exists",
+        "mtime_ms",
+        "size",
+        "type",
+      ],
+      "since": undefined,
+    },
+  ],
+  Array [
+    "query",
+    "/root-mock",
+    Object {
+      "expression": Array [
+        "allof",
+        Array [
+          "anyof",
+          Array [
+            "dirname",
+            "fruits",
+          ],
+          Array [
+            "dirname",
+            "vegetables",
+          ],
+        ],
+        Array [
+          "anyof",
+          Array [
+            "type",
+            "l",
+          ],
+          Array [
+            "allof",
+            Array [
+              "type",
+              "f",
+            ],
+            Array [
+              "anyof",
+              Array [
+                "suffix",
+                "js",
+              ],
+              Array [
+                "suffix",
+                "json",
+              ],
+            ],
+          ],
+        ],
+      ],
+      "fields": Array [
+        "name",
+        "exists",
+        "mtime_ms",
+        "size",
+        "type",
+      ],
+      "since": undefined,
+    },
+  ],
+]
+`;

--- a/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/watchman.test.js
@@ -123,6 +123,8 @@ describe('watchman watch', () => {
       data: {
         clocks: new Map(),
         files: new Map(),
+        links: new Map(),
+        roots: [],
       },
       extensions: ['js', 'json'],
       ignore: pearMatcher,
@@ -134,34 +136,11 @@ describe('watchman watch', () => {
 
       expect(client.on).toBeCalled();
       expect(client.on).toBeCalledWith('error', expect.any(Function));
-
-      // Call 0 and 1 are for ['watch-project']
-      expect(calls[0][0][0]).toEqual('watch-project');
-      expect(calls[1][0][0]).toEqual('watch-project');
-
-      // Call 2 is the query
-      const query = calls[2][0];
-      expect(query[0]).toEqual('query');
-
-      expect(query[2].expression).toEqual([
-        'allof',
-        ['type', 'f'],
-        ['anyof', ['suffix', 'js'], ['suffix', 'json']],
-        ['anyof', ['dirname', 'fruits'], ['dirname', 'vegetables']],
-      ]);
-
-      expect(query[2].fields).toEqual(['name', 'exists', 'mtime_ms', 'size']);
-
-      expect(query[2].glob).toEqual([
-        'fruits/**/*.js',
-        'fruits/**/*.json',
-        'vegetables/**/*.js',
-        'vegetables/**/*.json',
-      ]);
+      expect(calls.map(call => call[0])).toMatchSnapshot();
 
       expect(hasteMap.clocks).toEqual(
         createMap({
-          '': 'c:fake-clock:1',
+          '.': 'c:fake-clock:1',
         }),
       );
 
@@ -203,6 +182,8 @@ describe('watchman watch', () => {
       data: {
         clocks: new Map(),
         files: new Map(),
+        links: new Map(),
+        roots: [],
       },
       extensions: ['js', 'json', 'zip'],
       ignore: pearMatcher,
@@ -256,13 +237,15 @@ describe('watchman watch', () => {
     };
 
     const clocks = createMap({
-      '': 'c:fake-clock:1',
+      '.': 'c:fake-clock:1',
     });
 
     return watchmanCrawl({
       data: {
         clocks,
         files: mockFiles,
+        links: new Map(),
+        roots: [],
       },
       extensions: ['js', 'json'],
       ignore: pearMatcher,
@@ -274,7 +257,7 @@ describe('watchman watch', () => {
 
       expect(hasteMap.clocks).toEqual(
         createMap({
-          '': 'c:fake-clock:2',
+          '.': 'c:fake-clock:2',
         }),
       );
 
@@ -346,13 +329,15 @@ describe('watchman watch', () => {
     mockFiles.set(TOMATO_RELATIVE, mockTomatoMetadata);
 
     const clocks = createMap({
-      '': 'c:fake-clock:1',
+      '.': 'c:fake-clock:1',
     });
 
     return watchmanCrawl({
       data: {
         clocks,
         files: mockFiles,
+        links: new Map(),
+        roots: [],
       },
       extensions: ['js', 'json'],
       ignore: pearMatcher,
@@ -364,7 +349,7 @@ describe('watchman watch', () => {
 
       expect(hasteMap.clocks).toEqual(
         createMap({
-          '': 'c:fake-clock:3',
+          '.': 'c:fake-clock:3',
         }),
       );
 
@@ -449,6 +434,8 @@ describe('watchman watch', () => {
       data: {
         clocks,
         files: mockFiles,
+        links: new Map(),
+        roots: [],
       },
       extensions: ['js', 'json'],
       ignore: pearMatcher,
@@ -514,6 +501,8 @@ describe('watchman watch', () => {
       data: {
         clocks: new Map(),
         files: new Map(),
+        links: new Map(),
+        roots: [],
       },
       extensions: ['js', 'json'],
       ignore: pearMatcher,
@@ -525,29 +514,11 @@ describe('watchman watch', () => {
 
       expect(client.on).toBeCalled();
       expect(client.on).toBeCalledWith('error', expect.any(Function));
-
-      // First 3 calls are for ['watch-project']
-      expect(calls[0][0][0]).toEqual('watch-project');
-      expect(calls[1][0][0]).toEqual('watch-project');
-      expect(calls[2][0][0]).toEqual('watch-project');
-
-      // Call 4 is the query
-      const query = calls[3][0];
-      expect(query[0]).toEqual('query');
-
-      expect(query[2].expression).toEqual([
-        'allof',
-        ['type', 'f'],
-        ['anyof', ['suffix', 'js'], ['suffix', 'json']],
-      ]);
-
-      expect(query[2].fields).toEqual(['name', 'exists', 'mtime_ms', 'size']);
-
-      expect(query[2].glob).toEqual(['**/*.js', '**/*.json']);
+      expect(calls.map(call => call[0])).toMatchSnapshot();
 
       expect(hasteMap.clocks).toEqual(
         createMap({
-          '': 'c:fake-clock:1',
+          '.': 'c:fake-clock:1',
         }),
       );
 
@@ -588,6 +559,8 @@ describe('watchman watch', () => {
       data: {
         clocks: new Map(),
         files: new Map(),
+        links: new Map(),
+        roots: [],
       },
       extensions: ['js', 'json'],
       rootDir: ROOT_MOCK,
@@ -628,6 +601,8 @@ describe('watchman watch', () => {
       data: {
         clocks: new Map(),
         files: new Map(),
+        links: new Map(),
+        roots: [],
       },
       extensions: ['js', 'json'],
       rootDir: ROOT_MOCK,

--- a/packages/jest-haste-map/src/crawlers/node.ts
+++ b/packages/jest-haste-map/src/crawlers/node.ts
@@ -165,6 +165,7 @@ export = function nodeCrawl(
         removedFiles.delete(relativeFilePath);
       });
       data.files = files;
+      data.links = new Map(); // TODO: support symlinks
 
       resolve({
         hasteMap: data,

--- a/packages/jest-haste-map/src/crawlers/watchman.ts
+++ b/packages/jest-haste-map/src/crawlers/watchman.ts
@@ -206,9 +206,10 @@ export = async function watchmanCrawl(
       queryResponse.files.map(async (link: WatchmanFile) => {
         const name = normalizePathSep(link.name);
         const linkPath = path.join(watchRoot, name);
+        const relativePath = fastPath.relative(rootDir, linkPath);
 
         if (!link.exists || ignore(linkPath)) {
-          data.links.delete(linkPath);
+          data.links.delete(relativePath);
           return;
         }
 
@@ -219,10 +220,10 @@ export = async function watchmanCrawl(
           return; // Skip broken symlinks.
         }
 
-        const metaData = data.links.get(linkPath);
+        const metaData = data.links.get(relativePath);
         const mtime = testModified(metaData, link.mtime_ms);
         dependencyLinks.set(
-          linkPath,
+          relativePath,
           mtime !== 0 ? [target, mtime] : metaData!,
         );
 

--- a/packages/jest-haste-map/src/crawlers/watchman.ts
+++ b/packages/jest-haste-map/src/crawlers/watchman.ts
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import fs from 'fs';
 import path from 'path';
+import {sync as realpath} from 'realpath-native';
 import watchman from 'fb-watchman';
 import {Config} from '@jest/types';
 import * as fastPath from '../lib/fast_path';
@@ -16,12 +18,30 @@ import {
   CrawlerOptions,
   FileMetaData,
   FileData,
+  LinkMetaData,
 } from '../types';
 
 type WatchmanRoots = Map<string, Array<string>>;
 
 const watchmanURL =
   'https://facebook.github.io/watchman/docs/troubleshooting.html';
+
+// Matches symlinks in "node_modules" directories.
+const nodeModulesExpression = [
+  'allof',
+  ['type', 'l'],
+  [
+    'anyof',
+    ...['**/node_modules/*', '**/node_modules/@*/*'].map(glob => [
+      'match',
+      glob,
+      'wholename',
+      {includedotfiles: true},
+    ]),
+  ],
+];
+
+const NODE_MODULES = path.sep + 'node_modules' + path.sep;
 
 function WatchmanError(error: Error): Error {
   error.message =
@@ -37,14 +57,7 @@ export = async function watchmanCrawl(
   removedFiles: FileData;
   hasteMap: InternalHasteMap;
 }> {
-  const fields = ['name', 'exists', 'mtime_ms', 'size'];
-  const {data, extensions, ignore, rootDir, roots} = options;
-  const defaultWatchExpression = [
-    'allof',
-    ['type', 'f'],
-    ['anyof', ...extensions.map(extension => ['suffix', extension])],
-  ];
-  const clocks = data.clocks;
+  const {data, extensions, ignore, rootDir} = options;
   const client = new watchman.Client();
 
   let clientError;
@@ -58,208 +71,312 @@ export = async function watchmanCrawl(
       ),
     );
 
+  type WatchmanFile = {
+    name: string;
+    exists: boolean;
+    mtime_ms: number;
+    size: number;
+    type: string;
+    'content.sha1hex'?: string;
+  };
+
+  const fields = ['name', 'exists', 'mtime_ms', 'size', 'type'];
   if (options.computeSha1) {
     const {capabilities} = await cmd('list-capabilities');
-
-    if (capabilities.indexOf('field-content.sha1hex') !== -1) {
+    if (capabilities.includes('field-content.sha1hex')) {
       fields.push('content.sha1hex');
     }
   }
 
-  async function getWatchmanRoots(
-    roots: Array<Config.Path>,
-  ): Promise<WatchmanRoots> {
-    const watchmanRoots = new Map();
-    await Promise.all(
-      roots.map(async root => {
-        const response = await cmd('watch-project', root);
-        const existing = watchmanRoots.get(response.watch);
-        // A root can only be filtered if it was never seen with a
-        // relative_path before.
-        const canBeFiltered = !existing || existing.length > 0;
+  // Clone the clockspec cache to avoid mutations during the watch phase.
+  const clocks = new Map(data.clocks);
 
-        if (canBeFiltered) {
-          if (response.relative_path) {
-            watchmanRoots.set(
-              response.watch,
-              (existing || []).concat(response.relative_path),
-            );
-          } else {
-            // Make the filter directories an empty array to signal that this
-            // root was already seen and needs to be watched for all files or
-            // directories.
-            watchmanRoots.set(response.watch, []);
-          }
+  /**
+   * Fetch an array of files that match the given expression and are contained
+   * by the given `watchRoot` (with directory filters applied).
+   *
+   * When the `watchRoot` has a cached Watchman clockspec, only changed files
+   * are returned. The cloned clockspec cache is updated on every query.
+   *
+   * The given `watchRoot` must be absolute.
+   */
+  const queryRequest = async (
+    watchRoot: Config.Path,
+    dirs: Array<string>,
+    expression: Array<any>,
+  ) => {
+    if (dirs.length) {
+      expression = [
+        'allof',
+        ['anyof', ...dirs.map(dir => ['dirname', dir])],
+        expression,
+      ];
+    }
+
+    const relativeRoot = fastPath.relative(rootDir, watchRoot) || '.';
+    const response = await cmd('query', watchRoot, {
+      expression,
+      fields,
+      // Use the cached clockspec since `queryRequest` is called twice per root.
+      since: data.clocks.get(relativeRoot),
+    });
+
+    if ('warning' in response) {
+      console.warn('watchman warning:', response.warning);
+    }
+
+    clocks.set(relativeRoot, response.clock);
+    return response;
+  };
+
+  // The cached array of project roots.
+  const roots: Config.Path[] = [];
+  const isValidRoot = (root: Config.Path) =>
+    !root.includes(NODE_MODULES) &&
+    !roots.includes(root) &&
+    !roots.find(root => root.startsWith(root + path.sep));
+
+  // Ensure every configured root is valid.
+  options.roots
+    .map(root => realpath(root))
+    .sort((a, b) => a.length - b.length)
+    .forEach(root => {
+      if (isValidRoot(root)) {
+        roots.push(root);
+      }
+    });
+
+  // Ensure every linked root is searched if valid.
+  data.roots.forEach(root => {
+    root = path.resolve(rootDir, root);
+    if (isValidRoot(root)) {
+      try {
+        if (fs.statSync(root).isDirectory()) {
+          roots.push(root);
+        }
+      } catch (e) {}
+    }
+  });
+
+  // Track which directories share a "watch root" (a common ancestor identified
+  // by Watchman). Use an empty array to denote a project root that is its own
+  // watch root. These arrays are used as "directory filters" in the 2nd phase.
+  const watched = new Map<Config.Path, string[]>();
+
+  /**
+   * Look for linked dependencies in every "node_modules" directory within the
+   * given root. Repeat for every linked dependency found that resolves to a
+   * directory which exists outside of all known project roots.
+   */
+  const findDependencyLinks = async (root: Config.Path) => {
+    const response = await cmd('watch-project', root);
+    const watchRoot = normalizePathSep(response.watch);
+
+    let dirs = watched.get(watchRoot);
+    if (!dirs) {
+      watched.set(watchRoot, (dirs = []));
+    } else if (!dirs.length) {
+      return; // Ensure no directory filters are used.
+    }
+
+    const dir = normalizePathSep(response.relative_path || '');
+    if (dir) {
+      if (dirs.includes(dir)) {
+        return; // Avoid crawling the same directory twice.
+      }
+      dirs.push(dir);
+    } else {
+      // Ensure no directory filters are used.
+      dirs.length = 0;
+    }
+
+    // Search every "node_modules" directory in the entire tree.
+    // It should be faster for Watchman to do this in one fell swoop.
+    const queryResponse = await queryRequest(
+      watchRoot,
+      dir ? [dir] : [],
+      nodeModulesExpression,
+    );
+
+    await Promise.all(
+      queryResponse.files.map(async (link: WatchmanFile) => {
+        const name = normalizePathSep(link.name);
+        const linkPath = path.join(watchRoot, name);
+
+        if (!link.exists || ignore(linkPath)) {
+          data.links.delete(linkPath);
+          return;
+        }
+
+        let target;
+        try {
+          target = realpath(linkPath);
+        } catch (e) {
+          return; // Skip broken symlinks.
+        }
+
+        const metaData = data.links.get(linkPath);
+        const mtime = testModified(metaData, link.mtime_ms);
+        if (mtime !== 0) {
+          // See ../constants.ts
+          data.links.set(linkPath, [target, mtime]);
+        }
+
+        if (fs.statSync(target).isDirectory() && isValidRoot(target)) {
+          roots.push(target);
+          await findDependencyLinks(target);
         }
       }),
     );
-    return watchmanRoots;
-  }
+  };
 
-  async function queryWatchmanForDirs(rootProjectDirMappings: WatchmanRoots) {
-    const files = new Map();
-    let isFresh = false;
-    await Promise.all(
-      Array.from(rootProjectDirMappings).map(
-        async ([root, directoryFilters]) => {
-          const expression = Array.from(defaultWatchExpression);
-          const glob = [];
+  let isFresh = false;
+  let removedFiles = new Map();
+  const changedFiles = new Map();
+  try {
+    await Promise.all(roots.map(findDependencyLinks));
 
-          if (directoryFilters.length > 0) {
-            expression.push([
-              'anyof',
-              ...directoryFilters.map(dir => ['dirname', dir]),
-            ]);
+    const crawlExpression = [
+      'anyof',
+      ['type', 'l'],
+      [
+        'allof',
+        ['type', 'f'],
+        ['anyof', ...extensions.map(extension => ['suffix', extension])],
+      ],
+    ];
 
-            for (const directory of directoryFilters) {
-              for (const extension of extensions) {
-                glob.push(`${directory}/**/*.${extension}`);
+    const watchRoots = Array.from(watched.keys());
+    const crawled = await Promise.all(
+      watchRoots.map(async watchRoot => {
+        const queryResponse = await queryRequest(
+          watchRoot,
+          watched.get(watchRoot)!,
+          crawlExpression,
+        );
+        if (!isFresh) {
+          isFresh = queryResponse.is_fresh_instance;
+        }
+        return queryResponse.files;
+      }),
+    );
+
+    // Reset the file map if Watchman refreshed.
+    if (isFresh) {
+      removedFiles = new Map(data.files);
+      data.files = new Map();
+      data.links = new Map();
+    }
+
+    // Update the file map and symlink map.
+    crawled.forEach((files: WatchmanFile[], i) => {
+      const watchRoot = watchRoots[i];
+      for (const file of files) {
+        const name = normalizePathSep(file.name);
+        const filePath = path.join(watchRoot, name);
+        const relativeFilePath = fastPath.relative(rootDir, filePath);
+        const isLinked = file.type === 'l';
+
+        const existingFiles: Map<string, any> = isLinked
+          ? data.links
+          : data.files;
+
+        const existingFile = existingFiles.get(relativeFilePath);
+        if (isFresh && existingFile && file.exists) {
+          // If watchman is fresh, the removed files map starts with all files
+          // and we remove them as we verify they still exist.
+          removedFiles.delete(relativeFilePath);
+        }
+
+        if (!file.exists || ignore(filePath)) {
+          // No need to act on files that do not exist and were not tracked.
+          if (existingFile) {
+            existingFiles.delete(relativeFilePath);
+
+            // If watchman is not fresh, we will know what specific files were
+            // deleted since we last ran and can track only those files.
+            if (!isFresh) {
+              removedFiles.set(relativeFilePath, existingFile);
+            }
+          }
+          continue;
+        }
+
+        let sha1hex = file['content.sha1hex'] || null;
+        if (sha1hex && sha1hex.length !== 40) {
+          sha1hex = null;
+        }
+
+        const mtime = testModified(existingFile, file.mtime_ms);
+        if (mtime !== 0) {
+          if (isLinked) {
+            // See ../constants.ts
+            existingFiles.set(relativeFilePath, [undefined, mtime]);
+            continue;
+          }
+
+          let nextData: FileMetaData;
+          if (sha1hex && existingFile && existingFile[H.SHA1] === sha1hex) {
+            nextData = [
+              existingFile[0],
+              mtime,
+              existingFile[2],
+              existingFile[3],
+              existingFile[4],
+              existingFile[5],
+            ];
+          } else {
+            // See ../constants.ts
+            nextData = ['', mtime, file.size, 0, '', sha1hex];
+          }
+
+          const mappings = options.mapper ? options.mapper(filePath) : null;
+
+          if (mappings) {
+            for (const absoluteVirtualFilePath of mappings) {
+              if (!ignore(absoluteVirtualFilePath)) {
+                const relativeVirtualFilePath = fastPath.relative(
+                  rootDir,
+                  absoluteVirtualFilePath,
+                );
+                data.files.set(relativeVirtualFilePath, nextData);
+                changedFiles.set(relativeVirtualFilePath, nextData);
               }
             }
           } else {
-            for (const extension of extensions) {
-              glob.push(`**/*.${extension}`);
-            }
+            data.files.set(relativeFilePath, nextData);
+            changedFiles.set(relativeFilePath, nextData);
           }
-
-          const relativeRoot = fastPath.relative(rootDir, root);
-          const query = clocks.has(relativeRoot)
-            ? // Use the `since` generator if we have a clock available
-              {expression, fields, since: clocks.get(relativeRoot)}
-            : // Otherwise use the `glob` filter
-              {expression, fields, glob};
-
-          const response = await cmd('query', root, query);
-
-          if ('warning' in response) {
-            console.warn('watchman warning: ', response.warning);
-          }
-
-          isFresh = isFresh || response.is_fresh_instance;
-          files.set(root, response);
-        },
-      ),
-    );
-
-    return {
-      files,
-      isFresh,
-    };
-  }
-
-  let files = data.files;
-  let removedFiles = new Map();
-  const changedFiles = new Map();
-  let watchmanFiles: Map<string, any>;
-  let isFresh = false;
-  try {
-    const watchmanRoots = await getWatchmanRoots(roots);
-    const watchmanFileResults = await queryWatchmanForDirs(watchmanRoots);
-
-    // Reset the file map if watchman was restarted and sends us a list of
-    // files.
-    if (watchmanFileResults.isFresh) {
-      files = new Map();
-      removedFiles = new Map(data.files);
-      isFresh = true;
-    }
-
-    watchmanFiles = watchmanFileResults.files;
+        }
+      }
+    });
   } finally {
     client.end();
   }
-
   if (clientError) {
     throw clientError;
   }
 
-  // TODO: remove non-null
-  for (const [watchRoot, response] of watchmanFiles!) {
-    const fsRoot = normalizePathSep(watchRoot);
-    const relativeFsRoot = fastPath.relative(rootDir, fsRoot);
-    clocks.set(relativeFsRoot, response.clock);
-
-    for (const fileData of response.files) {
-      const filePath = fsRoot + path.sep + normalizePathSep(fileData.name);
-      const relativeFilePath = fastPath.relative(rootDir, filePath);
-      const existingFileData = data.files.get(relativeFilePath);
-
-      // If watchman is fresh, the removed files map starts with all files
-      // and we remove them as we verify they still exist.
-      if (isFresh && existingFileData && fileData.exists) {
-        removedFiles.delete(relativeFilePath);
-      }
-
-      if (!fileData.exists) {
-        // No need to act on files that do not exist and were not tracked.
-        if (existingFileData) {
-          files.delete(relativeFilePath);
-
-          // If watchman is not fresh, we will know what specific files were
-          // deleted since we last ran and can track only those files.
-          if (!isFresh) {
-            removedFiles.set(relativeFilePath, existingFileData);
-          }
-        }
-      } else if (!ignore(filePath)) {
-        const mtime =
-          typeof fileData.mtime_ms === 'number'
-            ? fileData.mtime_ms
-            : fileData.mtime_ms.toNumber();
-        const size = fileData.size;
-
-        let sha1hex = fileData['content.sha1hex'];
-        if (typeof sha1hex !== 'string' || sha1hex.length !== 40) {
-          sha1hex = null;
-        }
-
-        let nextData: FileMetaData;
-
-        if (existingFileData && existingFileData[H.MTIME] === mtime) {
-          nextData = existingFileData;
-        } else if (
-          existingFileData &&
-          sha1hex &&
-          existingFileData[H.SHA1] === sha1hex
-        ) {
-          nextData = [
-            existingFileData[0],
-            mtime,
-            existingFileData[2],
-            existingFileData[3],
-            existingFileData[4],
-            existingFileData[5],
-          ];
-        } else {
-          // See ../constants.ts
-          nextData = ['', mtime, size, 0, '', sha1hex];
-        }
-
-        const mappings = options.mapper ? options.mapper(filePath) : null;
-
-        if (mappings) {
-          for (const absoluteVirtualFilePath of mappings) {
-            if (!ignore(absoluteVirtualFilePath)) {
-              const relativeVirtualFilePath = fastPath.relative(
-                rootDir,
-                absoluteVirtualFilePath,
-              );
-              files.set(relativeVirtualFilePath, nextData);
-              changedFiles.set(relativeVirtualFilePath, nextData);
-            }
-          }
-        } else {
-          files.set(relativeFilePath, nextData);
-          changedFiles.set(relativeFilePath, nextData);
-        }
-      }
-    }
-  }
-
-  data.files = files;
+  data.roots = roots.map(root => fastPath.relative(rootDir, root));
+  data.clocks = clocks;
   return {
     changedFiles: isFresh ? undefined : changedFiles,
     hasteMap: data,
     removedFiles,
   };
 };
+
+/**
+ * Check if the file data has been modified since last cached.
+ *
+ * Returns the 2nd argument if modified, else zero.
+ */
+function testModified(
+  metaData: FileMetaData | LinkMetaData | undefined,
+  mtime: number | {toNumber(): number},
+) {
+  if (typeof mtime !== 'number') {
+    mtime = mtime.toNumber();
+  }
+  return !metaData || metaData[H.MTIME] !== mtime ? mtime : 0;
+}

--- a/packages/jest-haste-map/src/crawlers/watchman.ts
+++ b/packages/jest-haste-map/src/crawlers/watchman.ts
@@ -224,7 +224,7 @@ export = async function watchmanCrawl(
         const mtime = testModified(metaData, link.mtime_ms);
         dependencyLinks.set(
           relativePath,
-          mtime !== 0 ? [target, mtime] : metaData!,
+          mtime !== 0 ? [fastPath.relative(rootDir, target), mtime] : metaData!,
         );
 
         if (fs.statSync(target).isDirectory() && isValidRoot(target)) {

--- a/packages/jest-haste-map/src/types.ts
+++ b/packages/jest-haste-map/src/types.ts
@@ -45,6 +45,7 @@ export type HasteImpl = {
 };
 
 export type FileData = Map<Config.Path, FileMetaData>;
+export type LinkData = Map<Config.Path, LinkMetaData>;
 
 export type FileMetaData = [
   /* id */ string,
@@ -53,6 +54,11 @@ export type FileMetaData = [
   /* visited */ 0 | 1,
   /* dependencies */ string,
   /* sha1 */ string | null | undefined,
+];
+
+export type LinkMetaData = [
+  /* target */ string | undefined,
+  /* mtime */ number
 ];
 
 export type MockData = Map<string, Config.Path>;
@@ -67,6 +73,8 @@ export type InternalHasteMap = {
   clocks: WatchmanClocks;
   duplicates: DuplicatesIndex;
   files: FileData;
+  links: LinkData;
+  roots: Config.Path[];
   map: ModuleMapData;
   mocks: MockData;
 };


### PR DESCRIPTION
## Summary

This is a follow-up to #6993.

Its goals include:
- crawl any directory that's been linked to by a project root (eg: installed via `yarn link`)
- cache _all_ symlinks in `jest-haste-map` for later consumption
- add a `follow` method to the `HasteMap` class (for lazily resolving symlinks)

More details in the commit messages and code comments.

## What's missing

No support for symlinks in watch mode. 😢 But regular files in linked packages **are** watched.
More details on watch mode here: https://github.com/facebook/jest/pull/7549#issuecomment-468794373

## Test plan

I've fixed most of the tests that were broken by my changes. Please provide guidance on the remaining unfixed tests. Also, we could use some automated tests for symlinks.

I've tested locally on projects using:
- `pnpm install`
- `yarn link`
- `npm install`

For manual testing, you can use this repository:
https://github.com/aleclarson/repro/tree/jest-symlinks