### PR TITLE
fix(jest-leak-detector): gc() even harder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - `[jest-core]` Capture execError during `TestScheduler.scheduleTests` and dispatch to reporters ([#13203](https://github.com/facebook/jest/pull/13203))
+- `[jest-leak-detector]` Try even harder to cleanup before declaring a leak ([#10994](https://github.com/facebook/jest/pull/10994))
 
 ### Chore & Maintenance
 

--- a/packages/jest-leak-detector/src/index.ts
+++ b/packages/jest-leak-detector/src/index.ts
@@ -41,11 +41,13 @@ export default class LeakDetector {
   }
 
   async isLeaking(): Promise<boolean> {
-    this._runGarbageCollector();
+    for (let i = 0; i < 2; ++i) {
+      this._runGarbageCollector();
 
-    // wait some ticks to allow GC to run properly, see https://github.com/nodejs/node/issues/34636#issuecomment-669366235
-    for (let i = 0; i < 10; i++) {
-      await tick();
+      // wait some ticks to allow GC to run properly, see https://github.com/nodejs/node/issues/34636#issuecomment-669366235
+      for (let i = 0; i < 10; i++) {
+        await tick();
+      }
     }
 
     return this._isReferenceBeingHeld;


### PR DESCRIPTION
## Summary

jest-leak-detector declares a leak in some of our large projects,
a leak which does not exist. I have bisected it down to there
being too deep require() trees, and/or too many files loaded.

It is definitely not a timing issue; replacing the extra gc() with
a multi-second sleep does not fix it. Calling gc() from the app code
surprisingly does fix it, at least, for us. My working theory is that
the app's gc() takes out some of the actual garbage, leaving
leak-detector's gc() time to actually collect all of the code,
resulting, eventually, in no leak.

I realise this is hot garbage. I'm absolutely not going to try and
write a test for this, and I understand if you close the PR with
nelson.gif, and I will continue running with hacks, or try and
raise a PR which allows the leak-detector implementation to be
configurable.

Tested on node 12 and 14, same behaviour.

## Test plan

I really advise that you don't.

There are tests which cover the leak detector's behaviour, and they are not broken.