### PR TITLE
feat(jest-types): Allow fully typed expressions in .each tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[jest-message-util]` Add support for [error causes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause)
+- `[jest-types]` Allow fully typed expressions in `.each` tables ([#13897](https://github.com/facebook/jest/pull/13897))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Features
 
 - `[jest-message-util]` Add support for [error causes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause)
-- `[jest-types]` Allow fully typed expressions in `.each` tables ([#13897](https://github.com/facebook/jest/pull/13897))
+- `[@jest/types]` Allow fully typed expressions in `.each` tables ([#13897](https://github.com/facebook/jest/pull/13897))
 
 ### Fixes
 

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -1082,7 +1082,7 @@ test.each<{a: number; b: number; expected: string; extra?: boolean}>`
 
 Using a single generic argument sets the type for the test function argument, but it does not ensure that the values inside the table have the correct types. To do that, pass a tuple of Key-Type pairs and the number of rows as generic arguments instead:
 ```ts
-test.each<[['a', number], ['b', number], ['expected', string], ['extra', boolean|undefined]], 3>`
+test.each<[['a', number], ['b', number], ['expected', string], ['extra', boolean | undefined]], 3>`
   a    | b    | expected    | extra
   ${1} | ${2} | ${'three'}  | ${true}
   ${3} | ${4} | ${'seven'}  | ${false}

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -1079,3 +1079,15 @@ test.each<{a: number; b: number; expected: string; extra?: boolean}>`
   // without the generic argument in this case types would default to `unknown`
 });
 ```
+
+Using a single generic argument sets the type for the test function argument, but it does not ensure that the values inside the table have the correct types. To do that, pass a tuple of Key-Type pairs and the number of rows as generic arguments instead:
+```ts
+test.each<[['a', number], ['b', number], ['expected', string], ['extra', boolean|undefined]], 3>`
+  a    | b    | expected    | extra
+  ${1} | ${2} | ${'three'}  | ${true}
+  ${3} | ${4} | ${'seven'}  | ${false}
+  ${5} | ${6} | ${'eleven'} | ${undefined}
+`('template literal example', ({a, b, expected, extra}) => {
+  /* If the table does not contain the right amount of values, or if a value is not compatible with the provided type, a typescript error will be thrown. */
+});
+```

--- a/docs/GlobalAPI.md
+++ b/docs/GlobalAPI.md
@@ -1088,6 +1088,7 @@ test.each<[['a', number], ['b', number], ['expected', string], ['extra', boolean
   ${3} | ${4} | ${'seven'}  | ${false}
   ${5} | ${6} | ${'eleven'} | ${undefined}
 `('template literal example', ({a, b, expected, extra}) => {
-  /* If the table does not contain the right amount of values, or if a value is not compatible with the provided type, a typescript error will be thrown. */
+  // If the table does not contain the right amount of values, or if a value is
+  // not compatible with the provided type, a typescript error will be thrown.
 });
 ```

--- a/packages/jest-types/__typetests__/each.test.ts
+++ b/packages/jest-types/__typetests__/each.test.ts
@@ -252,6 +252,28 @@ expectType<void>(
     1000,
   ),
 );
+expectType<void>(
+  test.each<[['a', string], ['b', number], ['expected', boolean]], 2>`
+    a      | b    | expected
+    ${'1'} | ${1} | ${true}
+    ${'1'} | ${2} | ${false}
+  `(
+    'some test',
+    ({a, b, expected}) => {
+      expectType<string>(a);
+      expectType<number>(b);
+      expectType<boolean>(expected);
+    },
+    1000,
+  ),
+);
+
+expectError(
+  test.each<[['a', string]], 1>`
+    a
+    ${1}
+  `('some test', () => {}, 1000),
+);
 
 expectError(test.each());
 expectError(test.each('abc'));
@@ -426,6 +448,31 @@ expectType<void>(
     },
     1000,
   ),
+);
+expectType<void>(
+  test.concurrent.each<
+    [['a', string], ['b', number], ['expected', boolean]],
+    2
+  >`
+    a      | b    | expected
+    ${'1'} | ${1} | ${true}
+    ${'1'} | ${2} | ${false}
+  `(
+    'some test',
+    async ({a, b, expected}) => {
+      expectType<string>(a);
+      expectType<number>(b);
+      expectType<boolean>(expected);
+    },
+    1000,
+  ),
+);
+
+expectError(
+  test.concurrent.each<[['a', string]], 1>`
+    a
+    ${1}
+  `('some test', async () => {}, 1000),
 );
 
 expectError(test.concurrent.each());
@@ -635,6 +682,28 @@ expectType<void>(
     },
     1000,
   ),
+);
+expectType<void>(
+  describe.each<[['a', string], ['b', number], ['expected', boolean]], 2>`
+    a      | b    | expected
+    ${'1'} | ${1} | ${true}
+    ${'1'} | ${2} | ${false}
+  `(
+    'some test',
+    ({a, b, expected}) => {
+      expectType<string>(a);
+      expectType<number>(b);
+      expectType<boolean>(expected);
+    },
+    1000,
+  ),
+);
+
+expectError(
+  describe.each<[['a', string]], 1>`
+    a
+    ${1}
+  `('some test', () => {}, 1000),
 );
 
 expectError(describe.each());

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -72,11 +72,12 @@ type TTimesN<T, N extends number> = TTimesNRecursive<T, N, []>;
  */
 type Flat2DTuple<S extends Array<Array<unknown>>> = S['length'] extends 0
   ? []
-  : S extends [
-      infer T extends Array<unknown>,
-      ...infer Remaining extends Array<Array<unknown>>,
-    ]
-  ? [...T, ...Flat2DTuple<Remaining>]
+  : S extends [infer T, ...infer Remaining]
+  ? T extends Array<unknown>
+    ? Remaining extends Array<Array<unknown>>
+      ? [...T, ...Flat2DTuple<Remaining>]
+      : never
+    : never
   : never;
 
 /*


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I like writing `.each` tests in typescript using the table notation. And by passing an interface I can provide the type for the argument of the test function:
```typescript
it.each<{a: string, b: number, expected: boolean}>`
a      | b    | expected
${'1'} | ${1} | ${true}
${'1'} | ${2} | ${false}
`('some test', ({a, b, expected}) => {
  expect(a === `${b}`).toBe(expected)
});
```
But this only provides type for the test function argument, it does not ensure that the correct values were used inside the table. From typescript's perspective, the following is also correct:
```typescript
it.each<{a: string, b: number, expected: boolean}>`
a            | b     | expected
${undefined} | ${{}} | ${null}
`('some test', ({a, b, expected}) => {
  expect(a === `${b}`).toBe(expected)
});
```

To ensure the correct types are used inside the table I would like to propose an additional way of providing types to table tests:

```typescript
it.each<[['a', string], ['b', number], ['expected', boolean]], 2>`
a      | b    | expected
${'1'} | ${1} | ${true}
${'1'} | ${2} | ${false}
`('some test', ({a, b, expected}) => {
  expect(a === `${b}`).toBe(expected)
});
```

We need two things to apply the correct types to the test function and the table:
- An interface for the test function, `{a: string, b: number, expected: boolean}` in the case of the example above
- A tuple with a type for each expression inside the table: `[string, number, boolean, string, number, boolean]`

Because the properties of an interface do not have an order in typescript, we cannot generate the tuple for the expression from an interface. Instead a tuple with Key-Type pairs is used. The second generic parameter is the number of rows inside the table. With these values we can generate the interface for the test function argument and the tuple for the table expressions by using recursive typescript definitions.

I am using this solution through a [separate package](https://www.npmjs.com/package/@wistudent/jest-each-improved-types) in my own projects for a while now, but I think others could profit from it more easily if it were part of jest itself. Let me know what you think about it.

## Test plan

I added additional test cases to the type tests to ensure that the new notation
- creates the type for the test function argument correctly.
- results in a typescript error if a value that is incompatible with the desired type is used inside the table.
- does not interfer with existing ways of supplying types to `.each` tests.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
