### PR TITLE
fix invalid entry in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 
 - `[docs]` Updated documentation for the `--runTestsByPath` CLI command ([#14004](https://github.com/facebook/jest/pull/14004))
 - `[docs]` Updated documentation regarding the synchronous fallback when asynchronous code transforms are unavailable ([#14056](https://github.com/facebook/jest/pull/14056))
-- `[docs]` Update jest statistics of use and downloads in website Index. 
+- `[docs]` Update jest statistics of use and downloads in website Index. ([#14101](https://github.com/facebook/jest/pull/14101))
 
 ### Performance
 


### PR DESCRIPTION
## Summary

CI [fails](https://github.com/jestjs/jest/actions/runs/4805671398/jobs/8552322079) on main since #14101:

```
Run yarn lint:prettier:ci
Checking formatting...
[warn] CHANGELOG.md
[warn] Code style issues found in the above file. Forgot to run Prettier?
Error: Process completed with exit code 1.
``` 

This fixes that.

I guess this wouldn't warrant a changelog entry of its own?