### PR TITLE
Failing ScriptTransformer test

### DIFF
--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -107,6 +107,8 @@ class ScriptTransformer {
       projectCaches.set(configString, projectCache);
     }
 
+    console.log({configString});
+
     this._cache = projectCache;
   }
 
@@ -700,6 +702,8 @@ class ScriptTransformer {
       options.coverageProvider === 'babel' &&
       shouldInstrument(filename, options, this._config);
     const scriptCacheKey = getScriptCacheKey(filename, instrument);
+    console.log({scriptCacheKey});
+
     let result = this._cache.transformedFiles.get(scriptCacheKey);
     if (result) {
       return result;
@@ -728,6 +732,8 @@ class ScriptTransformer {
       options.coverageProvider === 'babel' &&
       shouldInstrument(filename, options, this._config);
     const scriptCacheKey = getScriptCacheKey(filename, instrument);
+
+    console.log({scriptCacheKey});
 
     let result = this._cache.transformedFiles.get(scriptCacheKey);
     if (result) {

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -2019,23 +2019,13 @@ describe('ScriptTransformer', () => {
     expect(fs.readFileSync).toHaveBeenCalledWith('/fruits/banana.js', 'utf8');
   });
 
-  it.only('regardless of sync/async, does not reuse the in-memory cache between different projects', async () => {
+  it('regardless of sync/async, does not reuse the in-memory cache between different projects', async () => {
     const scriptTransformer = await createScriptTransformer({
       ...config,
       transform: [['\\.js$', 'test_preprocessor', {}]],
     });
 
     scriptTransformer.transform('/fruits/banana.js', getCoverageOptions());
-
-    // const anotherScriptTransformer = await createScriptTransformer({
-    //   ...config,
-    //   transform: [['\\.js$', 'css-preprocessor', {}]],
-    // });
-
-    // await anotherScriptTransformer.transformAsync(
-    //   '/fruits/banana.js',
-    //   getCoverageOptions(),
-    // );
 
     const yetAnotherScriptTransformer = await createScriptTransformer({
       ...config,
@@ -2045,15 +2035,6 @@ describe('ScriptTransformer', () => {
       '/fruits/banana.js',
       getCoverageOptions(),
     );
-
-    // const fruityScriptTransformer = await createScriptTransformer({
-    //   ...config,
-    //   transform: [['\\.js$', 'test_async_preprocessor', {}]],
-    // });
-    // await fruityScriptTransformer.transformAsync(
-    //   '/fruits/banana.js',
-    //   getCoverageOptions(),
-    // );
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(2);
     expect(fs.readFileSync).toHaveBeenNthCalledWith(
@@ -2066,16 +2047,65 @@ describe('ScriptTransformer', () => {
       '/fruits/banana.js',
       'utf8',
     );
-    // expect(fs.readFileSync).toHaveBeenNthCalledWith(
-    //   3,
-    //   '/fruits/banana.js',
-    //   'utf8',
-    // );
-    // expect(fs.readFileSync).toHaveBeenNthCalledWith(
-    //   4,
-    //   '/fruits/banana.js',
-    //   'utf8',
-    // );
+  });
+
+  it('regardless of sync/async, does not reuse the in-memory cache between different projects', async () => {
+    const scriptTransformer = await createScriptTransformer({
+      ...config,
+      transform: [['\\.js$', 'test_preprocessor', {}]],
+    });
+
+    scriptTransformer.transform('/fruits/banana.js', getCoverageOptions());
+
+    const anotherScriptTransformer = await createScriptTransformer({
+      ...config,
+      transform: [['\\.js$', 'css-preprocessor', {}]],
+    });
+
+    await anotherScriptTransformer.transformAsync(
+      '/fruits/banana.js',
+      getCoverageOptions(),
+    );
+
+    const yetAnotherScriptTransformer = await createScriptTransformer({
+      ...config,
+      transform: [['\\.js$', 'test_preprocessor', {}]],
+    });
+    yetAnotherScriptTransformer.transform(
+      '/fruits/banana.js',
+      getCoverageOptions(),
+    );
+
+    const fruityScriptTransformer = await createScriptTransformer({
+      ...config,
+      transform: [['\\.js$', 'test_async_preprocessor', {}]],
+    });
+    await fruityScriptTransformer.transformAsync(
+      '/fruits/banana.js',
+      getCoverageOptions(),
+    );
+
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
+    expect(fs.readFileSync).toHaveBeenNthCalledWith(
+      1,
+      '/fruits/banana.js',
+      'utf8',
+    );
+    expect(fs.readFileSync).toHaveBeenNthCalledWith(
+      2,
+      '/fruits/banana.js',
+      'utf8',
+    );
+    expect(fs.readFileSync).toHaveBeenNthCalledWith(
+      3,
+      '/fruits/banana.js',
+      'utf8',
+    );
+    expect(fs.readFileSync).toHaveBeenNthCalledWith(
+      4,
+      '/fruits/banana.js',
+      'utf8',
+    );
   });
 
   it('preload transformer when using `createScriptTransformer`', async () => {

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -2019,7 +2019,7 @@ describe('ScriptTransformer', () => {
     expect(fs.readFileSync).toHaveBeenCalledWith('/fruits/banana.js', 'utf8');
   });
 
-  it('regardless of sync/async, does not reuse the in-memory cache between different projects', async () => {
+  it.only('regardless of sync/async, does not reuse the in-memory cache between different projects', async () => {
     const scriptTransformer = await createScriptTransformer({
       ...config,
       transform: [['\\.js$', 'test_preprocessor', {}]],
@@ -2027,15 +2027,15 @@ describe('ScriptTransformer', () => {
 
     scriptTransformer.transform('/fruits/banana.js', getCoverageOptions());
 
-    const anotherScriptTransformer = await createScriptTransformer({
-      ...config,
-      transform: [['\\.js$', 'css-preprocessor', {}]],
-    });
+    // const anotherScriptTransformer = await createScriptTransformer({
+    //   ...config,
+    //   transform: [['\\.js$', 'css-preprocessor', {}]],
+    // });
 
-    await anotherScriptTransformer.transformAsync(
-      '/fruits/banana.js',
-      getCoverageOptions(),
-    );
+    // await anotherScriptTransformer.transformAsync(
+    //   '/fruits/banana.js',
+    //   getCoverageOptions(),
+    // );
 
     const yetAnotherScriptTransformer = await createScriptTransformer({
       ...config,
@@ -2046,16 +2046,16 @@ describe('ScriptTransformer', () => {
       getCoverageOptions(),
     );
 
-    const fruityScriptTransformer = await createScriptTransformer({
-      ...config,
-      transform: [['\\.js$', 'test_async_preprocessor', {}]],
-    });
-    await fruityScriptTransformer.transformAsync(
-      '/fruits/banana.js',
-      getCoverageOptions(),
-    );
+    // const fruityScriptTransformer = await createScriptTransformer({
+    //   ...config,
+    //   transform: [['\\.js$', 'test_async_preprocessor', {}]],
+    // });
+    // await fruityScriptTransformer.transformAsync(
+    //   '/fruits/banana.js',
+    //   getCoverageOptions(),
+    // );
 
-    expect(fs.readFileSync).toHaveBeenCalledTimes(4);
+    expect(fs.readFileSync).toHaveBeenCalledTimes(2);
     expect(fs.readFileSync).toHaveBeenNthCalledWith(
       1,
       '/fruits/banana.js',
@@ -2066,16 +2066,16 @@ describe('ScriptTransformer', () => {
       '/fruits/banana.js',
       'utf8',
     );
-    expect(fs.readFileSync).toHaveBeenNthCalledWith(
-      3,
-      '/fruits/banana.js',
-      'utf8',
-    );
-    expect(fs.readFileSync).toHaveBeenNthCalledWith(
-      4,
-      '/fruits/banana.js',
-      'utf8',
-    );
+    // expect(fs.readFileSync).toHaveBeenNthCalledWith(
+    //   3,
+    //   '/fruits/banana.js',
+    //   'utf8',
+    // );
+    // expect(fs.readFileSync).toHaveBeenNthCalledWith(
+    //   4,
+    //   '/fruits/banana.js',
+    //   'utf8',
+    // );
   });
 
   it('preload transformer when using `createScriptTransformer`', async () => {

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -2056,7 +2056,26 @@ describe('ScriptTransformer', () => {
     );
 
     expect(fs.readFileSync).toHaveBeenCalledTimes(4);
-    expect(fs.readFileSync).toHaveBeenCalledWith('/fruits/banana.js', 'utf8');
+    expect(fs.readFileSync).toHaveBeenNthCalledWith(
+      1,
+      '/fruits/banana.js',
+      'utf8',
+    );
+    expect(fs.readFileSync).toHaveBeenNthCalledWith(
+      2,
+      '/fruits/banana.js',
+      'utf8',
+    );
+    expect(fs.readFileSync).toHaveBeenNthCalledWith(
+      3,
+      '/fruits/banana.js',
+      'utf8',
+    );
+    expect(fs.readFileSync).toHaveBeenNthCalledWith(
+      4,
+      '/fruits/banana.js',
+      'utf8',
+    );
   });
 
   it('preload transformer when using `createScriptTransformer`', async () => {

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -2049,7 +2049,7 @@ describe('ScriptTransformer', () => {
     );
   });
 
-  it('regardless of sync/async, does not reuse the in-memory cache between different projects', async () => {
+  it('regardless of sync/async, does not reuse the in-memory cache between different projects v2', async () => {
     const scriptTransformer = await createScriptTransformer({
       ...config,
       transform: [['\\.js$', 'test_preprocessor', {}]],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This PR is meant to show a failing test.

The test case that was modified checks that we fetch the file from scratch 4 times. But as you can see with the updated test, 2 of the transformers are reusing each others cache because they share the exact same configString. Is this intended?.

![Screen Shot 2023-03-06 at 5 50 16 PM](https://user-images.githubusercontent.com/2286579/223273615-ca78066d-ac7f-4c18-890d-a997dc7afd2d.png)




<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

This is a test

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
