### PR TITLE
feat(jest-haste-map): add workerTimeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-haste-map]` Add a `workerTimeout` failsafe to Throw if worker threads are slow to resolve. ([#11795](https://github.com/facebook/jest/pull/11795))
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -516,6 +516,8 @@ type HasteConfig = {
   throwOnModuleCollision?: boolean;
   /** Custom HasteMap module */
   hasteMapModulePath?: string;
+  /** Override timeout for unresponsive workers (milliseconds) */
+  workerTimeout?: number;
 };
 ```
 

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -65,6 +65,7 @@ const initialOptions: Config.InitialOptions = {
     hasteMapModulePath: '',
     platforms: ['ios', 'android'],
     throwOnModuleCollision: false,
+    workerTimeout: 3000,
   },
   injectGlobals: true,
   json: false,

--- a/packages/jest-haste-map/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/jest-haste-map/src/__tests__/__snapshots__/index.test.js.snap
@@ -37,3 +37,5 @@ jest-haste-map: Haste module naming collision: Strawberry
     * <rootDir>/fruits/other/Strawberry.js
 
 `;
+
+exports[`HasteMap workers should time out when workers are slow to resolve 1`] = `"jest-haste-map: timed out waiting for workers. This might be a bug in Jest, please open up an issue."`;

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -361,6 +361,7 @@ export default class Runtime {
       throwOnModuleCollision: config.haste.throwOnModuleCollision,
       useWatchman: options?.watchman,
       watch: options?.watch,
+      workerTimeout: config.haste.workerTimeout,
     });
   }
 

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -38,6 +38,8 @@ export type HasteConfig = {
   throwOnModuleCollision?: boolean;
   /** Custom HasteMap module */
   hasteMapModulePath?: string;
+  /** Override timeout for unresponsive workers (milliseconds) */
+  workerTimeout?: number;
 };
 
 export type CoverageReporterName = keyof ReportOptions;


### PR DESCRIPTION
## Summary

Closes  #11786

`jest-haste-map` can spawn a number of worker-threads to asynchronously gather metadata on files. Currently it bundles up the promises from all workers and awaits all of them to resolve.

This is vulnerable to freezing up (waiting indefinitely) if something unexpected happens with one or more of the workers, where they do not respond or exit cleanly.

This PR is a stab at introducing a mechanism to Throw if workers, for whatever reason, are unexpectedly slow to respond.

The timeout is configurable via `haste.workerTimeout` in `ProjectConfig` and defaults to 3000 ms. (Too long? Too short?)

## Motivation

A generalised approach to handling something unexpected happening with the workers - e.g. users testing with current or future experimental node features that do not play well with `jest-haste-map`.

## Test plan

- Check out PR
- `yarn install `&& `yarn build`
- `yarn jest packages/jest-haste-map/src/__tests__/index.test.js`
- Observe tests passing

- Then apply patch to return a `Promise.all()` like before, and re-run test suite. Observe test fail due to timeout.

```diff
diff --git a/packages/jest-haste-map/src/index.ts b/packages/jest-haste-map/src/index.ts
index 57afc72d2b..5b47b17d96 100644
--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -714,11 +714,11 @@ export default class HasteMap extends EventEmitter {
     };
 
     const allWorkerPromises = Promise.all(workerPromises);
-    const timeoutPromise = new Promise((_resolve, reject) =>
-      rejectAfterDelay(reject),
-    );
+    //const timeoutPromise = new Promise((_resolve, reject) =>
+    //  rejectAfterDelay(reject),
+    //);
 
-    return Promise.race([allWorkerPromises, timeoutPromise])
+    return allWorkerPromises
       .then(
         () => {
           hasteMap.map = map;
```
- To double check that the test simulates a delayed worker: change `setTimeout()` delay in the test's `resolveAfterDelay` to `0` and re-run test suite to observe `hasteMapInstance.build()` immediately resolved.

#11786 also includes a concrete example on how to blow up internals so that the worker threads become unresponsive.