### PR TITLE
Add a waitBeforeRetry option to jest.retryTimes

### DIFF
--- a/packages/jest-circus/src/types.ts
+++ b/packages/jest-circus/src/types.ts
@@ -9,6 +9,7 @@ import type {Circus} from '@jest/types';
 
 export const STATE_SYM = Symbol('JEST_STATE_SYMBOL');
 export const RETRY_TIMES = Symbol.for('RETRY_TIMES');
+export const WAIT_BEFORE_RETRY = Symbol.for('WAIT_BEFORE_RETRY')
 // To pass this value from Runtime object to state we need to use global[sym]
 export const TEST_TIMEOUT_SYMBOL = Symbol.for('TEST_TIMEOUT_SYMBOL');
 export const LOG_ERRORS_BEFORE_RETRY = Symbol.for('LOG_ERRORS_BEFORE_RETRY');
@@ -19,6 +20,7 @@ declare global {
     interface Global {
       [STATE_SYM]: Circus.State;
       [RETRY_TIMES]: string;
+      [WAIT_BEFORE_RETRY]: string;
       [TEST_TIMEOUT_SYMBOL]: number;
       [LOG_ERRORS_BEFORE_RETRY]: boolean;
     }

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -117,6 +117,7 @@ type ResolveOptions = Parameters<typeof require.resolve>[1] & {
 
 const testTimeoutSymbol = Symbol.for('TEST_TIMEOUT_SYMBOL');
 const retryTimesSymbol = Symbol.for('RETRY_TIMES');
+const waitBeforeRetrySymbol = Symbol.for('WAIT_BEFORE_RETRY')
 const logErrorsBeforeRetrySymbol = Symbol.for('LOG_ERRORS_BEFORE_RETRY');
 
 const NODE_MODULES = `${path.sep}node_modules${path.sep}`;
@@ -2180,6 +2181,7 @@ export default class Runtime {
       this._environment.global[retryTimesSymbol] = numTestRetries;
       this._environment.global[logErrorsBeforeRetrySymbol] =
         options?.logErrorsBeforeRetry;
+      this._environment.global[waitBeforeRetrySymbol] = options?.waitBeforeRetry
 
       return jestObject;
     };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

- This PR aims to solve [13659](https://github.com/facebook/jest/issues/13659).
- It adds the support for waiting for a certain amount of time before trying to run the test again when we use `jest.retryTimes`

## Test plan

- [ ] Add Tests to cover waitBeforeRetry options
