### PR TITLE
Use transpileOnly for ts-node register

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@
 
 ### Performance
 
+- `[jest-config]` Use `transpileOnly` option for `ts-node`
+
 ## 29.3.1
 
 ### Fixes

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -117,6 +117,7 @@ async function registerTsNode(): Promise<Service> {
       moduleTypes: {
         '**': 'cjs',
       },
+      transpileOnly: true,
     });
   } catch (e: any) {
     if (e.code === 'ERR_MODULE_NOT_FOUND') {


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This will skip running TypeScript type checks when loading config files,
and will just remove the TypeScript annotations so the code can be read
by node directly. This makes Jest startup much more efficient.

Documentation:

https://typestrong.org/ts-node/docs/options/#transpileonly

This could be made even faster by adding the following config, which
will use the much faster swc compiler to to the transpilation:

```
transpiler: 'ts-node/transpilers/swc-experimental'
```

However, that will require additional dependencies, so it should
probably be done on an opt-in basis via a new configuration field, and I
do not want to take that on at this time.

Fixes #11337

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I'm relying on CI to verify this change, please let me know if you would like me to be more thorough.
