### PR TITLE
Chore:-(Jest-types)-Added strict type for option extension toTreatAsEsm

### DIFF
--- a/packages/jest-types/__typetests__/config.test.ts
+++ b/packages/jest-types/__typetests__/config.test.ts
@@ -123,19 +123,17 @@ expectAssignable<Config.InitialOptions>({
 });
 
 expectError<Config.InitialOptions>({
-  extensionsToTreatAsEsm'.ts',
+  extensionsToTreatAsEsm: '.ts',
 });
 
 expectError<Config.InitialOptions>({
-  extensionsToTreatAsEsm: ['.js'], 
+  extensionsToTreatAsEsm: ['.js'],
 });
 
-
 expectError<Config.InitialOptions>({
-  extensionsToTreatAsEsm: ['.cjs'], 
+  extensionsToTreatAsEsm: ['.cjs'],
 });
 
-
 expectError<Config.InitialOptions>({
-  extensionsToTreatAsEsm: ['.mjs'], 
+  extensionsToTreatAsEsm: ['.mjs'],
 });

--- a/packages/jest-types/__typetests__/config.test.ts
+++ b/packages/jest-types/__typetests__/config.test.ts
@@ -117,3 +117,25 @@ expectError<Config.InitialOptions>({
     timerLimit: 1000,
   },
 });
+
+expectAssignable<Config.InitialOptions>({
+  extensionsToTreatAsEsm: ['.ts'],
+});
+
+expectError<Config.InitialOptions>({
+  extensionsToTreatAsEsm'.ts',
+});
+
+expectError<Config.InitialOptions>({
+  extensionsToTreatAsEsm: ['.js'], 
+});
+
+
+expectError<Config.InitialOptions>({
+  extensionsToTreatAsEsm: ['.cjs'], 
+});
+
+
+expectError<Config.InitialOptions>({
+  extensionsToTreatAsEsm: ['.mjs'], 
+});

--- a/packages/jest-types/__typetests__/config.test.ts
+++ b/packages/jest-types/__typetests__/config.test.ts
@@ -127,13 +127,13 @@ expectError<Config.InitialOptions>({
 });
 
 expectError<Config.InitialOptions>({
-  extensionsToTreatAsEsm: ['.js'],
+  extensionsToTreatAsEsm: '.js',
 });
 
 expectError<Config.InitialOptions>({
-  extensionsToTreatAsEsm: ['.cjs'],
+  extensionsToTreatAsEsm: '.cjs',
 });
 
 expectError<Config.InitialOptions>({
-  extensionsToTreatAsEsm: ['.mjs'],
+  extensionsToTreatAsEsm: '.mjs',
 });

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -126,6 +126,8 @@ export type HasteConfig = {
   retainAllFiles?: boolean;
 };
 
+export type ExtToTreatAsESM = Exclude<string, '.js' | '.cjs' | '.mjs'>;
+
 export type CoverageReporterName = keyof ReportOptions;
 
 export type CoverageReporterWithOptions<K = CoverageReporterName> =
@@ -162,7 +164,7 @@ export type DefaultOptions = {
   detectOpenHandles: boolean;
   errorOnDeprecated: boolean;
   expand: boolean;
-  extensionsToTreatAsEsm: Array<string>;
+  extensionsToTreatAsEsm: Array<ExtToTreatAsESM>;
   fakeTimers: FakeTimers;
   forceCoverageMatch: Array<string>;
   globals: ConfigGlobals;
@@ -242,7 +244,7 @@ export type InitialOptions = Partial<{
   detectOpenHandles: boolean;
   displayName: string | DisplayName;
   expand: boolean;
-  extensionsToTreatAsEsm: Array<string>;
+  extensionsToTreatAsEsm: Array<ExtToTreatAsESM>;
   fakeTimers: FakeTimers;
   filter: string;
   findRelatedTests: boolean;
@@ -433,7 +435,7 @@ export type ProjectConfig = {
   detectOpenHandles: boolean;
   displayName?: DisplayName;
   errorOnDeprecated: boolean;
-  extensionsToTreatAsEsm: Array<string>;
+  extensionsToTreatAsEsm: Array<ExtToTreatAsESM>;
   fakeTimers: FakeTimers;
   filter?: string;
   forceCoverageMatch: Array<string>;


### PR DESCRIPTION
Make extensionsToTreatAsEsm type stricter by excluding 3 error cases .js, .cjs and .mjs.