### PR TITLE
Add note about zero width space

### DIFF
--- a/packages/expect/src/matchers.ts
+++ b/packages/expect/src/matchers.ts
@@ -26,6 +26,7 @@ import {
   MatcherHintOptions,
   RECEIVED_COLOR,
   SUGGEST_TO_CONTAIN_EQUAL,
+  checkZeroWidthSpace,
   ensureExpectedIsNonNegativeInteger,
   ensureNoExpected,
   ensureNumbers,
@@ -131,7 +132,8 @@ const matchers: MatchersObject = {
               EXPECTED_LABEL,
               RECEIVED_LABEL,
               isExpand(this.expand),
-            )
+            ) +
+            checkZeroWidthSpace(received, expected)
           );
         };
 
@@ -641,7 +643,8 @@ const matchers: MatchersObject = {
             EXPECTED_LABEL,
             RECEIVED_LABEL,
             isExpand(this.expand),
-          );
+          ) +
+          checkZeroWidthSpace(received, expected);
 
     // Passing the actual and expected objects so that a custom reporter
     // could access them, for example in order to display a custom visual diff,
@@ -978,7 +981,8 @@ const matchers: MatchersObject = {
             EXPECTED_LABEL,
             RECEIVED_LABEL,
             isExpand(this.expand),
-          );
+          ) +
+          checkZeroWidthSpace(received, expected);
 
     // Passing the actual and expected objects so that a custom reporter
     // could access them, for example in order to display a custom visual diff,

--- a/packages/jest-matcher-utils/src/index.ts
+++ b/packages/jest-matcher-utils/src/index.ts
@@ -582,3 +582,33 @@ export const matcherHint = (
 
   return hint;
 };
+
+export const checkZeroWidthSpace = (
+  received: unknown,
+  expected: unknown,
+): string => {
+  const createNote = (str: string, isReceived: boolean): string | undefined => {
+    // eslint-disable-next-line no-misleading-character-class
+    const zwspRegExp = RegExp(
+      '[\\u001c-\\u001f\\u11a3-\\u11a7\\u180e\\u200b-\\u200f\\u2060\\u3164\\u034f\\u202a-\\u202e\\u2061-\\u2063\\ufeff]',
+    );
+
+    const pos = str.search(zwspRegExp);
+    if (pos !== -1) {
+      return `Note: A zero-width space exists at index ${pos - 1} of ${
+        isReceived ? 'Received' : 'Expected'
+      }.`;
+    }
+    return undefined;
+  };
+
+  const note =
+    createNote(stringify(received), true) ||
+    createNote(stringify(expected), false);
+
+  if (note) {
+    return `\n${chalk.yellow(note)}`;
+  } else {
+    return '';
+  }
+};


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
Added the ability to display a NOTE for `toEqual()`, `toStrictEqual()` and `toBe()` when the test fails due to the presence of a zero-width space.

**Related**

https://github.com/facebook/jest/issues/10584

https://github.com/facebook/jest/pull/13997
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Test
<img width="659" alt="image" src="https://user-images.githubusercontent.com/5201487/224470847-43c58498-7405-4877-bc82-f1272d781df2.png">


Result

<img width="557" alt="image" src="https://user-images.githubusercontent.com/5201487/224470808-fad47c88-3da4-4318-9e63-74f337e54657.png">