### PR TITLE
Result.message is not a function error

### DIFF
--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -137,8 +137,8 @@ const expect: any = (actual: any, ...rest: Array<any>) => {
   return expectation;
 };
 
-const getMessage = (message?: () => string) =>
-  (message && message()) ||
+const getMessage = (message?:  string) =>
+  (message) ||
   matcherUtils.RECEIVED_COLOR('No message was specified for this matcher.');
 
 const makeResolveMatcher =

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -14,7 +14,7 @@ import {INTERNAL_MATCHER_FLAG} from './jestMatchersObject';
 
 export type SyncExpectationResult = {
   pass: boolean;
-  message: () => string;
+  message: string;
 };
 
 export type AsyncExpectationResult = Promise<SyncExpectationResult>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
I was using Jest version 27.0.4 and got this error:
![image](https://user-images.githubusercontent.com/59834135/122551573-70d84d80-d035-11eb-8c7e-a7a465f4899b.png)
And no `Expected` or `Received` messages.

Then I went into the jest files and changed 
![image](https://user-images.githubusercontent.com/59834135/122551791-c0b71480-d035-11eb-9bc9-67b45e926e21.png)
To:
![image](https://user-images.githubusercontent.com/59834135/122551831-cdd40380-d035-11eb-8898-74a0f4d7e28f.png)
 And then everything worked as expected. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
## Motivation
I had a bug.
## Test plan
Just do the normal test. This shouldn't be a huge change. 
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->