### PR TITLE
Draft: feat(babel-plugin-jest-hoist): Transformations for ES modules static import statements

### DIFF
--- a/e2e/native-esm-static/__test__/native-esm-static-imports.test.mjs
+++ b/e2e/native-esm-static/__test__/native-esm-static-imports.test.mjs
@@ -1,0 +1,40 @@
+import {Buffer} from 'buffer';
+import * as fs from 'fs/promises';
+import {jest} from '@jest/globals';
+import inc from '../../native-esm/stateful.mjs';
+import DefaultCalculator, * as calc from '../static-import';
+import {NegativeCalculator} from '../static-import';
+
+// eslint-disable-next-line no-var
+var mockInc;
+const mockSampleData = new Buffer('test-content');
+
+jest.unstable_mockModule('../../native-esm/stateful.mjs', () => {
+  mockInc = jest.fn().mockImplementation(() => {
+    return 100;
+  });
+
+  return {
+    default: mockInc,
+  };
+});
+
+jest.unstable_mockModule('fs/promises', () => {
+  return {
+    readFile: jest.fn().mockImplementation(() => mockSampleData),
+  };
+});
+
+it('mocks to be called', () => {
+  expect(new DefaultCalculator().inc()).toBe(100);
+  expect(inc).toHaveBeenCalled();
+  expect(new NegativeCalculator().dec()).toBe(-100);
+  expect(inc).toHaveBeenCalledTimes(2);
+  expect(new calc.NegativeCalculator().dec()).toBe(-100);
+  expect(inc).toHaveBeenCalledTimes(3);
+});
+
+it('system module mocked', async () => {
+  const buffer = await fs.readFile('test-file');
+  expect(buffer.toString()).toBe('test-content');
+});

--- a/e2e/native-esm-static/package.json
+++ b/e2e/native-esm-static/package.json
@@ -1,0 +1,14 @@
+{
+  "type": "module",
+  "devDependencies": {
+    "discord.js": "14.3.0",
+    "yargs": "^17.5.1"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/__tests__/**/*.(m)[jt]s?(x)",
+      "**/?(*.)+(spec|test).(m)?[tj]s?(x)"
+    ]
+  }
+}

--- a/e2e/native-esm-static/package.json
+++ b/e2e/native-esm-static/package.json
@@ -6,6 +6,9 @@
   },
   "jest": {
     "testEnvironment": "node",
+    "transform": {
+      "\\.m?[jt]sx?$": "babel-jest"
+    },
     "testMatch": [
       "**/__tests__/**/*.(m)[jt]s?(x)",
       "**/?(*.)+(spec|test).(m)?[tj]s?(x)"

--- a/e2e/native-esm-static/static-import.js
+++ b/e2e/native-esm-static/static-import.js
@@ -1,0 +1,13 @@
+import inc from '../native-esm/stateful.mjs';
+
+export default class DefaultCalculator {
+  inc() {
+    return inc();
+  }
+}
+
+export class NegativeCalculator {
+  dec() {
+    return -inc();
+  }
+}

--- a/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
@@ -168,6 +168,32 @@ jest.mock('some-module', () => {
 
 `;
 
+exports[`babel-plugin-jest-hoist static imports converted to dynamic await imports: static imports converted to dynamic await imports 1`] = `
+
+import SoundPlayer, {SoundPlayerHelper as Helper} from './some-module';
+import SoundPlayerConsumer, * as spc from './sound-player-consumer';
+jest.unstable_mockModule('some-module', () => {
+  return jest.fn();
+});
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().unstable_mockModule('some-module', () => {
+  return jest.fn();
+});
+const {default: SoundPlayer, SoundPlayerHelper: Helper} = await import(
+  './some-module'
+);
+const {default: SoundPlayerConsumer} = await import('./sound-player-consumer'),
+  spc = await import('./sound-player-consumer');
+import {jest as _jest_import_alias} from '@jest/globals';
+function _getJestObj() {
+  return _jest_import_alias;
+}
+
+
+`;
+
 exports[`babel-plugin-jest-hoist top level mocking: top level mocking 1`] = `
 
 require('x');

--- a/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
@@ -48,12 +48,12 @@ _getJestObj().mock(
       this,
     ),
 );
-import {jsxDEV as _jsxDEV} from 'react/jsx-dev-runtime';
 function _getJestObj() {
   const {jest} = require('@jest/globals');
   _getJestObj = () => jest;
   return jest;
 }
+import {jsxDEV as _jsxDEV} from 'react/jsx-dev-runtime';
 
 
 `;

--- a/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.test.ts
@@ -151,6 +151,20 @@ pluginTester({
       formatResult,
       snapshot: true,
     },
+    'static imports converted to dynamic await imports': {
+      babelOptions: {
+        filename: path.resolve(__dirname, '../file.mjs'),
+      },
+      code: formatResult(`
+      import SoundPlayer, {SoundPlayerHelper as Helper} from './some-module';
+      import SoundPlayerConsumer, * as spc from './sound-player-consumer';
+      jest.unstable_mockModule('some-module', () => {
+        return jest.fn();
+      });
+      `),
+      formatResult,
+      snapshot: true,
+    },
   },
   /* eslint-enable */
 });

--- a/packages/jest-config/src/constants.ts
+++ b/packages/jest-config/src/constants.ts
@@ -8,7 +8,7 @@
 import * as path from 'path';
 
 export const NODE_MODULES = `${path.sep}node_modules${path.sep}`;
-export const DEFAULT_JS_PATTERN = '\\.m?[jt]sx?$';
+export const DEFAULT_JS_PATTERN = '\\.[jt]sx?$';
 export const PACKAGE_JSON = 'package.json';
 export const JEST_CONFIG_BASE_NAME = 'jest.config';
 export const JEST_CONFIG_EXT_CJS = '.cjs';

--- a/packages/jest-config/src/constants.ts
+++ b/packages/jest-config/src/constants.ts
@@ -8,7 +8,7 @@
 import * as path from 'path';
 
 export const NODE_MODULES = `${path.sep}node_modules${path.sep}`;
-export const DEFAULT_JS_PATTERN = '\\.[jt]sx?$';
+export const DEFAULT_JS_PATTERN = '\\.m?[jt]sx?$';
 export const PACKAGE_JSON = 'package.json';
 export const JEST_CONFIG_BASE_NAME = 'jest.config';
 export const JEST_CONFIG_EXT_CJS = '.cjs';


### PR DESCRIPTION
# Summary
This change introduces transformations which transforms static imports to dynamic, await imports and hoist this calls,
so EcmaScript modules can be used more freely in more natural way like it's with CJS modules (see e2e test file `native-esm-static-imports.test.mjs`).

Changes has been tested in Node 19.x.

This transformation mainly transforms
```
import {default as SoundPlayer, SoundPlayerHelper as Helper} from './some-module';
```
into something like
```
const {default: SoundPlayer, SoundPlayerHelper: Helper} = await import('./some-module');
```

and hoist this calls.

TODO: Please remember to update CHANGELOG.md at the root of the project if you have not done so.

# Test plan

Added integration and unit tests, tested runs on Node 19.x.
