### PR TITLE
chore(website): remove `globby` from dependencies list

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -39,7 +39,6 @@
     "@docusaurus/remark-plugin-npm2yarn": "^2.0.0",
     "clsx": "^1.1.1",
     "docusaurus-remark-plugin-tab-blocks": "^1.2.0",
-    "globby": "^11.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-github-btn": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13048,7 +13048,6 @@ __metadata:
     "@types/react": ^17.0.3
     clsx: ^1.1.1
     docusaurus-remark-plugin-tab-blocks: ^1.2.0
-    globby: ^11.0.1
     graphql: ^16.3.0
     graphql-request: ^6.0.0
     js-yaml: ^4.1.0


### PR DESCRIPTION
## Summary

`globby` is included in website’s dependencies list, but it is not used. Just cleaning up around (;

## Test plan

The website should build successfully.
