### PR TITLE
fix(jest-changed-files): avoid crashing if the `sl` command is taken by Steam Locomotive instead of Sapling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- `[jest-changed-files]` Avoid crashing if the `sl` command is taken by Steam Locomotive instead of Sapling ([#14061](https://github.com/facebook/jest/pull/14061))
 - `[jest-config]` Handle frozen config object ([#14054](https://github.com/facebook/jest/pull/14054))
 - `[jest-environment-jsdom, jest-environment-node]` Fix assignment of `customExportConditions` via `testEnvironmentOptions` when custom env subclass defines a default value ([#13989](https://github.com/facebook/jest/pull/13989))
 - `[jest-matcher-utils]` Fix copying value of inherited getters ([#14007](https://github.com/facebook/jest/pull/14007))

--- a/packages/jest-changed-files/src/sl.ts
+++ b/packages/jest-changed-files/src/sl.ts
@@ -56,7 +56,7 @@ const adapter: SCMAdapter = {
 
   getRoot: async cwd => {
     try {
-      const result = await execa('sl', ['root'], {cwd, env});
+      const result = await execa('sl', ['root'], {cwd, env, timeout: 250});
 
       return result.stdout;
     } catch {


### PR DESCRIPTION
Fixes #14046

## Summary

Just an idea. If the `sl` command is taken by [Steam Locomotive](https://github.com/mtoyoda/sl), it takes some 5-6 seconds to run its CLI animation. Adding `timeout` to Execa's options kills the process earlier, hence the `getRoots()` logic ends up in `catch` and returns `null`.

Unfortunately the timeout time is a penalty for those who have Steam Locomotive installed. For them `--watch` or `--onlyChanged` will be pause for that amount of time. So the number cannot be too large, but should be just enough to get response from Sapling. I don’t know Sapling at all. Seemed like the response was rather instant running `sl root` in a repo with Sapling enabled.

## Test plan

Tested locally. All tests pass with Sapling installed; no unexpected crash with Steam Locomotive installed.