### PR TITLE
Support for using native Node ESM loader

### DIFF
--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -19,7 +19,10 @@ import {
 } from '@jest/console';
 import type {JestEnvironment} from '@jest/environment';
 import type {TestFileEvent, TestResult} from '@jest/test-result';
-import {createScriptTransformer} from '@jest/transform';
+import {
+  createNodeEsmLoaderTransformer,
+  createScriptTransformer,
+} from '@jest/transform';
 import type {Config} from '@jest/types';
 import * as docblock from 'jest-docblock';
 import LeakDetector from 'jest-leak-detector';
@@ -104,7 +107,9 @@ async function runTestInternal(
   }
 
   const cacheFS = new Map([[path, testSource]]);
-  const transformer = await createScriptTransformer(projectConfig, cacheFS);
+  const transformer =
+    (await createNodeEsmLoaderTransformer()) ??
+    (await createScriptTransformer(projectConfig, cacheFS));
 
   const TestEnvironment: typeof JestEnvironment =
     await transformer.requireAndTranspileModule(testEnvironment);

--- a/packages/jest-transform/src/NodeEsmLoaderTransformer.ts
+++ b/packages/jest-transform/src/NodeEsmLoaderTransformer.ts
@@ -30,7 +30,7 @@ interface NodeEsmLoader {
 }
 
 const reLoader =
