### PR TITLE
feat(jest-worker): add gnumake jobclient to limit number of workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-worker]` add gnumake jobclient to limit number of workers ([#12968](https://github.com/facebook/jest/pull/12968))
+
 ### Fixes
 
 -`[jest-runtime]` Avoid star type import from `@jest/globals` ([#12949](https://github.com/facebook/jest/pull/12949))

--- a/packages/jest-worker/__tests__/jobclient/Makefile
+++ b/packages/jest-worker/__tests__/jobclient/Makefile
@@ -1,0 +1,2 @@
+all:
+	+node test.js

--- a/packages/jest-worker/__tests__/jobclient/test.js
+++ b/packages/jest-worker/__tests__/jobclient/test.js
@@ -1,0 +1,39 @@
+/*
+based on
+rollup-plugin-terser/rollup-plugin-terser.js
+in
+qtwebengine-everywhere-src-6.3.1/src/3rdparty/chromium/third_party/devtools-frontend/src/node_modules/
+*/
+
+//const Worker = require("jest-worker").default;
+const Worker = require("../../build/index.js").Worker;
+
+(async () => {
+
+const userOptions = {};
+
+//userOptions.numWorkers = 1; // debug. no parallel
+//userOptions.numWorkers = 2;
+
+const worker = new Worker(require.resolve("./worker.js"), {
+  numWorkers: userOptions.numWorkers,
+});
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+console.log('start jobs');
+var a = worker.transform("a");
+var b = worker.transform("b");
+var c = worker.transform("c");
+var d = worker.transform("d");
+
+console.log('');
+console.log('await jobs ...');
+await Promise.all([a, b, c, d]);
+
+console.log('stop workers');
+worker.end();
+
+console.log('done');
+
+})();

--- a/packages/jest-worker/__tests__/jobclient/test.sh
+++ b/packages/jest-worker/__tests__/jobclient/test.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+export DEBUG_JEST_WORKER=1
+export DEBUG_JOBCLIENT=1
+set -e
+cd "$(dirname "$0")"
+set -x
+
+make -j1 # 0 workers -> no jobserver
+
+make -j2 # 1 worker
+
+make -j3 # 2 workers
+
+make -j4 # 3 workers
+
+make -j4 -l4 # 3 workers + maxLoad 4
+
+echo all tests passed

--- a/packages/jest-worker/__tests__/jobclient/worker.js
+++ b/packages/jest-worker/__tests__/jobclient/worker.js
@@ -1,0 +1,13 @@
+/*
+/home/user/src/qtwebengine-everywhere-src-6.3.1/src/3rdparty/chromium/third_party/devtools-frontend/src/node_modules/rollup-plugin-terser/transform.js
+*/
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+const transform = async (code) => {
+  //console.log(`worker: starting transform of ${code}`); // not visible
+  await sleep(1000);
+  return `${code} ${code}`;
+};
+
+exports.transform = transform;

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jest-worker",
-  "version": "28.1.1",
+  "version": "28.2.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/facebook/jest.git",
@@ -22,6 +22,7 @@
     "supports-color": "^8.0.0"
   },
   "devDependencies": {
+    "@milahu/gnumake-jobclient": "^0.0.3",
     "@tsd/typescript": "~4.7.3",
     "@types/merge-stream": "^1.1.2",
     "@types/supports-color": "^8.1.0",

--- a/packages/jest-worker/src/WorkerPool.ts
+++ b/packages/jest-worker/src/WorkerPool.ts
@@ -6,6 +6,7 @@
  */
 
 import BaseWorkerPool from './base/BaseWorkerPool';
+import {debug} from './debug';
 import type {
   ChildMessage,
   OnCustomMessage,
@@ -23,11 +24,16 @@ class WorkerPool extends BaseWorkerPool implements WorkerPoolInterface {
     onStart: OnStart,
     onEnd: OnEnd,
     onCustomMessage: OnCustomMessage,
-  ): void {
-    this.getWorkerById(workerId).send(request, onStart, onEnd, onCustomMessage);
+  ): boolean {
+    const worker = this.getWorkerById(workerId);
+    debug(`WorkerPool.send: workerId=${workerId} worker=${worker}`)
+    if (worker == null) return false;
+    worker.send(request, onStart, onEnd, onCustomMessage);
+    return true;
   }
 
   override createWorker(workerOptions: WorkerOptions): WorkerInterface {
+    debug(`WorkerPool.createWorker`)
     let Worker;
     if (this._options.enableWorkerThreads) {
       Worker = require('./workers/NodeThreadsWorker').default;

--- a/packages/jest-worker/src/base/BaseWorkerPool.ts
+++ b/packages/jest-worker/src/base/BaseWorkerPool.ts
@@ -6,6 +6,13 @@
  */
 
 import mergeStream = require('merge-stream');
+import {debug} from '../debug';
+
+//import type {MergedStream} from '@types/merge-stream'; // requires esModuleInterop
+interface MergedStream extends NodeJS.ReadWriteStream {
+    add(source: NodeJS.ReadableStream | ReadonlyArray<NodeJS.ReadableStream>): MergedStream;
+    isEmpty(): boolean;
+}
 import {
   CHILD_MESSAGE_END,
   PoolExitResult,
@@ -23,47 +30,85 @@ const FORCE_EXIT_DELAY = 500;
 const emptyMethod = () => {};
 
 export default class BaseWorkerPool {
-  private readonly _stderr: NodeJS.ReadableStream;
-  private readonly _stdout: NodeJS.ReadableStream;
+  private readonly _stderr: MergedStream;
+  private readonly _stdout: MergedStream;
   protected readonly _options: WorkerPoolOptions;
+  protected readonly _workerPath: string;
   private readonly _workers: Array<WorkerInterface>;
+  private readonly _workerTokens: Array<number | undefined>;
 
   constructor(workerPath: string, options: WorkerPoolOptions) {
+    this._workerPath = workerPath;
     this._options = options;
-    this._workers = new Array(options.numWorkers);
 
-    const stdout = mergeStream();
-    const stderr = mergeStream();
+    this._stdout = mergeStream();
+    this._stderr = mergeStream();
 
-    const {forkOptions, maxRetries, resourceLimits, setupArgs} = options;
-
-    for (let i = 0; i < options.numWorkers; i++) {
-      const workerOptions: WorkerOptions = {
-        forkOptions,
-        maxRetries,
-        resourceLimits,
-        setupArgs,
-        workerId: i,
-        workerPath,
-      };
-
-      const worker = this.createWorker(workerOptions);
-      const workerStdout = worker.getStdout();
-      const workerStderr = worker.getStderr();
-
-      if (workerStdout) {
-        stdout.add(workerStdout);
-      }
-
-      if (workerStderr) {
-        stderr.add(workerStderr);
-      }
-
-      this._workers[i] = worker;
+    if (options.jobClient) {
+      // with jobClient, override numWorkers
+      // NOTE maxJobs is upper bound. minJobs is 1
+      options.numWorkers = options.jobClient.maxJobs;
     }
 
-    this._stdout = stdout;
-    this._stderr = stderr;
+    this._workers = new Array(options.numWorkers);
+    this._workerTokens = new Array(options.numWorkers);
+
+    if (options.jobClient) {
+      // start 1 worker, grow on demand
+      this._addWorker(0, true);
+    }
+    else {
+      debug(`BaseWorkerPool.constructor: no jobClient -> start all workers before demand`)
+      // no jobclient -> numWorkers is static
+      // start all workers before demand
+      for (let i = 0; i < options.numWorkers; i++) {
+        this._addWorker(i);
+      }
+    }
+  }
+
+  _addWorker(workerId: number, ignoreJobClient = false): WorkerInterface | null {
+    debug(`BaseWorkerPool._addWorker`)
+    // ignoreJobClient is true for the first worker with jobclient
+
+    if (this._workers[workerId]) return this._workers[workerId];
+
+    if (this._options.jobClient && !ignoreJobClient) {
+      const numWorkers = this._workers.filter(Boolean).length;
+      if (numWorkers > 0) {
+        const token = this._options.jobClient.acquire();
+        if (token == null) {
+          return null; // jobserver is full, try again later
+        }
+        this._workerTokens[workerId] = token;
+      }
+      // else: dont acquire token for the first worker
+    }
+
+    const {forkOptions, maxRetries, resourceLimits, setupArgs} = this._options;
+    const workerOptions: WorkerOptions = {
+      forkOptions,
+      maxRetries,
+      resourceLimits,
+      setupArgs,
+      workerId,
+      workerPath: this._workerPath,
+    };
+
+    const worker = this.createWorker(workerOptions);
+    const workerStdout = worker.getStdout();
+    const workerStderr = worker.getStderr();
+
+    if (workerStdout) {
+      this._stdout.add(workerStdout);
+    }
+
+    if (workerStderr) {
+      this._stderr.add(workerStderr);
+    }
+
+    this._workers[workerId] = worker;
+    return worker;
   }
 
   getStderr(): NodeJS.ReadableStream {
@@ -78,7 +123,12 @@ export default class BaseWorkerPool {
     return this._workers;
   }
 
-  getWorkerById(workerId: number): WorkerInterface {
+  getWorkerById(workerId: number): WorkerInterface | null {
+    if (this._options.jobClient && this._workers[workerId] == undefined) {
+      // try to create new worker
+      debug(`BaseWorkerPool.getWorkerById: create worker ${workerId}`);
+      return this._addWorker(workerId);
+    }
     return this._workers[workerId];
   }
 
@@ -89,7 +139,8 @@ export default class BaseWorkerPool {
   async end(): Promise<PoolExitResult> {
     // We do not cache the request object here. If so, it would only be only
     // processed by one of the workers, and we want them all to close.
-    const workerExitPromises = this._workers.map(async worker => {
+    const workerExitPromises = this._workers.map(async (worker, workerId) => {
+      if (!worker) return false;
       worker.send(
         [CHILD_MESSAGE_END, false],
         emptyMethod,
@@ -108,6 +159,14 @@ export default class BaseWorkerPool {
       await worker.waitForExit();
       // Worker ideally exited gracefully, don't send force exit then
       clearTimeout(forceExitTimeout);
+
+      if (this._options.jobClient) {
+        const token = this._workerTokens[workerId];
+        if (token != undefined) {
+          this._options.jobClient.release(token);
+          this._workerTokens[workerId] = undefined;
+        }
+      }
 
       return forceExited;
     });

--- a/packages/jest-worker/src/debug.ts
+++ b/packages/jest-worker/src/debug.ts
@@ -1,0 +1,5 @@
+import * as process from 'process';
+
+export const debug = process.env.DEBUG_JEST_WORKER
+  ? (msg: string) => console.log(`jest-worker: ${msg}`)
+  : (_msg: string) => {};

--- a/packages/jest-worker/src/index.ts
+++ b/packages/jest-worker/src/index.ts
@@ -9,6 +9,8 @@ import {cpus} from 'os';
 import {isAbsolute} from 'path';
 import Farm from './Farm';
 import WorkerPool from './WorkerPool';
+import {JobClient} from '@milahu/gnumake-jobclient';
+import {debug} from './debug';
 import type {
   PoolExitResult,
   WorkerFarmOptions,
@@ -93,6 +95,8 @@ export class Worker {
       throw new Error(`'workerPath' must be absolute, got '${workerPath}'`);
     }
 
+    debug(`Worker.constructor: this._options.jobClient = ${this._options.jobClient}`);
+
     const workerPoolOptions: WorkerPoolOptions = {
       enableWorkerThreads: this._options.enableWorkerThreads ?? false,
       forkOptions: this._options.forkOptions ?? {},
@@ -100,7 +104,10 @@ export class Worker {
       numWorkers: this._options.numWorkers ?? Math.max(cpus().length - 1, 1),
       resourceLimits: this._options.resourceLimits ?? {},
       setupArgs: this._options.setupArgs ?? [],
+      jobClient: this._options.jobClient ?? JobClient(),
     };
+
+    debug(`Worker.constructor: workerPoolOptions.jobClient = ${workerPoolOptions.jobClient}`);
 
     if (this._options.WorkerPool) {
       this._workerPool = new this._options.WorkerPool(

--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -8,6 +8,7 @@
 import type {ForkOptions} from 'child_process';
 import type {EventEmitter} from 'events';
 import type {ResourceLimits} from 'worker_threads';
+import type {JobClient} from '@milahu/gnumake-jobclient';
 
 type ReservedKeys = 'end' | 'getStderr' | 'getStdout' | 'setup' | 'teardown';
 type ExcludeReservedKeys<K> = Exclude<K, ReservedKeys>;
@@ -52,7 +53,7 @@ export type WorkerCallback = (
   onStart: OnStart,
   onEnd: OnEnd,
   onCustomMessage: OnCustomMessage,
-) => void;
+) => boolean;
 
 export interface WorkerPoolInterface {
   getStderr(): NodeJS.ReadableStream;
@@ -122,6 +123,7 @@ export type WorkerFarmOptions = {
     options?: WorkerPoolOptions,
   ) => WorkerPoolInterface;
   workerSchedulingPolicy?: WorkerSchedulingPolicy;
+  jobClient?: JobClient | null;
 };
 
 export type WorkerPoolOptions = {
@@ -131,6 +133,7 @@ export type WorkerPoolOptions = {
   maxRetries: number;
   numWorkers: number;
   enableWorkerThreads: boolean;
+  jobClient: JobClient | null;
 };
 
 export type WorkerOptions = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3875,6 +3875,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@milahu/gnumake-jobclient@npm:^0.0.3":
+  version: 0.0.3
+  resolution: "@milahu/gnumake-jobclient@npm:0.0.3"
+  checksum: d79e749694ed089dc246ab286b30144f0506b9c615ba0f577dfb09afe427e0f3e598b687743f04b302c60134ae6fcfd178b090f2257610b690c392619c518ea7
+  languageName: node
+  linkType: hard
+
 "@nodelib/fs.scandir@npm:2.1.5":
   version: 2.1.5
   resolution: "@nodelib/fs.scandir@npm:2.1.5"
@@ -13840,6 +13847,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-worker@workspace:packages/jest-worker"
   dependencies:
+    "@milahu/gnumake-jobclient": ^0.0.3
     "@tsd/typescript": ~4.7.3
     "@types/merge-stream": ^1.1.2
     "@types/node": "*"


### PR DESCRIPTION
## Summary

limit jobs when jest-worker is running under make / cmake / ninja

## Details

use case: chromium or qtwebengine
call stack: devtools-frontend -> rollup -> terser -> jest-worker

by default, jest-worker spawns $nproc workers (100 workers on a 100 core machine)
even if jobs are limited with `make -j10 -l10`

this overload causes trouble on build servers -> downstream issue https://github.com/NixOS/nixpkgs/pull/178171

based on my [gnumake-tokenpool](https://github.com/milahu/gnumake-tokenpool)

needs some polish -> draft PR

## Versions

* jest-worker@28.1.1 [source](https://github.com/milahu/jest/tree/add-gnumake-jobclient) and [compiled](https://github.com/milahu/jest-worker) (outdated, needs [bugfix](https://github.com/milahu/gnumake-tokenpool/commit/247c42b6ac517c3e4b45de0af22d57ad45ec44a7))
* jest-worker@26.6.2 [source](https://github.com/milahu/jest/tree/add-gnumake-jobclient-backport-jest-worker-26.6.2) and [compiled](https://github.com/milahu/jest-worker/tree/26.6.2)

## Test plan

manual test in `packages/jest-worker/tests/jobserver/test.sh`
todo: integrate with automatic tests
the test requires gnumake to run

synthetic test is passing

i have [integrated this change into chromium](https://github.com/milahu/nixpkgs/tree/qt6-631-debug-qtwebengine), now the job count is limited by [ninja](https://github.com/ninja-build/ninja/issues/1139#issuecomment-461750356)

## API change

i had to change some internal APIs between Farm and WorkerPool (bump major version?)
i hope noone depends on the old APIs ...
if needed, this can be made backward compatible

## debug prints

for production builds, the debug prints could be removed by typescript
