### PR TITLE
fix(jest-transform): fix race condition while reading cache file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[@jest/types]` Mark deprecated configuration options as `@deprecated` ([#11913](https://github.com/facebook/jest/pull/11913))
 - `[jest-cli]` Improve `--help` printout by removing defunct `--browser` option ([#11914](https://github.com/facebook/jest/pull/11914))
 - `[jest-haste-map]` Use distinct cache paths for different values of `computeDependencies` ([#11916](https://github.com/facebook/jest/pull/11916))
+- `[jest-transform]` Fix potential race condition while reading from cache file if the cache file is deleted while processing. ([#11920](https://github.com/facebook/jest/pull/11920))
 
 ### Chore & Maintenance
 

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -926,21 +926,22 @@ const cacheWriteErrorSafeToIgnore = (
   fs.existsSync(cachePath);
 
 const readCacheFile = (cachePath: Config.Path): string | null => {
-  if (!fs.existsSync(cachePath)) {
-    return null;
-  }
-
   let fileData;
   try {
     fileData = fs.readFileSync(cachePath, 'utf8');
   } catch (e) {
-    e.message =
-      'jest: failed to read cache file: ' +
-      cachePath +
-      '\nFailure message: ' +
-      e.message;
-    removeFile(cachePath);
-    throw e;
+    if (e.code === 'ENOENT') {
+      return null;
+    } else {
+      e.message =
+        'jest: failed to read cache file: ' +
+        cachePath +
+        '\nFailure message: ' +
+        e.message;
+      removeFile(cachePath);
+      throw e;
+    }
+    
   }
 
   if (fileData == null) {

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -941,7 +941,6 @@ const readCacheFile = (cachePath: Config.Path): string | null => {
       removeFile(cachePath);
       throw e;
     }
-    
   }
 
   if (fileData == null) {

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -926,6 +926,10 @@ const cacheWriteErrorSafeToIgnore = (
   fs.existsSync(cachePath);
 
 const readCacheFile = (cachePath: Config.Path): string | null => {
+  if (!fs.existsSync(cachePath)) {
+    return null;
+  }
+
   let fileData;
   try {
     fileData = fs.readFileSync(cachePath, 'utf8');

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -1822,6 +1822,19 @@ describe('ScriptTransformer', () => {
       ['test_preprocessor', expect.any(Object)],
     ]);
   });
+
+  it('regardless of sync/async, handles race condition where cache was deleted (fs.existsSync returns true but readFileSync returns ENOENT)', async () => {
+    fs.existsSync = jest.fn(() => true);
+
+    const scriptTransformer = await createScriptTransformer(config);
+
+    scriptTransformer.transform('/fruits/banana.js', getCoverageOptions());
+
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+    expect(fs.readFileSync).toBeCalledWith('/fruits/banana.js', 'utf8');
+    expect(fs.readFileSync).toBeCalledWith(expect.stringMatching(/\/cache\/jest-transform-cache-test\/[0-9a-f]{2}\/banana_.+/), 'utf8');
+  });
+  
 });
 
 function getCoverageOptions(

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -266,7 +266,11 @@ describe('ScriptTransformer', () => {
         return mockFs[path];
       }
 
-      throw new Error(`Cannot read path '${path}'.`);
+      const err: NodeJS.ErrnoException = new Error(`Cannot read path '${path}'.`);
+      err.code = 'ENOENT';
+      err.syscall = 'open';
+      err.errno = 2;
+      throw err;
     });
     fs.writeFileSync = jest.fn((path, data, options) => {
       invariant(typeof path === 'string');

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -1828,11 +1828,11 @@ describe('ScriptTransformer', () => {
 
     const scriptTransformer = await createScriptTransformer(config);
 
-    scriptTransformer.transform('/fruits/banana.js', getCoverageOptions());
+    scriptTransformer.transform('/fruits/deleted_file.js', getCoverageOptions());
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(2);
-    expect(fs.readFileSync).toBeCalledWith('/fruits/banana.js', 'utf8');
-    expect(fs.readFileSync).toBeCalledWith(expect.stringMatching(/\/cache\/jest-transform-cache-test\/[0-9a-f]{2}\/banana_.+/), 'utf8');
+    expect(fs.readFileSync).toBeCalledWith('/fruits/deleted_file.js', 'utf8');
+    expect(fs.readFileSync).toBeCalledWith(expect.stringMatching(/\/cache\/jest-transform-cache-test\/[0-9a-f]{2}\/deleted_file_.+/), 'utf8');
   });
   
 });

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -322,8 +322,9 @@ describe('ScriptTransformer', () => {
     expect(wrap(transformedBananaWithCoverage.code)).toMatchSnapshot();
 
     // no-cache case
-    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
     expect(fs.readFileSync).toBeCalledWith('/fruits/banana.js', 'utf8');
+    expect(fs.readFileSync).toBeCalledWith(expect.stringMatching(/\/cache\/jest-transform-cache-test\/[0-9a-f]{2}\/banana_.+/), 'utf8');
 
     // in-memory cache
     const transformedBananaWithCoverageAgain = scriptTransformer.transform(

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -322,9 +322,8 @@ describe('ScriptTransformer', () => {
     expect(wrap(transformedBananaWithCoverage.code)).toMatchSnapshot();
 
     // no-cache case
-    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(1);
     expect(fs.readFileSync).toBeCalledWith('/fruits/banana.js', 'utf8');
-    expect(fs.readFileSync).toBeCalledWith(expect.stringMatching(/\/cache\/jest-transform-cache-test\/[0-9a-f]{2}\/banana_.+/), 'utf8');
 
     // in-memory cache
     const transformedBananaWithCoverageAgain = scriptTransformer.transform(

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -1828,11 +1828,11 @@ describe('ScriptTransformer', () => {
 
     const scriptTransformer = await createScriptTransformer(config);
 
-    scriptTransformer.transform('/fruits/deleted_file.js', getCoverageOptions());
+    scriptTransformer.transform('/fruits/banana.js', getCoverageOptions());
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(2);
-    expect(fs.readFileSync).toBeCalledWith('/fruits/deleted_file.js', 'utf8');
-    expect(fs.readFileSync).toBeCalledWith(expect.stringMatching(/\/cache\/jest-transform-cache-test\/[0-9a-f]{2}\/deleted_file_.+/), 'utf8');
+    expect(fs.readFileSync).toBeCalledWith('/fruits/banana.js', 'utf8');
+    expect(fs.readFileSync).toBeCalledWith(expect.stringMatching(/\/cache\/jest-transform-cache-test\/[0-9a-f]{2}\/banana.+/), 'utf8');
   });
   
 });

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -266,7 +266,9 @@ describe('ScriptTransformer', () => {
         return mockFs[path];
       }
 
-      const err: NodeJS.ErrnoException = new Error(`Cannot read path '${path}'.`);
+      const err: NodeJS.ErrnoException = new Error(
+        `Cannot read path '${path}'.`,
+      );
       err.code = 'ENOENT';
       err.syscall = 'open';
       err.errno = 2;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Potential race condition if the cache is read and simultaneously deleted.

## Test plan

Added unit test where `fs.existsSync` return true but `fs.readFileSync` throws ENOENT. Not sure how to reliably simulate a filesystem race condition in NodeJS for integration test (if needed).
