### PR TITLE
fix(website): Add guide how to avoid temporal dead zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[jest-resolve]` add global paths to `require.resolve.paths` ([#13633](https://github.com/facebook/jest/pull/13633))
+- `[website]` add guide how to avoid temporal dead zone with manual mock ([#13691](https://github.com/facebook/jest/pull/13691))
 
 ### Chore & Maintenance
 

--- a/website/versioned_docs/version-29.3/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.3/Es6ClassMocks.md
@@ -220,7 +220,7 @@ jest.mock('./sound-player', () => {
   mockPlaySoundFile = jest.fn();
 
   return jest.fn().mockImplementation(() => {
-      return {playSoundFile: mockPlaySoundFile};
+    return {playSoundFile: mockPlaySoundFile};
   })
 });
 ```

--- a/website/versioned_docs/version-29.3/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.3/Es6ClassMocks.md
@@ -180,7 +180,7 @@ jest.mock('./sound-player', () => {
 
 When mocking classes or objects which are initialized during static
 initialization, solution provided in [Calling `jest.mock()` with the module factory parameter​](#calling-jestmock-with-the-module-factory-parameter)
-may not work due to hoisting, temporal dead zone - a need for variable
+may not work due to hoisting and *temporal dead zone* - a need for variable
 to be initialized before it is used.
 
 Consider slightly changed file `sound-player-consumer.js`. Now `SoundPlayer` is a singleton initialized at the very beginning:
@@ -198,8 +198,8 @@ export default class SoundPlayerConsumer {
 }
 ```
 
-This code will produce error, because Jest mocking will be hoisted 
-before following statement.
+This code will produce error, because `jest.mock('./sound-player', /*...*/)`
+is hoisted before following statement:
 ```javascript
 const mockSoundPlayer = jest.fn().mockImplementation(() => {
   return {playSoundFile: mockPlaySoundFile};
@@ -209,7 +209,7 @@ const mockSoundPlayer = jest.fn().mockImplementation(() => {
 In order to fix mocking two things have to be done:
 1. Avoid [Temporal Dead Zone](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/let#temporal_dead_zone_tdz)
 trap by replacing `const` or `let` with **`var`**.
-2. Assign mock, when it's used in module mocking block.
+2. Assign mocks when are going to be used, in module mocking block.
 
 ```javascript
 // `var` is hoisted by specification
@@ -221,7 +221,7 @@ jest.mock('./sound-player', () => {
 
   return jest.fn().mockImplementation(() => {
       return {playSoundFile: mockPlaySoundFile};
-    })
+  })
 });
 ```
 

--- a/website/versioned_docs/version-29.3/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.3/Es6ClassMocks.md
@@ -183,7 +183,7 @@ initialization, solution provided in [Calling `jest.mock()` with the module fact
 may not work due to hoisting and *temporal dead zone* - a need for variable
 to be initialized before it is used.
 
-Consider slightly changed file `sound-player-consumer.js`. Now `SoundPlayer` is a singleton initialized at the very beginning:
+Consider slightly changed file `sound-player-consumer.js`. Now `soundPlayer` is initialized at the very beginning:
 
 ```javascript
 import SoundPlayer from './sound-player'


### PR DESCRIPTION
## Summary

Update to website `Es6ClassMocks.md` with guide how to avoid temporal dead zone. This concern
happens from time and for me (and my partner) it was hard to solve it. Recently I've found
solution to it, and I think it could be useful to share it with others.

**Note:** for now this update is done only for recent version of documentation, as waiting for initial feedback from
maintainer.

## Test plan

Site built locally.

Review documentation changes.