### PR TITLE
add(snaplink): add customisation to snapshot reference link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## main
 
 ### Features
+- `[jest-snapshot]` Add `process.env.SNAPSHOT_GUIDE_LINK` to allow snapshot description URL to be customized ([#13821](https://github.com/facebook/jest/pull/13821))
 
 ### Fixes
 

--- a/packages/jest-snapshot/src/__tests__/utils.test.ts
+++ b/packages/jest-snapshot/src/__tests__/utils.test.ts
@@ -56,6 +56,22 @@ test('saveSnapshotFile() works with \r\n', () => {
   );
 });
 
+test('Uses SNAPSHOT_GUIDE_LINK environment', () => {
+  const filename = path.join(__dirname, 'remove-newlines.snap');
+  process.env.SNAPSHOT_GUIDE_LINK = '--- disabled ---';
+  const data = {
+    myKey: '',
+  };
+
+  saveSnapshotFile(data, filename);
+  expect(fs.writeFileSync).toHaveBeenCalledWith(
+    filename,
+    '// Jest Snapshot v1, --- disabled ---\n\nexports[`myKey`] = ``;\n',
+  );
+
+  delete process.env.SNAPSHOT_GUIDE_LINK;
+});
+
 test('saveSnapshotFile() works with \r', () => {
   const filename = path.join(__dirname, 'remove-newlines.snap');
   const data = {

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -27,7 +27,9 @@ export const SNAPSHOT_VERSION_WARNING = chalk.yellow(
 );
 
 const writeSnapshotVersion = () =>
-  `// Jest Snapshot v${SNAPSHOT_VERSION}, ${SNAPSHOT_GUIDE_LINK}`;
+  `// Jest Snapshot v${SNAPSHOT_VERSION}, ${
+    process.env.SNAPSHOT_GUIDE_LINK || SNAPSHOT_GUIDE_LINK
+  }`;
 
 const validateSnapshotVersion = (snapshotContents: string) => {
   const versionTest = SNAPSHOT_VERSION_REGEXP.exec(snapshotContents);


### PR DESCRIPTION
## Summary

Some snapshots I use require special descriptions and there are currently no way to change the description url

## Test plan
Ran all the tests and created a new one to check if the functionality works. And it does.
