### PR TITLE
docs: Added warning that Jest does not support ES6 modules

### DIFF
--- a/website/versioned_docs/version-29.4/MockFunctions.md
+++ b/website/versioned_docs/version-29.4/MockFunctions.md
@@ -145,6 +145,10 @@ Now, in order to test this method without actually hitting the API (and thus cre
 Once we mock the module we can provide a `mockResolvedValue` for `.get` that returns the data we want our test to assert against. In effect, we are saying that we want `axios.get('/users.json')` to return a fake response.
 
 ```js title="users.test.js"
+// this example can't be used purely,
+// because Jest doesn't support ES6 modules fully
+// To run this example, it needs additional configuration
+
 import axios from 'axios';
 import Users from './users';
 


### PR DESCRIPTION
Add warning for users who want to copy, paste and run this example with pure config without additional config: babel, ts-jest.

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Some users want to copy and paste this example for Jest out-of-the box. But Jest doesn't support ES6 modules, so this example needs additional config, otherwise we get an error "SyntaxError: Cannot use import statement outside a module"

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