-  /--loader\s+((@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*)/;
+  /--loader\s+((@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*(\/\S+)?)/;
 
 class NodeEsmLoaderTransformer implements ScriptTransformer {
   private readonly _loader: NodeEsmLoader;

--- a/packages/jest-transform/src/NodeEsmLoaderTransformer.ts
+++ b/packages/jest-transform/src/NodeEsmLoaderTransformer.ts
@@ -1,0 +1,128 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {pathToFileURL} from 'url';
+import {requireOrImportModule} from 'jest-util';
+import type {
+  Options,
+  ReducedTransformOptions,
+  RequireAndTranspileModuleOptions,
+} from './types';
+import type {ScriptTransformer, TransformResult} from '.';
+
+// https://nodejs.org/api/esm.html#loadurl-context-nextload
+interface NodeEsmLoader {
+  load(
+    url: string,
+    context: {
+      format: string;
+      importAssertions: Record<string, string>;
+    },
+    defaultLoad: NodeEsmLoader['load'],
+  ): Promise<{
+    format: string;
+    source: string | ArrayBuffer | SharedArrayBuffer | Uint8Array;
+  }>;
+}
+
+const reLoader =
+  /--loader\s+((@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*)/;
+
+class NodeEsmLoaderTransformer implements ScriptTransformer {
+  private readonly _loader: NodeEsmLoader;
+
+  constructor(loader: NodeEsmLoader) {
+    this._loader = loader;
+  }
+
+  transformSource(
+    _: string,
+    __: string,
+    ___: ReducedTransformOptions,
+  ): TransformResult {
+    throw new Error(
+      'Synchrnous transforms are not supported when using --loader',
+    );
+  }
+
+  async transformSourceAsync(
+    _: string,
+    __: string,
+    ___: ReducedTransformOptions,
+  ): Promise<TransformResult> {
+    return Promise.reject(
+      new Error(
+        '`transformSourceAsync` should not be called when using --loader',
+      ),
+    );
+  }
+
+  transform(_: string, __: Options, ___?: string): TransformResult {
+    throw new Error(
+      'Synchrnous transforms are not supported when using --loader',
+    );
+  }
+
+  transformJson(_: string, __: any, fileSource: string): string {
+    return fileSource;
+  }
+
+  async transformAsync(
+    filename: string,
+    _: unknown,
+    fileSource: string,
+  ): Promise<TransformResult> {
+    const url = pathToFileURL(filename).href;
+
+    const result = await this._loader.load(
+      url,
+      {format: 'module', importAssertions: {}},
+      async () => {
+        return Promise.resolve({format: 'module', source: fileSource});
+      },
+    );
+
+    return {
+      code:
+        typeof result.source === 'string'
+          ? result.source
+          : new TextDecoder().decode(result.source),
+      originalCode: fileSource,
+      sourceMapPath: null,
+    };
+  }
+
+  async requireAndTranspileModule<ModuleType = unknown>(
+    moduleName: string,
+    callback?: (module: ModuleType) => void | Promise<void>,
+    options?: RequireAndTranspileModuleOptions,
+  ): Promise<ModuleType> {
+    if (callback) {
+      throw new Error(
+        '`requireAndTranspileModule` with a callback should not be called when using --loader',
+      );
+    }
+
+    if (options) {
+      throw new Error(
+        '`requireAndTranspileModule` with options should not be called when using --loader',
+      );
+    }
+
+    return requireOrImportModule(moduleName);
+  }
+}
+
+export async function createNodeEsmLoaderTransformer(): Promise<ScriptTransformer | null> {
+  const match = reLoader.exec(process.env.NODE_OPTIONS ?? '');
+  if (match == null) return null;
+
+  const loaderName = match[1];
+  const loader = (await import(loaderName)) as NodeEsmLoader;
+
+  return new NodeEsmLoaderTransformer(loader);
+}

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -1051,7 +1051,14 @@ function assertSyncTransformer(
   );
 }
 
-export type TransformerType = ScriptTransformer;
+export interface TransformerType {
+  requireAndTranspileModule: ScriptTransformer['requireAndTranspileModule'];
+  transform: ScriptTransformer['transform'];
+  transformAsync: ScriptTransformer['transformAsync'];
+  transformJson: ScriptTransformer['transformJson'];
+  transformSource: ScriptTransformer['transformSource'];
+  transformSourceAsync: ScriptTransformer['transformSourceAsync'];
+}
 
 export async function createScriptTransformer(
   config: Config.ProjectConfig,

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -2066,7 +2066,9 @@ describe('ScriptTransformer', () => {
     });
 
     // @ts-expect-error - private property
-    expect(Array.from(scriptTransformer._transformCache.entries())).toEqual([
+    const cache = scriptTransformer._transformCache as Map<unknown, unknown>;
+
+    expect(Array.from(cache.entries())).toEqual([
       ['\\.js$test_preprocessor', expect.any(Object)],
     ]);
   });

--- a/packages/jest-transform/src/index.ts
+++ b/packages/jest-transform/src/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+export {createNodeEsmLoaderTransformer} from './NodeEsmLoaderTransformer';
 export {
   createScriptTransformer,
   createTranspilingRequire,


### PR DESCRIPTION
## Summary

As previously discussed in #13143, this PR shows roughly what changes would be needed in order to support Node.js `--loader`. I'm opening this as a draft PR since I would need guidance on where the code should live, how the code should be activated by the user, and how to create tests for it.

ping @SimenB 

I would be very happy to receive any feedback, or to discuss how this could/should work!

## Test plan

I've tested this by running `yarn build` and manually coping the changed files into another small test project 🙈 

**`package.json`**

```json
{
  "type": "module",
  "dependencies": {
    "@esbuild-kit/esm-loader": "^2.5.0",
    "jest": "^29.2.2"
  },
  "jest": {
    "extensionsToTreatAsEsm": [
      ".ts"
    ]
  }
}
```

**`foobar.test.ts`**

```ts
test('it works', (): void => {
  expect(1).toBe(1)
})
```

```
cp ~/coding/jest/packages/jest-worker/build/workers/ChildProcessWorker.js node_modules/jest-worker/build/workers/ChildProcessWorker.js
cp ~/coding/jest/packages/jest-transform/build/NodeEsmLoaderTransformer.js node_modules/@jest/transform/build/NodeEsmLoaderTransformer.js
cp ~/coding/jest/packages/jest-transform/build/index.js node_modules/@jest/transform/build/index.js
cp ~/coding/jest/packages/jest-runner/build/runTest.js node_modules/jest-runner/build/runTest.js
```

> `NODE_OPTIONS='--experimental-vm-modules --loader @esbuild-kit/esm-loader' jest`

<img width="875" alt="Screenshot 2022-10-27 at 01 00 00" src="https://user-images.githubusercontent.com/189580/198154467-ce317e20-abb2-471b-bbed-9bb4c4e1eca2.png">

I have currently only tested this with `@esbuild-kit/esm-loader`, but the goal is that it should work with any `--loader`