### PR TITLE
chore: remove the `"enzyme/cheerio"` resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,6 @@
     "@types/node": "~14.14.45",
     "ansi-escapes/type-fest": "^2.0.0",
     "babel-jest": "workspace:^",
-    "enzyme/cheerio": "=1.0.0-rc.3",
     "jest": "workspace:^",
     "jest-environment-node": "workspace:^",
     "ts-node@^10.5.0": "patch:ts-node@npm:^10.5.0#./.yarn/patches/ts-node-npm-10.9.1-6c268be7f4.patch"


### PR DESCRIPTION
## Summary

The `"enzyme/cheerio"` resolution seems to be unnecessary after #14119. Or?

## Test plan

Green CI.