### PR TITLE
feat(jest-mock): allow `jest.replaceProperty` to replace `undefined` or nonexistent properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - `[@jest/create-cache-key-function]` Allow passing `length` argument to `createCacheKey()` function and set its default value to `16` on Windows ([#13827](https://github.com/facebook/jest/pull/13827))
 - `[jest-message-util]` Add support for [AggregateError](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/AggregateError) ([#13946](https://github.com/facebook/jest/pull/13946) & [#13947](https://github.com/facebook/jest/pull/13947))
 - `[jest-message-util]` Add support for [Error causes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) in `test` and `it` ([#13935](https://github.com/facebook/jest/pull/13935))
+- `[jest-mock]` Allow `jest.replaceProperty()` to replace `undefined` or nonexistent properties ([#13958](https://github.com/facebook/jest/pull/13958))
 - `[jest-worker]` Add `start` method to worker farms ([#13937](https://github.com/facebook/jest/pull/13937))
 
 ### Fixes

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -614,9 +614,9 @@ See the [Mock Functions](MockFunctionAPI.md#jestfnimplementation) page for detai
 
 Determines if the given function is a mocked function.
 
-### `jest.replaceProperty(object, propertyKey, value)`
+### `jest.replaceProperty(object, propertyKey, value, options?)`
 
-Replace `object[propertyKey]` with a `value`. The property must already exist on the object. The same property might be replaced multiple times. Returns a Jest [replaced property](MockFunctionAPI.md#replaced-properties).
+Replace `object[propertyKey]` with a `value`. The same property might be replaced multiple times. Returns a Jest [replaced property](MockFunctionAPI.md#replaced-properties).
 
 :::note
 
@@ -660,6 +660,22 @@ test('isLocalhost returns true when HOSTNAME is localhost', () => {
 test('isLocalhost returns false when HOSTNAME is not localhost', () => {
   jest.replaceProperty(process, 'env', {HOSTNAME: 'not-localhost'});
   expect(utils.isLocalhost()).toBe(false);
+});
+```
+
+Jest will make sure that the target property exists on the object and its value is not `undefined`. To skip this precaution, use `tolerateUndefined` option:
+
+```js
+const isCI = () => process.env.CI === 'true';
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test('when process.env.CI is true', () => {
+  jest.replaceProperty(process.env, 'CI', 'true', {tolerateUndefined: true});
+
+  expect(isCI()).toBe(true);
 });
 ```
 

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -562,3 +562,10 @@ expectType<Replaced<ComplexObject['multipleTypes']>>(
     .replaceValue({foo: 1})
     .replaceValue(null),
 );
+
+expectType<Replaced<string | undefined>>(
+  replaceProperty(process.env, 'CI', 'true', {tolerateUndefined: true}),
+);
+expectError<Replaced<string | undefined>>(
+  replaceProperty(process.env, 'CI', 'true', {tolerateUndefined: 'all'}),
+);

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -2099,11 +2099,25 @@ describe('moduleMocker', () => {
           Object.defineProperty(obj, 'property', {
             configurable: false,
             value: 1,
-            writable: false,
+            writable: true,
           });
 
           moduleMocker.replaceProperty(obj, 'property', 2);
         }).toThrow('property is not declared configurable');
+      });
+
+      it('when property is not writable', () => {
+        expect(() => {
+          const obj = {};
+
+          Object.defineProperty(obj, 'property', {
+            configurable: true,
+            value: 1,
+            writable: false,
+          });
+
+          moduleMocker.replaceProperty(obj, 'property', 2);
+        }).toThrow('property is not declared writable');
       });
 
       it('when trying to mock a method', () => {

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -1980,7 +1980,7 @@ describe('moduleMocker', () => {
       expect(obj.property).toBe(1);
     });
 
-    it('should allow mocking a property multiple times', () => {
+    it('should allow replacing a property multiple times', () => {
       const obj = {
         property: 1,
       };
@@ -2000,8 +2000,8 @@ describe('moduleMocker', () => {
       expect(obj.property).toBe(1);
     });
 
-    it('should allow mocking with value of different type', () => {
-      const obj = {
+    it('should allow replacing with value of different type', () => {
+      const obj: {property: unknown} = {
         property: 1,
       };
 
@@ -2014,6 +2014,36 @@ describe('moduleMocker', () => {
       replaced.restore();
 
       expect(obj.property).toBe(1);
+    });
+
+    it('should allow replacing undefined property, when `tolerateUndefined: true` is set', () => {
+      const obj: {property: number | undefined} = {
+        property: undefined,
+      };
+
+      const replaced = moduleMocker.replaceProperty(obj, 'property', 2, {
+        tolerateUndefined: true,
+      });
+
+      expect(obj.property).toBe(2);
+
+      replaced.restore();
+
+      expect(obj).toStrictEqual({property: undefined});
+    });
+
+    it('should allow adding nonexistent property, when `tolerateUndefined: true` is set', () => {
+      const obj: Record<string, unknown> = {};
+
+      const replaced = moduleMocker.replaceProperty(obj, 'nonexistent', 2, {
+        tolerateUndefined: true,
+      });
+
+      expect(obj.nonexistent).toBe(2);
+
+      replaced.restore();
+
+      expect(obj).not.toHaveProperty('nonexistent');
     });
 
     describe('should throw', () => {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1366,8 +1366,12 @@ export class ModuleMocker {
     if (!descriptor && !options?.tolerateUndefined) {
       throw new Error(`${String(propertyKey)} property does not exist`);
     }
+
     if (descriptor?.configurable === false) {
       throw new Error(`${String(propertyKey)} is not declared configurable`);
+    }
+    if (descriptor?.writable === false) {
+      throw new Error(`${String(propertyKey)} is not declared writable`);
     }
 
     if (descriptor?.get !== undefined) {


### PR DESCRIPTION
## Summary

As discussed in #13496, it would be useful if `jest.replaceProperty` could replace `undefined` or nonexistent properties as well.

Here I implemented this through `tolerateUndefined` option. The name can be different, of course.

## Test plan

Tests are added.