### PR TITLE
Make test suite exit early if `beforeEach` hook fails (jest-jasmine2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[jest-snapshot]` Prevent inline snapshots from drifting when inline snapshots are updated ([#8492](https://github.com/facebook/jest/pull/8492))
 - `[jest-haste-map]` Don't throw on missing mapper in Node crawler ([#8558](https://github.com/facebook/jest/pull/8558))
 - `[jest-core]` Fix incorrect `passWithNoTests` warning ([#8595](https://github.com/facebook/jest/pull/8595))
+- `[jest-jasmine2]` Make test suite exit early if a `beforeEach` hook fails ([#8654](https://github.com/facebook/jest/pull/8654))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/__snapshots__/beforeEachAbortsTests.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/beforeEachAbortsTests.test.ts.snap
@@ -1,0 +1,435 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`in the global context does not run any tests if a global beforeEach hook fails 1`] = `
+FAIL __tests__/global/skipsTests.test.js
+  ● Console
+
+    console.log __tests__/global/skipsTests.test.js:9
+      global beforeEach
+    console.log __tests__/global/skipsTests.test.js:9
+      global beforeEach
+    console.log __tests__/global/skipsTests.test.js:9
+      global beforeEach
+
+  ● global test
+
+    The global beforeEach hook failed.
+
+       8 | beforeEach(() => {
+       9 |   console.log('global beforeEach');
+    > 10 |   throw new Error('The global beforeEach hook failed.');
+         |         ^
+      11 | });
+      12 | 
+      13 | it('global test', () => {
+
+      at Object.<anonymous>.beforeEach (__tests__/global/skipsTests.test.js:10:9)
+
+  ● test suite › outer test
+
+    The global beforeEach hook failed.
+
+       8 | beforeEach(() => {
+       9 |   console.log('global beforeEach');
+    > 10 |   throw new Error('The global beforeEach hook failed.');
+         |         ^
+      11 | });
+      12 | 
+      13 | it('global test', () => {
+
+      at Object.<anonymous>.beforeEach (__tests__/global/skipsTests.test.js:10:9)
+
+  ● test suite › nested block › nested test
+
+    The global beforeEach hook failed.
+
+       8 | beforeEach(() => {
+       9 |   console.log('global beforeEach');
+    > 10 |   throw new Error('The global beforeEach hook failed.');
+         |         ^
+      11 | });
+      12 | 
+      13 | it('global test', () => {
+
+      at Object.<anonymous>.beforeEach (__tests__/global/skipsTests.test.js:10:9)
+`;
+
+exports[`in the global context does not run any tests if a global beforeEach hook fails 2`] = `
+Test Suites: 1 failed, 1 total
+Tests:       3 failed, 3 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching /global\\/skipsTests.test.js/i.
+`;
+
+exports[`in the global context still runs global afterAll hooks if a global beforeEach fails 1`] = `
+FAIL __tests__/global/afterAllHook.test.js
+  ● Console
+
+    console.log __tests__/global/afterAllHook.test.js:9
+      global beforeEach
+    console.log __tests__/global/afterAllHook.test.js:18
+      global afterAll
+
+  ● global test
+
+    The global beforeEach hook failed.
+
+       8 | beforeEach(() => {
+       9 |   console.log('global beforeEach');
+    > 10 |   throw new Error('The global beforeEach hook failed.');
+         |         ^
+      11 | });
+      12 | 
+      13 | it('global test', () => {
+
+      at Object.<anonymous>.beforeEach (__tests__/global/afterAllHook.test.js:10:9)
+`;
+
+exports[`in the global context still runs global afterAll hooks if a global beforeEach fails 2`] = `
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching /global\\/afterAllHook.test.js/i.
+`;
+
+exports[`in the global context still runs global afterEach hooks if a global beforeEach fails 1`] = `
+FAIL __tests__/global/afterEachHook.test.js
+  ● Console
+
+    console.log __tests__/global/afterEachHook.test.js:9
+      global beforeEach
+    console.log __tests__/global/afterEachHook.test.js:18
+      global afterEach
+
+  ● global test
+
+    The global beforeEach hook failed.
+
+       8 | beforeEach(() => {
+       9 |   console.log('global beforeEach');
+    > 10 |   throw new Error('The global beforeEach hook failed.');
+         |         ^
+      11 | });
+      12 | 
+      13 | it('global test', () => {
+
+      at Object.<anonymous>.beforeEach (__tests__/global/afterEachHook.test.js:10:9)
+`;
+
+exports[`in the global context still runs global afterEach hooks if a global beforeEach fails 2`] = `
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching /global\\/afterEachHook.test.js/i.
+`;
+
+exports[`inside deeply nested blocks can cancel tests only for the nested describe block it is in 1`] = `
+FAIL __tests__/nestedBlocks/testsInDifferentBlocks.test.js
+  ● Console
+
+    console.log __tests__/nestedBlocks/testsInDifferentBlocks.test.js:10
+      outer test
+    console.log __tests__/nestedBlocks/testsInDifferentBlocks.test.js:15
+      nested beforeEach
+    console.log __tests__/nestedBlocks/testsInDifferentBlocks.test.js:15
+      nested beforeEach
+
+  ● tests for the nested beforeEach › nested block › first nested test
+
+    The nested beforeEach hook failed.
+
+      14 |     beforeEach(() => {
+      15 |       console.log('nested beforeEach');
+    > 16 |       throw new Error('The nested beforeEach hook failed.');
+         |             ^
+      17 |     });
+      18 | 
+      19 |     it('first nested test', () => {
+
+      at Object.beforeEach (__tests__/nestedBlocks/testsInDifferentBlocks.test.js:16:13)
+
+  ● tests for the nested beforeEach › nested block › second nested test
+
+    The nested beforeEach hook failed.
+
+      14 |     beforeEach(() => {
+      15 |       console.log('nested beforeEach');
+    > 16 |       throw new Error('The nested beforeEach hook failed.');
+         |             ^
+      17 |     });
+      18 | 
+      19 |     it('first nested test', () => {
+
+      at Object.beforeEach (__tests__/nestedBlocks/testsInDifferentBlocks.test.js:16:13)
+`;
+
+exports[`inside deeply nested blocks can cancel tests only for the nested describe block it is in 2`] = `
+Test Suites: 1 failed, 1 total
+Tests:       2 failed, 1 passed, 3 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching /nestedBlocks\\/testsInDifferentBlocks.test.js/i.
+`;
+
+exports[`inside deeply nested blocks still runs afterEach hooks for the test whose beforeEach failed 1`] = `
+FAIL __tests__/nestedBlocks/afterEachHook.test.js
+  ● Console
+
+    console.log __tests__/nestedBlocks/afterEachHook.test.js:10
+      outer test
+    console.log __tests__/nestedBlocks/afterEachHook.test.js:29
+      outer afterEach
+    console.log __tests__/nestedBlocks/afterEachHook.test.js:15
+      nested beforeEach
+    console.log __tests__/nestedBlocks/afterEachHook.test.js:24
+      nested afterEach
+    console.log __tests__/nestedBlocks/afterEachHook.test.js:29
+      outer afterEach
+
+  ● afterEach hooks with a nested beforeEach › nested block › nested test
+
+    The nested beforeEach hook failed.
+
+      14 |     beforeEach(() => {
+      15 |       console.log('nested beforeEach');
+    > 16 |       throw new Error('The nested beforeEach hook failed.');
+         |             ^
+      17 |     });
+      18 | 
+      19 |     it('nested test', () => {
+
+      at Object.beforeEach (__tests__/nestedBlocks/afterEachHook.test.js:16:13)
+`;
+
+exports[`inside deeply nested blocks still runs afterEach hooks for the test whose beforeEach failed 2`] = `
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 passed, 2 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching /nestedBlocks\\/afterEachHook.test.js/i.
+`;
+
+exports[`inside deeply nested blocks still runs the afterAll hooks if a nested beforeEach fails 1`] = `
+FAIL __tests__/nestedBlocks/afterAllHook.test.js
+  ● Console
+
+    console.log __tests__/nestedBlocks/afterAllHook.test.js:10
+      outer test
+    console.log __tests__/nestedBlocks/afterAllHook.test.js:15
+      nested beforeEach
+    console.log __tests__/nestedBlocks/afterAllHook.test.js:24
+      nested afterAll
+    console.log __tests__/nestedBlocks/afterAllHook.test.js:29
+      outer afterAll
+
+  ● afterAll hooks with a nested beforeEach › nested block › nested test
+
+    The nested beforeEach hook failed.
+
+      14 |     beforeEach(() => {
+      15 |       console.log('nested beforeEach');
+    > 16 |       throw new Error('The nested beforeEach hook failed.');
+         |             ^
+      17 |     });
+      18 | 
+      19 |     it('nested test', () => {
+
+      at Object.beforeEach (__tests__/nestedBlocks/afterAllHook.test.js:16:13)
+`;
+
+exports[`inside deeply nested blocks still runs the afterAll hooks if a nested beforeEach fails 2`] = `
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 passed, 2 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching /nestedBlocks\\/afterAllHook.test.js/i.
+`;
+
+exports[`without nested blocks does not run any of the tests if beforeEach fails 1`] = `
+FAIL __tests__/singleBlock/multipleTests.test.js
+  ● Console
+
+    console.log __tests__/singleBlock/multipleTests.test.js:10
+      beforeEach
+    console.log __tests__/singleBlock/multipleTests.test.js:10
+      beforeEach
+
+  ● a block with multiple tests › skipped first test
+
+    The beforeEach hook failed.
+
+       9 |   beforeEach(() => {
+      10 |     console.log('beforeEach');
+    > 11 |     throw new Error('The beforeEach hook failed.');
+         |           ^
+      12 |   });
+      13 | 
+      14 |   test('skipped first test', () => {
+
+      at Object.beforeEach (__tests__/singleBlock/multipleTests.test.js:11:11)
+
+  ● a block with multiple tests › skipped second test
+
+    The beforeEach hook failed.
+
+       9 |   beforeEach(() => {
+      10 |     console.log('beforeEach');
+    > 11 |     throw new Error('The beforeEach hook failed.');
+         |           ^
+      12 |   });
+      13 | 
+      14 |   test('skipped first test', () => {
+
+      at Object.beforeEach (__tests__/singleBlock/multipleTests.test.js:11:11)
+`;
+
+exports[`without nested blocks does not run any of the tests if beforeEach fails 2`] = `
+Test Suites: 1 failed, 1 total
+Tests:       2 failed, 2 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching /singleBlock\\/multipleTests.test.js/i.
+`;
+
+exports[`without nested blocks does not run the test if beforeEach fails 1`] = `
+FAIL __tests__/singleBlock/singleTest.test.js
+  ● Console
+
+    console.log __tests__/singleBlock/singleTest.test.js:10
+      beforeEach
+
+  ● a block with a single test › skipped test
+
+    The beforeEach hook failed.
+
+       9 |   beforeEach(() => {
+      10 |     console.log('beforeEach');
+    > 11 |     throw new Error('The beforeEach hook failed.');
+         |           ^
+      12 |   });
+      13 | 
+      14 |   test('skipped test', () => {
+
+      at Object.beforeEach (__tests__/singleBlock/singleTest.test.js:11:11)
+`;
+
+exports[`without nested blocks does not run the test if beforeEach fails 2`] = `
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching /singleBlock\\/singleTest.test.js/i.
+`;
+
+exports[`without nested blocks runs all of the beforeEach hooks if one fails but does not run the tests 1`] = `
+FAIL __tests__/singleBlock/multipleBeforeEachHooks.test.js
+  ● Console
+
+    console.log __tests__/singleBlock/multipleBeforeEachHooks.test.js:10
+      first beforeEach
+    console.log __tests__/singleBlock/multipleBeforeEachHooks.test.js:15
+      second beforeEach
+
+  ● a block with multiple beforeEach hooks › skipped test
+
+    The first beforeEach hook failed.
+
+       9 |   beforeEach(() => {
+      10 |     console.log('first beforeEach');
+    > 11 |     throw new Error('The first beforeEach hook failed.');
+         |           ^
+      12 |   });
+      13 | 
+      14 |   beforeEach(() => {
+
+      at Object.beforeEach (__tests__/singleBlock/multipleBeforeEachHooks.test.js:11:11)
+
+  ● a block with multiple beforeEach hooks › skipped test
+
+    The second beforeEach hook failed.
+
+      14 |   beforeEach(() => {
+      15 |     console.log('second beforeEach');
+    > 16 |     throw new Error('The second beforeEach hook failed.');
+         |           ^
+      17 |   });
+      18 | 
+      19 |   test('skipped test', () => {
+
+      at Object.beforeEach (__tests__/singleBlock/multipleBeforeEachHooks.test.js:16:11)
+`;
+
+exports[`without nested blocks runs all of the beforeEach hooks if one fails but does not run the tests 2`] = `
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching /singleBlock\\/multipleBeforeEachHooks.test.js/i.
+`;
+
+exports[`without nested blocks still runs afterEach hook if the beforeEach hook fails 1`] = `
+FAIL __tests__/singleBlock/afterEachHook.test.js
+  ● Console
+
+    console.log __tests__/singleBlock/afterEachHook.test.js:10
+      beforeEach
+    console.log __tests__/singleBlock/afterEachHook.test.js:19
+      afterEach
+
+  ● a block with afterEach hooks › skipped test
+
+    The beforeEach hook failed.
+
+       9 |   beforeEach(() => {
+      10 |     console.log('beforeEach');
+    > 11 |     throw new Error('The beforeEach hook failed.');
+         |           ^
+      12 |   });
+      13 | 
+      14 |   test('skipped test', () => {
+
+      at Object.beforeEach (__tests__/singleBlock/afterEachHook.test.js:11:11)
+`;
+
+exports[`without nested blocks still runs afterEach hook if the beforeEach hook fails 2`] = `
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching /singleBlock\\/afterEachHook.test.js/i.
+`;
+
+exports[`without nested blocks still runs the afterAll hook if the beforeEach hook fails 1`] = `
+FAIL __tests__/singleBlock/afterAllHook.test.js
+  ● Console
+
+    console.log __tests__/singleBlock/afterAllHook.test.js:10
+      beforeEach
+    console.log __tests__/singleBlock/afterAllHook.test.js:19
+      afterAll
+
+  ● a block with an afterAll hook › skipped test
+
+    The beforeEach hook failed.
+
+       9 |   beforeEach(() => {
+      10 |     console.log('beforeEach');
+    > 11 |     throw new Error('The beforeEach hook failed.');
+         |           ^
+      12 |   });
+      13 | 
+      14 |   test('skipped test', () => {
+
+      at Object.beforeEach (__tests__/singleBlock/afterAllHook.test.js:11:11)
+`;
+
+exports[`without nested blocks still runs the afterAll hook if the beforeEach hook fails 2`] = `
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching /singleBlock\\/afterAllHook.test.js/i.
+`;

--- a/e2e/__tests__/beforeEachAbortsTests.test.ts
+++ b/e2e/__tests__/beforeEachAbortsTests.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import path from 'path';
+import {wrap} from 'jest-snapshot-serializer-raw';
+import runJest from '../runJest';
+import {extractSummary} from '../Utils';
+
+const dir = path.resolve(__dirname, '../before-each-aborts-tests');
+
+const runAgainstSnapshot = testPath => {
+  const {status, stderr} = runJest(dir, [testPath]);
+  const {summary, rest} = extractSummary(stderr);
+
+  expect(status).toBe(1);
+  expect(wrap(rest)).toMatchSnapshot();
+  expect(wrap(summary)).toMatchSnapshot();
+};
+
+describe('in the global context', () => {
+  test('does not run any tests if a global beforeEach hook fails', () => {
+    runAgainstSnapshot('global/skipsTests.test.js');
+  });
+
+  test('still runs global afterEach hooks if a global beforeEach fails', () => {
+    runAgainstSnapshot('global/afterEachHook.test.js');
+  });
+
+  test('still runs global afterAll hooks if a global beforeEach fails', () => {
+    runAgainstSnapshot('global/afterAllHook.test.js');
+  });
+});
+
+describe('without nested blocks', () => {
+  test('does not run the test if beforeEach fails', () => {
+    runAgainstSnapshot('singleBlock/singleTest.test.js');
+  });
+
+  test('does not run any of the tests if beforeEach fails', () => {
+    runAgainstSnapshot('singleBlock/multipleTests.test.js');
+  });
+
+  test('runs all of the beforeEach hooks if one fails but does not run the tests', () => {
+    runAgainstSnapshot('singleBlock/multipleBeforeEachHooks.test.js');
+  });
+
+  test('still runs afterEach hook if the beforeEach hook fails', () => {
+    runAgainstSnapshot('singleBlock/afterEachHook.test.js');
+  });
+
+  test('still runs the afterAll hook if the beforeEach hook fails', () => {
+    runAgainstSnapshot('singleBlock/afterAllHook.test.js');
+  });
+});
+
+describe('inside deeply nested blocks', () => {
+  test('can cancel tests only for the nested describe block it is in', () => {
+    runAgainstSnapshot('nestedBlocks/testsInDifferentBlocks.test.js');
+  });
+
+  test('still runs the afterAll hooks if a nested beforeEach fails', () => {
+    runAgainstSnapshot('nestedBlocks/afterAllHook.test.js');
+  });
+
+  test('still runs afterEach hooks for the test whose beforeEach failed', () => {
+    runAgainstSnapshot('nestedBlocks/afterEachHook.test.js');
+  });
+});

--- a/e2e/before-each-aborts-tests/__tests__/global/afterAllHook.test.js
+++ b/e2e/before-each-aborts-tests/__tests__/global/afterAllHook.test.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+beforeEach(() => {
+  console.log('global beforeEach');
+  throw new Error('The global beforeEach hook failed.');
+});
+
+it('global test', () => {
+  console.log('global test');
+});
+
+afterAll(() => {
+  console.log('global afterAll');
+});

--- a/e2e/before-each-aborts-tests/__tests__/global/afterEachHook.test.js
+++ b/e2e/before-each-aborts-tests/__tests__/global/afterEachHook.test.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+beforeEach(() => {
+  console.log('global beforeEach');
+  throw new Error('The global beforeEach hook failed.');
+});
+
+it('global test', () => {
+  console.log('global test');
+});
+
+afterEach(() => {
+  console.log('global afterEach');
+});

--- a/e2e/before-each-aborts-tests/__tests__/global/skipsTests.test.js
+++ b/e2e/before-each-aborts-tests/__tests__/global/skipsTests.test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+beforeEach(() => {
+  console.log('global beforeEach');
+  throw new Error('The global beforeEach hook failed.');
+});
+
+it('global test', () => {
+  console.log('outer test');
+});
+
+describe('test suite', () => {
+  it('outer test', () => {
+    console.log('outer test');
+  });
+
+  describe('nested block', () => {
+    it('nested test', () => {
+      console.log('nested test');
+    });
+  });
+});

--- a/e2e/before-each-aborts-tests/__tests__/nestedBlocks/afterAllHook.test.js
+++ b/e2e/before-each-aborts-tests/__tests__/nestedBlocks/afterAllHook.test.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe('afterAll hooks with a nested beforeEach', () => {
+  it('outer test', () => {
+    console.log('outer test');
+  });
+
+  describe('nested block', () => {
+    beforeEach(() => {
+      console.log('nested beforeEach');
+      throw new Error('The nested beforeEach hook failed.');
+    });
+
+    it('nested test', () => {
+      console.log('nested test');
+    });
+
+    afterAll(() => {
+      console.log('nested afterAll');
+    });
+  });
+
+  afterAll(() => {
+    console.log('outer afterAll');
+  });
+});

--- a/e2e/before-each-aborts-tests/__tests__/nestedBlocks/afterEachHook.test.js
+++ b/e2e/before-each-aborts-tests/__tests__/nestedBlocks/afterEachHook.test.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe('afterEach hooks with a nested beforeEach', () => {
+  it('outer test', () => {
+    console.log('outer test');
+  });
+
+  describe('nested block', () => {
+    beforeEach(() => {
+      console.log('nested beforeEach');
+      throw new Error('The nested beforeEach hook failed.');
+    });
+
+    it('nested test', () => {
+      console.log('nested test');
+    });
+
+    afterEach(() => {
+      console.log('nested afterEach');
+    });
+  });
+
+  afterEach(() => {
+    console.log('outer afterEach');
+  });
+});

--- a/e2e/before-each-aborts-tests/__tests__/nestedBlocks/testsInDifferentBlocks.test.js
+++ b/e2e/before-each-aborts-tests/__tests__/nestedBlocks/testsInDifferentBlocks.test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe('tests for the nested beforeEach', () => {
+  it('outer test', () => {
+    console.log('outer test');
+  });
+
+  describe('nested block', () => {
+    beforeEach(() => {
+      console.log('nested beforeEach');
+      throw new Error('The nested beforeEach hook failed.');
+    });
+
+    it('first nested test', () => {
+      console.log('first nested test');
+    });
+
+    it('second nested test', () => {
+      console.log('second nested test');
+    });
+  });
+});

--- a/e2e/before-each-aborts-tests/__tests__/singleBlock/afterAllHook.test.js
+++ b/e2e/before-each-aborts-tests/__tests__/singleBlock/afterAllHook.test.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe('a block with an afterAll hook', () => {
+  beforeEach(() => {
+    console.log('beforeEach');
+    throw new Error('The beforeEach hook failed.');
+  });
+
+  test('skipped test', () => {
+    console.log('test');
+  });
+
+  afterAll(() => {
+    console.log('afterAll');
+  });
+});

--- a/e2e/before-each-aborts-tests/__tests__/singleBlock/afterEachHook.test.js
+++ b/e2e/before-each-aborts-tests/__tests__/singleBlock/afterEachHook.test.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe('a block with afterEach hooks', () => {
+  beforeEach(() => {
+    console.log('beforeEach');
+    throw new Error('The beforeEach hook failed.');
+  });
+
+  test('skipped test', () => {
+    console.log('test');
+  });
+
+  afterEach(() => {
+    console.log('afterEach');
+  });
+});

--- a/e2e/before-each-aborts-tests/__tests__/singleBlock/multipleBeforeEachHooks.test.js
+++ b/e2e/before-each-aborts-tests/__tests__/singleBlock/multipleBeforeEachHooks.test.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe('a block with multiple beforeEach hooks', () => {
+  beforeEach(() => {
+    console.log('first beforeEach');
+    throw new Error('The first beforeEach hook failed.');
+  });
+
+  beforeEach(() => {
+    console.log('second beforeEach');
+    throw new Error('The second beforeEach hook failed.');
+  });
+
+  test('skipped test', () => {
+    console.log('test');
+  });
+});

--- a/e2e/before-each-aborts-tests/__tests__/singleBlock/multipleTests.test.js
+++ b/e2e/before-each-aborts-tests/__tests__/singleBlock/multipleTests.test.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe('a block with multiple tests', () => {
+  beforeEach(() => {
+    console.log('beforeEach');
+    throw new Error('The beforeEach hook failed.');
+  });
+
+  test('skipped first test', () => {
+    console.log('first test');
+  });
+
+  test('skipped second test', () => {
+    console.log('second test');
+  });
+});

--- a/e2e/before-each-aborts-tests/__tests__/singleBlock/singleTest.test.js
+++ b/e2e/before-each-aborts-tests/__tests__/singleBlock/singleTest.test.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+describe('a block with a single test', () => {
+  beforeEach(() => {
+    console.log('beforeEach');
+    throw new Error('The beforeEach hook failed.');
+  });
+
+  test('skipped test', () => {
+    console.log('test');
+  });
+});

--- a/e2e/before-each-aborts-tests/package.json
+++ b/e2e/before-each-aborts-tests/package.json
@@ -1,0 +1,6 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "verbose": false
+  }
+}


### PR DESCRIPTION
## Summary

This PR fixes https://github.com/facebook/jest/issues/6527 by not running tests inside of a test suite if one of its `beforeEach` hooks fail.

This is already the default behaviour in `jest-circus` and has been confirmed to be the desired behaviour as per [this comment](https://github.com/facebook/jest/issues/6527#issuecomment-505774402).


## Why this problem happens

1. Jest jasmine's `Env` will start building the hierarchy of blocks with children. This means [adding the `describe` blocks to their respective parents](https://github.com/facebook/jest/blob/d051b0da359c5930ab4c3ea69fe5524266622c96/packages/jest-jasmine2/src/jasmine/Env.ts#L422) to build a tree

2. If it finds any `beforeEach` hooks, `jest-jasmine2` will [add them to an array in the `Suite`](https://github.com/facebook/jest/blob/d051b0da359c5930ab4c3ea69fe5524266622c96/packages/jest-jasmine2/src/jasmine/Suite.ts#L118-L120).

3. Each `it` (`Spec`) [is added as a child to the `describe` block they are in](https://github.com/facebook/jest/blob/d051b0da359c5930ab4c3ea69fe5524266622c96/packages/jest-jasmine2/src/jasmine/Env.ts#L576).

4. `jest-jasmine2` will start [executing tests through the `treeProcessor`](https://github.com/facebook/jest/blob/d051b0da359c5930ab4c3ea69fe5524266622c96/packages/jest-jasmine2/src/jasmine/Env.ts#L270-L321).

5. For each test (`it`/`Spec`) [the `beforeEach` and `afterEach` hooks will be put into an array in the order they should run](https://github.com/facebook/jest/blob/d051b0da359c5930ab4c3ea69fe5524266622c96/packages/jest-jasmine2/src/jasmine/Spec.ts#L189-L190) and [`queueRunner` will run the functions in the array sequentially](https://github.com/facebook/jest/blob/d051b0da359c5930ab4c3ea69fe5524266622c96/packages/jest-jasmine2/src/queueRunner.ts#L80-L83).

6. [If any of the functions in the promise chain throws an error, the `onException` callback will be invoked, but all the following functions will still run because the chain won't be discontinued](https://github.com/facebook/jest/blob/d051b0da359c5930ab4c3ea69fe5524266622c96/packages/jest-jasmine2/src/queueRunner.ts#L48-L53).


## How the fix was implemented

I essentially broke the single chain of promises with all the hooks and the test into two chains. [The first chain contains only the `beforeEach` hooks](https://github.com/facebook/jest/compare/master...lucasfcosta:beforeEach-aborts-tests?expand=1#diff-4d37cd9b3701ca1e2bc530ce970b33ffR213) and [the second chain contains the test and the `afterEach` hooks](https://github.com/facebook/jest/compare/master...lucasfcosta:beforeEach-aborts-tests?expand=1#diff-4d37cd9b3701ca1e2bc530ce970b33ffR215). Then, if the chain for `beforeEach` fails [I will turn on a flag](https://github.com/facebook/jest/compare/master...lucasfcosta:beforeEach-aborts-tests?expand=1#diff-4d37cd9b3701ca1e2bc530ce970b33ffR202) which [will be used to determine whether the continuation (the second chain with tests and `afterEach` hooks) should run](https://github.com/facebook/jest/compare/master...lucasfcosta:beforeEach-aborts-tests?expand=1#diff-4d37cd9b3701ca1e2bc530ce970b33ffR217).


## Test plan

I have added extensive E2E tests to this to ensure that multiple scenarios would be covered.

I covered the following cases:
* For the global context
    * Not running tests if a global `beforeEach` hook fails
    * Still running global `afterEach` hooks if a global `beforeEach` fails
    * Still running global `afterAll` hooks if a global `beforeEach` fails
* Inside a single suite
    * Not running a single test if a `beforeEach` hook fails
    * Not running any tests in the same suite if a `beforeEach` hook fails
    * Trying to run all `beforeEach` hooks even if one fails
    * Still running the `afterEach` hooks if `beforeEach` fails
    * Still running the `afterAll` hooks if `beforeEach` fails
* Inside nested suites
    * Canceling tests only for the suite the `beforeEach` hook is in
    * Still running the upper `afterEach` hooks if the nested `beforeEach` fails
    * Still running the upper `afterAll` hook if the nested `beforeEach` fails


I don't know if the way I organised these tests is adequate; any ideas on how to improve this are more than welcome.

I thought about writing more tests for more scenarios, but then I came to the conclusion that whatever I could write would end-up being redundant since the basis of them is already covered.

I also made the `runAgainstSnapshot` function generic since that's what I do in each test anyway.