### PR TITLE
fix: handle module name case differences on case-sensitive and case-insensitive file systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - `[jest-runtime]` [**BREAKING**] remove long-deprecated `jest.addMatchers`, `jest.resetModuleRegistry`, and `jest.runTimersToTime` ([#9853](https://github.com/facebook/jest/pull/9853))
 - `[jest-transform]` Show enhanced `SyntaxError` message for all `SyntaxError`s ([#10749](https://github.com/facebook/jest/pull/10749))
 - `[jest-transform]` [**BREAKING**] Refactor API to pass an options bag around rather than multiple boolean options ([#10753](https://github.com/facebook/jest/pull/10753))
-- `[jest-resolve]` Warn if a module has different casing in the file system ([#10794](https://github.com/facebook/jest/pull/10794))
+- `[jest-resolve]` Handle module name case differences on case-sensitive and case-insensitive file systems ([#10794](https://github.com/facebook/jest/pull/10794))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[jest-runtime]` [**BREAKING**] remove long-deprecated `jest.addMatchers`, `jest.resetModuleRegistry`, and `jest.runTimersToTime` ([#9853](https://github.com/facebook/jest/pull/9853))
 - `[jest-transform]` Show enhanced `SyntaxError` message for all `SyntaxError`s ([#10749](https://github.com/facebook/jest/pull/10749))
 - `[jest-transform]` [**BREAKING**] Refactor API to pass an options bag around rather than multiple boolean options ([#10753](https://github.com/facebook/jest/pull/10753))
+- `[jest-resolve]` Warn if a module has different casing in the file system
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 - `[jest-runtime]` [**BREAKING**] remove long-deprecated `jest.addMatchers`, `jest.resetModuleRegistry`, and `jest.runTimersToTime` ([#9853](https://github.com/facebook/jest/pull/9853))
 - `[jest-transform]` Show enhanced `SyntaxError` message for all `SyntaxError`s ([#10749](https://github.com/facebook/jest/pull/10749))
 - `[jest-transform]` [**BREAKING**] Refactor API to pass an options bag around rather than multiple boolean options ([#10753](https://github.com/facebook/jest/pull/10753))
-- `[jest-resolve]` Warn if a module has different casing in the file system
+- `[jest-resolve]` Warn if a module has different casing in the file system ([#10794](https://github.com/facebook/jest/pull/10794))
 
 ### Chore & Maintenance
 

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -41,7 +41,7 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:596:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:611:17)
       at Object.require (index.js:10:1)
 `;
 
@@ -70,6 +70,6 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:596:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:611:17)
       at Object.require (index.js:10:1)
 `;

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -41,7 +41,7 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:556:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:596:17)
       at Object.require (index.js:10:1)
 `;
 
@@ -70,6 +70,6 @@ FAIL __tests__/index.js
       12 | module.exports = () => 'test';
       13 | 
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:556:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:596:17)
       at Object.require (index.js:10:1)
 `;

--- a/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
@@ -37,6 +37,6 @@ FAIL __tests__/test.js
         |                  ^
       9 | 
 
-      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:311:11)
+      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:332:11)
       at Object.require (index.js:8:18)
 `;

--- a/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
@@ -37,6 +37,6 @@ FAIL __tests__/test.js
         |                  ^
       9 | 
 
-      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:332:11)
+      at Resolver.resolveModule (../../packages/jest-resolve/build/index.js:347:11)
       at Object.require (index.js:8:18)
 `;

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -222,7 +222,7 @@ describe('resolveModule', () => {
   });
 
   it('warns if a module has different casing on case-insensitive file system', () => {
-    let warning: string = '';
+    let warning = '';
     const spy = jest
       .spyOn(global.console, 'warn')
       .mockImplementation(message => (warning = message));
@@ -235,14 +235,17 @@ describe('resolveModule', () => {
       ...require('resolve'),
       sync: () => modulePath,
     }));
-    resolver.resolveModule(src, './__mocks__/Mockjsdependency');
+    try {
+      resolver.resolveModule(src, './__mocks__/Mockjsdependency');
+    } finally {
+      spy.mockRestore();
+      jest.dontMock('resolve');
+    }
     expect(
       warning.includes(
         `Mockjsdependency.js resolved, but has different casing: ${modulePath}`,
       ),
     ).toBe(true);
-    spy.mockRestore();
-    jest.dontMock('resolve');
   });
 
   it('suggests similarly named modules if cannot find module on case-sensitive file system', () => {

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -292,7 +292,7 @@ describe('Resolver.getModulePaths() -> nodeModulesPaths()', () => {
     // about the test environment when it comes to absolute paths.
     jest.doMock('graceful-fs', () => ({
       ...jest.requireActual('graceful-fs'),
-      realPathSync: {
+      realpathSync: {
         native: (dirInput: string) => dirInput,
       },
     }));

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -220,6 +220,26 @@ describe('resolveModule', () => {
     expect(resolvedWithSlash).toBe(fooSlashIndex);
     expect(resolvedWithSlash).toBe(resolvedWithDot);
   });
+
+  it('warns if a module has different casing in the file system', () => {
+    let warning: string = '';
+    const spy = jest
+      .spyOn(global.console, 'warn')
+      .mockImplementation(message => (warning = message));
+    const resolver = new Resolver(moduleMap, {
+      extensions: ['.js'],
+    } as ResolverConfig);
+    const src = require.resolve('../');
+    resolver.resolveModule(src, './__mocks__/Mockjsdependency');
+
+    expect(
+      warning.includes(
+        '/__mocks__/Mockjsdependency.js resolved, but has different casing: ' +
+          require.resolve('../__mocks__/mockJsDependency.js'),
+      ),
+    ).toBe(true);
+    spy.mockRestore();
+  });
 });
 
 describe('getMockModule', () => {

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -231,21 +231,17 @@ describe('resolveModule', () => {
     } as ResolverConfig);
     const src = require.resolve('../');
     const modulePath = require.resolve('../__mocks__/mockJsDependency.js');
-    jest.doMock('resolve', () => ({
-      ...require('resolve'),
-      sync: () => modulePath,
-    }));
+    jest
+      .spyOn(resolver, 'resolveModuleFromDirIfExists')
+      .mockImplementation(() => modulePath);
     try {
       resolver.resolveModule(src, './__mocks__/Mockjsdependency');
     } finally {
       spy.mockRestore();
-      jest.dontMock('resolve');
     }
-    expect(
-      warning.includes(
-        `Mockjsdependency.js resolved, but has different casing: ${modulePath}`,
-      ),
-    ).toBe(true);
+    expect(warning).toBe(
+      'Module Mockjsdependency resolved, but has different casing: mockJsDependency',
+    );
   });
 
   it('suggests similarly named modules if cannot find module on case-sensitive file system', () => {

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -112,12 +112,6 @@ function realpathCached(path: Config.Path): Config.Path {
   if (path !== result) {
     // also cache the result in case it's ever referenced directly - no reason to `realpath` that as well
     checkedRealpathPaths.set(result, result);
-
-    if (path.toUpperCase() === result.toUpperCase()) {
-      console.warn(
-        `Module ${path} resolved, but has different casing: ${result}`,
-      );
-    }
   }
 
   return result;

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -112,6 +112,12 @@ function realpathCached(path: Config.Path): Config.Path {
   if (path !== result) {
     // also cache the result in case it's ever referenced directly - no reason to `realpath` that as well
     checkedRealpathPaths.set(result, result);
+
+    if (path.toUpperCase() === result.toUpperCase()) {
+      console.warn(
+        `Module ${path} resolved, but has different casing: ${result}`,
+      );
+    }
   }
 
   return result;

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -9,7 +9,7 @@
 
 import * as path from 'path';
 import chalk = require('chalk');
-import {readdirSync} from 'graceful-fs';
+import {existsSync, readdirSync} from 'graceful-fs';
 import slash = require('slash');
 import type {Config} from '@jest/types';
 import type {ModuleMap} from 'jest-haste-map';
@@ -254,7 +254,11 @@ class Resolver {
 
   private _getSimilarlyNamedFiles(dirname: string, moduleName: string): string {
     const fullModulePath = path.resolve(dirname, moduleName);
-    const files = readdirSync(path.dirname(fullModulePath));
+    const moduleParentDir = path.dirname(fullModulePath);
+    if (!existsSync(moduleParentDir)) {
+      return '';
+    }
+    const files = readdirSync(moduleParentDir);
     const moduleBaseName = path.basename(moduleName);
     const uppercaseModuleName = moduleBaseName.toUpperCase();
     return files

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -231,7 +231,21 @@ class Resolver {
     const module =
       this.resolveStubModuleName(from, moduleName) ||
       this.resolveModuleFromDirIfExists(dirname, moduleName, options);
-    if (module) return module;
+    if (module) {
+      const resolvedModuleName = path.parse(module).name;
+      const requestedModuleName = path.parse(moduleName).name;
+
+      if (
+        resolvedModuleName !== requestedModuleName &&
+        resolvedModuleName.toUpperCase() === requestedModuleName.toUpperCase()
+      ) {
+        console.warn(
+          `Module ${requestedModuleName} resolved, but has different casing: ${resolvedModuleName}`,
+        );
+      }
+
+      return module;
+    }
 
     // 5. Throw an error if the module could not be found. `resolve.sync` only
     // produces an error based on the dirname but we have the actual current

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -254,13 +254,17 @@ class Resolver {
 
   private _getSimilarlyNamedFiles(dirname: string, moduleName: string): string {
     const fullModulePath = path.resolve(dirname, moduleName);
-    const moduleDir = path.dirname(fullModulePath);
-    const files = readdirSync(moduleDir);
-    const uppercaseModuleName = path.basename(moduleName).toUpperCase();
+    const files = readdirSync(path.dirname(fullModulePath));
+    const moduleBaseName = path.basename(moduleName);
+    const uppercaseModuleName = moduleBaseName.toUpperCase();
     return files
-      .filter(
-        file => path.parse(file).name.toUpperCase() === uppercaseModuleName,
-      )
+      .filter(file => {
+        const fileName = path.parse(file).name;
+        return (
+          fileName !== moduleBaseName &&
+          fileName.toUpperCase() === uppercaseModuleName
+        );
+      })
       .join(', ');
   }
 

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -9,6 +9,7 @@
 
 import * as path from 'path';
 import chalk = require('chalk');
+import {readdirSync} from 'graceful-fs';
 import slash = require('slash');
 import type {Config} from '@jest/types';
 import type {ModuleMap} from 'jest-haste-map';
@@ -19,7 +20,6 @@ import isBuiltinModule from './isBuiltinModule';
 import nodeModulesPaths from './nodeModulesPaths';
 import shouldLoadAsEsm, {clearCachedLookups} from './shouldLoadAsEsm';
 import type {ResolverConfig} from './types';
-import {readdirSync} from 'graceful-fs';
 
 type FindNodeModuleConfig = {
   basedir: Config.Path;


### PR DESCRIPTION
## Summary

This attempts to address #10398 – trying to mock modules with different casing than the actual file prevents the mock from working, but only on case sensitive file systems.

### Case-sensitive file systems (Linux, some macOS)

After finding that there are no modules by that exact name, a function is called which finds files with the same name but different casing. These are then appended as a suggestion to the previous error message. 

Hopefully this is enough for a developer to see the difference in casing, and fix it. 

### Case-insensitive file systems (Windows, most macOS)

After resolving the module, there's a check for whether the casing is different, in which case we do `console.warn()` to let the developer know about this. 

I didn't want to outright fail the resolution, that sounds too aggressive to me and would cause issues for developers. I expect it's enough to log a warning. 

I would like a suggestion on how to get the warning to the reporter! Then I can put some color on it as well, it isn't very noticeable at the moment (see screenshot below).

## Test plan

My basic setup for testing it out: 

index.js:
```javascript
function sum(a, b) {
  return a + b;
}

module.exports = sum;
```

index.test.js:
```javascript
const sum = require("./index");

test("add 1 and 2 to make 3", () => {
  jest.mock("./INDEX", () => ({ get: jest.fn(() => 1000) })); // Note INDEX vs index
  expect(sum(1, 2)).toBe(3);
});
```

Configure `package.json`:
```json
"scripts": {
    "test": "jest"
}
```

`yarn link` the `jest-cli` package

`yarn link jest-cli` in my test 

Then in shell:

```shell
$ cd path/to/jest/packages/jest-cli

$ yarn link

$ cd path/to/JestTest

$ yarn link jest-cli

$ yarn test
```
The output on a case-sensitive file system: 
![image](https://user-images.githubusercontent.com/1223518/99099803-f334f680-25a8-11eb-8f88-ac6e6fad93b3.png)


The output on a case-insensitive file system: 
![image](https://user-images.githubusercontent.com/1223518/98459810-4bfd2d00-216c-11eb-9144-da8a0f3d2f22.png)
