### PR TITLE
Add esbuild resolver for `jest.config.ts`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[jest-config]` Add esbuild resolver for `jest.config.ts` as a `ts-node` alternative ([#12041](https://github.com/facebook/jest/pull/12041))
 - `[jest-core]` Add support for `testResultsProcessor` written in ESM ([#12006](https://github.com/facebook/jest/pull/12006))
 - `[jest-diff, pretty-format]` Add `compareKeys` option for custom sorting of object keys ([#11992](https://github.com/facebook/jest/pull/11992))
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,6 @@
   "devDependencies": {
     "@babel/core": "^7.3.4",
     "@babel/plugin-proposal-class-properties": "^7.3.4",
-    "@babel/plugin-transform-modules-commonjs": "^7.1.0",
-    "@babel/preset-env": "^7.1.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/preset-typescript": "^7.0.0",
     "@babel/register": "^7.0.0",
@@ -31,6 +29,7 @@
     "codecov": "^3.0.0",
     "debug": "^4.0.1",
     "dedent": "^0.7.0",
+    "esbuild-register": "^3.0.0",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-eslint-comments": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "codecov": "^3.0.0",
     "debug": "^4.0.1",
     "dedent": "^0.7.0",
-    "esbuild": "^0.13.12",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-eslint-comments": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "codecov": "^3.0.0",
     "debug": "^4.0.1",
     "dedent": "^0.7.0",
-    "esbuild-register": "^3.0.0",
+    "esbuild-register": "^3.1.0",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-eslint-comments": "^3.1.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "codecov": "^3.0.0",
     "debug": "^4.0.1",
     "dedent": "^0.7.0",
+    "esbuild": "^0.13.12",
     "eslint": "^7.7.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-eslint-comments": "^3.1.2",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -14,11 +14,11 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
-    "esbuild": ">=0.13.12",
+    "esbuild-register": ">=3.0.0",
     "ts-node": ">=9.0.0"
   },
   "peerDependenciesMeta": {
-    "esbuild": {
+    "esbuild-register": {
       "optional": true
     },
     "ts-node": {
@@ -33,7 +33,6 @@
     "chalk": "^4.0.0",
     "ci-info": "^3.2.0",
     "deepmerge": "^4.2.2",
-    "esbuild-register": "^3.0.0",
     "glob": "^7.1.1",
     "graceful-fs": "^4.2.4",
     "jest-circus": "^27.3.1",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -14,7 +14,7 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
-    "esbuild-register": ">=3.0.0",
+    "esbuild-register": ">=3.1.0",
     "ts-node": ">=9.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -14,9 +14,13 @@
     "./package.json": "./package.json"
   },
   "peerDependencies": {
+    "esbuild": ">=0.13.12",
     "ts-node": ">=9.0.0"
   },
   "peerDependenciesMeta": {
+    "esbuild": {
+      "optional": true
+    },
     "ts-node": {
       "optional": true
     }

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -33,6 +33,7 @@
     "chalk": "^4.0.0",
     "ci-info": "^3.2.0",
     "deepmerge": "^4.2.2",
+    "esbuild-register": "^3.0.0",
     "glob": "^7.1.1",
     "graceful-fs": "^4.2.4",
     "jest-circus": "^27.3.1",

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -109,7 +109,11 @@ const loadTSConfigFile = async (
         throw error;
       }
 
-      const outfile = 'node_modules/jest-config/_jest.config.js';
+      const outfile = require('path').join(
+        require('os').tmpdir(),
+        'jest',
+        '_jest.config.js',
+      );
 
       await esbuild({
         // By bundling we add support for importing stuff in the config file.

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -84,7 +84,6 @@ const loadTSConfigFile = async (
   configPath: Config.Path,
 ): Promise<Config.InitialOptions> => {
   let registerer: Service;
-  let tsNode;
 
   // Register TypeScript compiler instance
   try {
@@ -93,11 +92,10 @@ const loadTSConfigFile = async (
         module: 'CommonJS',
       },
     });
-    tsNode = true;
   } catch (e: any) {
     if (e.code === 'MODULE_NOT_FOUND') {
       try {
-        require('esbuild');
+        registerer = require('esbuild-register');
       } catch (error: any) {
         if (error.code === 'MODULE_NOT_FOUND') {
           throw new Error(
@@ -107,16 +105,12 @@ const loadTSConfigFile = async (
 
         throw error;
       }
-
-      registerer = require('esbuild-register').register();
     }
 
     throw e;
   }
 
-  if (tsNode) {
-    registerer.enabled(true);
-  }
+  registerer.enabled(true);
 
   let configObject = interopRequireDefault(require(configPath)).default;
 
@@ -125,9 +119,7 @@ const loadTSConfigFile = async (
     configObject = await configObject();
   }
 
-  if (tsNode) {
-    registerer.enabled(false);
-  }
+  registerer.enabled(false);
 
   return configObject;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,6 +2582,7 @@ __metadata:
     codecov: ^3.0.0
     debug: ^4.0.1
     dedent: ^0.7.0
+    esbuild: ^0.13.12
     eslint: ^7.7.0
     eslint-config-prettier: ^8.1.0
     eslint-plugin-eslint-comments: ^3.1.2
@@ -9113,6 +9114,187 @@ __metadata:
   languageName: node
   linkType: hard
 
+"esbuild-android-arm64@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-android-arm64@npm:0.13.12"
+  checksum: 463cab1bdcbb1cffd0d5dca4db7759d781dab3dcbcb957b07d94c4811a8f1f427122de4eef0be3522ef58acd0ee3995c93d1a0e54f06ba66e2972c94fd10051c
+  languageName: node
+  linkType: hard
+
+"esbuild-darwin-64@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-darwin-64@npm:0.13.12"
+  checksum: 363da95450ce0834094b4325f08e9cba9c5e86cbb705411b54375e7c07cec719a12f98e77779db07c7cf297e5060acfe3f89a410682482dbf85de1478ae10d51
+  languageName: node
+  linkType: hard
+
+"esbuild-darwin-arm64@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-darwin-arm64@npm:0.13.12"
+  checksum: 9103cfff8e9abd325bfc119394ab26b0e488a5ead3beb3cc08e02960a4c6a1b3ee3120864add421d9519446ec06bff283127d122776e5c18361aaceac47971be
+  languageName: node
+  linkType: hard
+
+"esbuild-freebsd-64@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-freebsd-64@npm:0.13.12"
+  checksum: 684f656e1296099fc87bb7e62e8b9cd75b12d9bc076e7e5a388149126e1cc1185346790e2c8b0f4bd2d2131395f1d6f356aab1e0adf7659263c125cecae9ea88
+  languageName: node
+  linkType: hard
+
+"esbuild-freebsd-arm64@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-freebsd-arm64@npm:0.13.12"
+  checksum: 359205d7650c5ac0edf0e0bf89ede9f54a3b2d973dbb6371f18cd467e523e5980fa30edf93dc00abd8812cb40f6928da31cf14425cd8ab6f462e0a6f510336fa
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-32@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-linux-32@npm:0.13.12"
+  checksum: 4d2f4d7dbf6277c8f0e31c1654822088dc4e73c37a5a0e0f81181c78140cd220ec7ba8cb7a3e840c43395b1745ebe84d11b2671f19025e2c18210407ef88cc7a
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-64@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-linux-64@npm:0.13.12"
+  checksum: df135e615c6acbdd851fcf67bf79ecf92a8cc26d0a2530b517b9c41f314835d5bc9a046cb086c39bb361d5984a0f63d3f8d789d4011fe506e3650c815b0d22e1
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-arm64@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-linux-arm64@npm:0.13.12"
+  checksum: f066529d03708c2d3b62d95f939ff5517232380e944c8cd4fc4a0d631324acaeddb58a48f93cfb84447a8f894b8312e8b0b639d360fdd16ad8503084b8cef094
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-arm@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-linux-arm@npm:0.13.12"
+  checksum: 3324b32fdeffb546118a5a6a3a1b5039bd95bd54ca679377e5032266d17241b0073cb24d76a8746f47f18bc1a491be3a478ececdebdf55932a2a6e1d2b66459e
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-mips64le@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-linux-mips64le@npm:0.13.12"
+  checksum: 3a8e424f30f80d939f3327cbd73f19965b55ff877e0ddc6ce64fb6a2df0c5f8f91e6c84da3e62b8237597a0d11b619f4946dfca93141ba182071f2ccf824762d
+  languageName: node
+  linkType: hard
+
+"esbuild-linux-ppc64le@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-linux-ppc64le@npm:0.13.12"
+  checksum: d9eefd1fa82111fca3807560b5554cc45c3904865dd85583c7417c8b3504bc7bab64f03e89db6061980ba0719b27abc25dccf4244c53df848ba066bbd97dafb1
+  languageName: node
+  linkType: hard
+
+"esbuild-netbsd-64@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-netbsd-64@npm:0.13.12"
+  checksum: 7786a50566233ba9970ce56e26fda783d95e5f8a770b2fc9cf57f7b530780dbd3ba2b93d2efc0ff30653479315564c5b0f3ca52ac0834ed16ae73beb8cce7333
+  languageName: node
+  linkType: hard
+
+"esbuild-openbsd-64@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-openbsd-64@npm:0.13.12"
+  checksum: 6e1d5761c4b3c6779693da4e362a2fb20501181c7d570c26f9b31824ce54f1ed2b47aa82f4e70d0f22456f8a238ed8100dffe07ff8a3ed5ca98ea8671d783bcb
+  languageName: node
+  linkType: hard
+
+"esbuild-sunos-64@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-sunos-64@npm:0.13.12"
+  checksum: dda28729e84997e78323c8098cc2749033428f63436ef49d7436d85409145e55a48ce09117bcda7b86846aa98ba00dfb57518551fc74aefcb238e5655e5e0fd5
+  languageName: node
+  linkType: hard
+
+"esbuild-windows-32@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-windows-32@npm:0.13.12"
+  checksum: 4b10efad53682b5c8a2c3aa0181e2163f857715ea7dfeb64066528b54f93baa573fa1afd10a87730e268aa358f192ba1882c9fcd4a05f8d18b97d3f37a57b56a
+  languageName: node
+  linkType: hard
+
+"esbuild-windows-64@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-windows-64@npm:0.13.12"
+  checksum: d44ed2c7e9faa682e6b41f7c7a75847ca9fedddc5f78852e25de14fe48c29e4b65f40210b2f12255f0b9363b08ba34ddb70ca6676d5e55e63e58855ebd3ef94f
+  languageName: node
+  linkType: hard
+
+"esbuild-windows-arm64@npm:0.13.12":
+  version: 0.13.12
+  resolution: "esbuild-windows-arm64@npm:0.13.12"
+  checksum: 3d191bfe862209021bf2e504ee9a886eac6006400de5d659d33828be1711de3d9afa3f75ef39d7f2f6cab592128c53651c3898fbdeeddf6983d0934ed3db155c
+  languageName: node
+  linkType: hard
+
+"esbuild@npm:^0.13.12":
+  version: 0.13.12
+  resolution: "esbuild@npm:0.13.12"
+  dependencies:
+    esbuild-android-arm64: 0.13.12
+    esbuild-darwin-64: 0.13.12
+    esbuild-darwin-arm64: 0.13.12
+    esbuild-freebsd-64: 0.13.12
+    esbuild-freebsd-arm64: 0.13.12
+    esbuild-linux-32: 0.13.12
+    esbuild-linux-64: 0.13.12
+    esbuild-linux-arm: 0.13.12
+    esbuild-linux-arm64: 0.13.12
+    esbuild-linux-mips64le: 0.13.12
+    esbuild-linux-ppc64le: 0.13.12
+    esbuild-netbsd-64: 0.13.12
+    esbuild-openbsd-64: 0.13.12
+    esbuild-sunos-64: 0.13.12
+    esbuild-windows-32: 0.13.12
+    esbuild-windows-64: 0.13.12
+    esbuild-windows-arm64: 0.13.12
+  dependenciesMeta:
+    esbuild-android-arm64:
+      optional: true
+    esbuild-darwin-64:
+      optional: true
+    esbuild-darwin-arm64:
+      optional: true
+    esbuild-freebsd-64:
+      optional: true
+    esbuild-freebsd-arm64:
+      optional: true
+    esbuild-linux-32:
+      optional: true
+    esbuild-linux-64:
+      optional: true
+    esbuild-linux-arm:
+      optional: true
+    esbuild-linux-arm64:
+      optional: true
+    esbuild-linux-mips64le:
+      optional: true
+    esbuild-linux-ppc64le:
+      optional: true
+    esbuild-netbsd-64:
+      optional: true
+    esbuild-openbsd-64:
+      optional: true
+    esbuild-sunos-64:
+      optional: true
+    esbuild-windows-32:
+      optional: true
+    esbuild-windows-64:
+      optional: true
+    esbuild-windows-arm64:
+      optional: true
+  bin:
+    esbuild: bin/esbuild
+  checksum: 9e3d2b0f7003f48788c82b8bd7d8cd3f4364b51dfffe4fbe35c1b25a39ccdc76f568defebe4b3cbdf69bcb094ec57a1ffb671e00310fc852f76717477c851ae1
+  languageName: node
+  linkType: hard
+
 "escalade@npm:^3.0.2, escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
@@ -12662,8 +12844,11 @@ fsevents@^1.2.7:
     ts-node: ^9.0.0
     typescript: ^4.0.3
   peerDependencies:
+    esbuild: "*"
     ts-node: ">=9.0.0"
   peerDependenciesMeta:
+    esbuild:
+      optional: true
     ts-node:
       optional: true
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -2580,7 +2580,7 @@ __metadata:
     codecov: ^3.0.0
     debug: ^4.0.1
     dedent: ^0.7.0
-    esbuild-register: ^3.0.0
+    esbuild-register: ^3.1.0
     eslint: ^7.7.0
     eslint-config-prettier: ^8.1.0
     eslint-plugin-eslint-comments: ^3.1.2
@@ -9112,14 +9112,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-register@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "esbuild-register@npm:3.0.0"
+"esbuild-register@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "esbuild-register@npm:3.1.0"
   dependencies:
     jsonc-parser: ^3.0.0
   peerDependencies:
     esbuild: ">=0.12 <1"
-  checksum: 9d60f690f9b1ed6b08fdca1d9d40ac464d9580bfec439be9cc5df8a5cab565e0ded8671c07726f35fea0299f94d69ea3e1cd6b46f762c6783b93c1a58fae7503
+  checksum: 6177ce57f7599bf2f83684611b445e002766183d804eee01f3a33f776bbd2e97e24083e090ee638a39f9711ab44cd9f3587db458ea090d7d801de7c3bd027701
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,7 +2582,6 @@ __metadata:
     codecov: ^3.0.0
     debug: ^4.0.1
     dedent: ^0.7.0
-    esbuild: ^0.13.12
     eslint: ^7.7.0
     eslint-config-prettier: ^8.1.0
     eslint-plugin-eslint-comments: ^3.1.2
@@ -9114,184 +9113,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"esbuild-android-arm64@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-android-arm64@npm:0.13.12"
-  checksum: 463cab1bdcbb1cffd0d5dca4db7759d781dab3dcbcb957b07d94c4811a8f1f427122de4eef0be3522ef58acd0ee3995c93d1a0e54f06ba66e2972c94fd10051c
-  languageName: node
-  linkType: hard
-
-"esbuild-darwin-64@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-darwin-64@npm:0.13.12"
-  checksum: 363da95450ce0834094b4325f08e9cba9c5e86cbb705411b54375e7c07cec719a12f98e77779db07c7cf297e5060acfe3f89a410682482dbf85de1478ae10d51
-  languageName: node
-  linkType: hard
-
-"esbuild-darwin-arm64@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-darwin-arm64@npm:0.13.12"
-  checksum: 9103cfff8e9abd325bfc119394ab26b0e488a5ead3beb3cc08e02960a4c6a1b3ee3120864add421d9519446ec06bff283127d122776e5c18361aaceac47971be
-  languageName: node
-  linkType: hard
-
-"esbuild-freebsd-64@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-freebsd-64@npm:0.13.12"
-  checksum: 684f656e1296099fc87bb7e62e8b9cd75b12d9bc076e7e5a388149126e1cc1185346790e2c8b0f4bd2d2131395f1d6f356aab1e0adf7659263c125cecae9ea88
-  languageName: node
-  linkType: hard
-
-"esbuild-freebsd-arm64@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-freebsd-arm64@npm:0.13.12"
-  checksum: 359205d7650c5ac0edf0e0bf89ede9f54a3b2d973dbb6371f18cd467e523e5980fa30edf93dc00abd8812cb40f6928da31cf14425cd8ab6f462e0a6f510336fa
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-32@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-linux-32@npm:0.13.12"
-  checksum: 4d2f4d7dbf6277c8f0e31c1654822088dc4e73c37a5a0e0f81181c78140cd220ec7ba8cb7a3e840c43395b1745ebe84d11b2671f19025e2c18210407ef88cc7a
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-64@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-linux-64@npm:0.13.12"
-  checksum: df135e615c6acbdd851fcf67bf79ecf92a8cc26d0a2530b517b9c41f314835d5bc9a046cb086c39bb361d5984a0f63d3f8d789d4011fe506e3650c815b0d22e1
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-arm64@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-linux-arm64@npm:0.13.12"
-  checksum: f066529d03708c2d3b62d95f939ff5517232380e944c8cd4fc4a0d631324acaeddb58a48f93cfb84447a8f894b8312e8b0b639d360fdd16ad8503084b8cef094
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-arm@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-linux-arm@npm:0.13.12"
-  checksum: 3324b32fdeffb546118a5a6a3a1b5039bd95bd54ca679377e5032266d17241b0073cb24d76a8746f47f18bc1a491be3a478ececdebdf55932a2a6e1d2b66459e
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-mips64le@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-linux-mips64le@npm:0.13.12"
-  checksum: 3a8e424f30f80d939f3327cbd73f19965b55ff877e0ddc6ce64fb6a2df0c5f8f91e6c84da3e62b8237597a0d11b619f4946dfca93141ba182071f2ccf824762d
-  languageName: node
-  linkType: hard
-
-"esbuild-linux-ppc64le@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-linux-ppc64le@npm:0.13.12"
-  checksum: d9eefd1fa82111fca3807560b5554cc45c3904865dd85583c7417c8b3504bc7bab64f03e89db6061980ba0719b27abc25dccf4244c53df848ba066bbd97dafb1
-  languageName: node
-  linkType: hard
-
-"esbuild-netbsd-64@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-netbsd-64@npm:0.13.12"
-  checksum: 7786a50566233ba9970ce56e26fda783d95e5f8a770b2fc9cf57f7b530780dbd3ba2b93d2efc0ff30653479315564c5b0f3ca52ac0834ed16ae73beb8cce7333
-  languageName: node
-  linkType: hard
-
-"esbuild-openbsd-64@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-openbsd-64@npm:0.13.12"
-  checksum: 6e1d5761c4b3c6779693da4e362a2fb20501181c7d570c26f9b31824ce54f1ed2b47aa82f4e70d0f22456f8a238ed8100dffe07ff8a3ed5ca98ea8671d783bcb
-  languageName: node
-  linkType: hard
-
-"esbuild-sunos-64@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-sunos-64@npm:0.13.12"
-  checksum: dda28729e84997e78323c8098cc2749033428f63436ef49d7436d85409145e55a48ce09117bcda7b86846aa98ba00dfb57518551fc74aefcb238e5655e5e0fd5
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-32@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-windows-32@npm:0.13.12"
-  checksum: 4b10efad53682b5c8a2c3aa0181e2163f857715ea7dfeb64066528b54f93baa573fa1afd10a87730e268aa358f192ba1882c9fcd4a05f8d18b97d3f37a57b56a
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-64@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-windows-64@npm:0.13.12"
-  checksum: d44ed2c7e9faa682e6b41f7c7a75847ca9fedddc5f78852e25de14fe48c29e4b65f40210b2f12255f0b9363b08ba34ddb70ca6676d5e55e63e58855ebd3ef94f
-  languageName: node
-  linkType: hard
-
-"esbuild-windows-arm64@npm:0.13.12":
-  version: 0.13.12
-  resolution: "esbuild-windows-arm64@npm:0.13.12"
-  checksum: 3d191bfe862209021bf2e504ee9a886eac6006400de5d659d33828be1711de3d9afa3f75ef39d7f2f6cab592128c53651c3898fbdeeddf6983d0934ed3db155c
-  languageName: node
-  linkType: hard
-
-"esbuild@npm:^0.13.12":
-  version: 0.13.12
-  resolution: "esbuild@npm:0.13.12"
+"esbuild-register@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "esbuild-register@npm:3.0.0"
   dependencies:
-    esbuild-android-arm64: 0.13.12
-    esbuild-darwin-64: 0.13.12
-    esbuild-darwin-arm64: 0.13.12
-    esbuild-freebsd-64: 0.13.12
-    esbuild-freebsd-arm64: 0.13.12
-    esbuild-linux-32: 0.13.12
-    esbuild-linux-64: 0.13.12
-    esbuild-linux-arm: 0.13.12
-    esbuild-linux-arm64: 0.13.12
-    esbuild-linux-mips64le: 0.13.12
-    esbuild-linux-ppc64le: 0.13.12
-    esbuild-netbsd-64: 0.13.12
-    esbuild-openbsd-64: 0.13.12
-    esbuild-sunos-64: 0.13.12
-    esbuild-windows-32: 0.13.12
-    esbuild-windows-64: 0.13.12
-    esbuild-windows-arm64: 0.13.12
-  dependenciesMeta:
-    esbuild-android-arm64:
-      optional: true
-    esbuild-darwin-64:
-      optional: true
-    esbuild-darwin-arm64:
-      optional: true
-    esbuild-freebsd-64:
-      optional: true
-    esbuild-freebsd-arm64:
-      optional: true
-    esbuild-linux-32:
-      optional: true
-    esbuild-linux-64:
-      optional: true
-    esbuild-linux-arm:
-      optional: true
-    esbuild-linux-arm64:
-      optional: true
-    esbuild-linux-mips64le:
-      optional: true
-    esbuild-linux-ppc64le:
-      optional: true
-    esbuild-netbsd-64:
-      optional: true
-    esbuild-openbsd-64:
-      optional: true
-    esbuild-sunos-64:
-      optional: true
-    esbuild-windows-32:
-      optional: true
-    esbuild-windows-64:
-      optional: true
-    esbuild-windows-arm64:
-      optional: true
-  bin:
-    esbuild: bin/esbuild
-  checksum: 9e3d2b0f7003f48788c82b8bd7d8cd3f4364b51dfffe4fbe35c1b25a39ccdc76f568defebe4b3cbdf69bcb094ec57a1ffb671e00310fc852f76717477c851ae1
+    jsonc-parser: ^3.0.0
+  peerDependencies:
+    esbuild: ">=0.12 <1"
+  checksum: 9d60f690f9b1ed6b08fdca1d9d40ac464d9580bfec439be9cc5df8a5cab565e0ded8671c07726f35fea0299f94d69ea3e1cd6b46f762c6783b93c1a58fae7503
   languageName: node
   linkType: hard
 
@@ -12824,6 +12653,7 @@ fsevents@^1.2.7:
     chalk: ^4.0.0
     ci-info: ^3.2.0
     deepmerge: ^4.2.2
+    esbuild-register: ^3.0.0
     glob: ^7.1.1
     graceful-fs: ^4.2.4
     jest-circus: ^27.3.1
@@ -13784,6 +13614,13 @@ fsevents@^1.2.7:
   bin:
     json5: lib/cli.js
   checksum: 07b1f90c2801dc52df2b0ac8d606cc400a85cda79130e754780fa2ab9805d0fb85a0e61b6a5cdd68e88e5d0c8f9109ec415af08283175556cdccaa8563853908
+  languageName: node
+  linkType: hard
+
+"jsonc-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "jsonc-parser@npm:3.0.0"
+  checksum: 36b9080a7e25f5052c7d551109c4ead564f3102d7ca0c5ee4a2f7debc18b2cd31896e0e369cfd1442d9d2d71fc1defaf094ba885bc9b43a6a3f2b3a9083fd2cb
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12844,7 +12844,7 @@ fsevents@^1.2.7:
     ts-node: ^9.0.0
     typescript: ^4.0.3
   peerDependencies:
-    esbuild: "*"
+    esbuild: ">=0.13.12"
     ts-node: ">=9.0.0"
   peerDependenciesMeta:
     esbuild:

--- a/yarn.lock
+++ b/yarn.lock
@@ -12672,7 +12672,7 @@ fsevents@^1.2.7:
     ts-node: ^9.0.0
     typescript: ^4.0.3
   peerDependencies:
-    esbuild-register: ">=3.0.0"
+    esbuild-register: ">=3.1.0"
     ts-node: ">=9.0.0"
   peerDependenciesMeta:
     esbuild-register:

--- a/yarn.lock
+++ b/yarn.lock
@@ -1619,7 +1619,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/preset-env@npm:*, @babel/preset-env@npm:^7.1.0, @babel/preset-env@npm:^7.11.0, @babel/preset-env@npm:^7.12.1, @babel/preset-env@npm:^7.12.16":
+"@babel/preset-env@npm:*, @babel/preset-env@npm:^7.11.0, @babel/preset-env@npm:^7.12.1, @babel/preset-env@npm:^7.12.16":
   version: 7.15.6
   resolution: "@babel/preset-env@npm:7.15.6"
   dependencies:
@@ -2556,8 +2556,6 @@ __metadata:
   dependencies:
     "@babel/core": ^7.3.4
     "@babel/plugin-proposal-class-properties": ^7.3.4
-    "@babel/plugin-transform-modules-commonjs": ^7.1.0
-    "@babel/preset-env": ^7.1.0
     "@babel/preset-react": ^7.0.0
     "@babel/preset-typescript": ^7.0.0
     "@babel/register": ^7.0.0
@@ -2582,6 +2580,7 @@ __metadata:
     codecov: ^3.0.0
     debug: ^4.0.1
     dedent: ^0.7.0
+    esbuild-register: ^3.0.0
     eslint: ^7.7.0
     eslint-config-prettier: ^8.1.0
     eslint-plugin-eslint-comments: ^3.1.2
@@ -12653,7 +12652,6 @@ fsevents@^1.2.7:
     chalk: ^4.0.0
     ci-info: ^3.2.0
     deepmerge: ^4.2.2
-    esbuild-register: ^3.0.0
     glob: ^7.1.1
     graceful-fs: ^4.2.4
     jest-circus: ^27.3.1
@@ -12674,10 +12672,10 @@ fsevents@^1.2.7:
     ts-node: ^9.0.0
     typescript: ^4.0.3
   peerDependencies:
-    esbuild: ">=0.13.12"
+    esbuild-register: ">=3.0.0"
     ts-node: ">=9.0.0"
   peerDependenciesMeta:
-    esbuild:
+    esbuild-register:
       optional: true
     ts-node:
       optional: true


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
I was using Jest with a `jest.config.ts` config file written in TypeScript and I found it annoying that I had to make changes to my `tsconfig.json` file in order for it to work. This pull request adds a fallback option to `jest-config` where if `ts-node` isn't installed it will try to use `esbuild` instead. `esbuild` is faster, doesn't check types ( I found this annoying, Jest doesn't check the types of my tests, so why should it for my config? Let me check my own types please :) ), and supports importing other files in your config file ( not sure whether `ts-node` supported this ). 
## Test plan


I made the change, then ran these commands to verify things work:
```
npm run jest packages/jest-config // these tests pass
cd packages/jest-config
npm pack // gives a .tar.gz file
cd ~/Code ( whatever works for you )
gh repo clone jensmeindertsma/package-template
npm install --save-dev esbuild <FILE_URL_FROM_NPM_PACK>
npm uninstall ts-node

// Wipe lockfile so `ts-node` is properly removed
rm -rf node_modules package-lock.json
npm install

npm run test
```
The tests in my demo repository are passing, which means this change works! It successfully loaded the TS config file without `ts-node` installed.
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Oh yeah, this closes #11989 and #11453, although the latter one probably requires some docs updates.