### PR TITLE
feat: add support for snapshot matchers in concurrent tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[jest-circus, jest-snapshot]` Add support for snapshot matchers in concurrent tests
 - `[jest-cli]` Include type definitions to generated config files ([#14078](https://github.com/facebook/jest/pull/14078))
 - `[jest-snapshot]` Support arrays as property matchers ([#14025](https://github.com/facebook/jest/pull/14025))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[jest-circus, jest-snapshot]` Add support for snapshot matchers in concurrent tests
+- `[jest-circus, jest-snapshot]` Add support for snapshot matchers in concurrent tests ([#14139](https://github.com/jestjs/jest/pull/14139))
 - `[jest-cli]` Include type definitions to generated config files ([#14078](https://github.com/facebook/jest/pull/14078))
 - `[jest-snapshot]` Support arrays as property matchers ([#14025](https://github.com/facebook/jest/pull/14025))
 

--- a/e2e/__tests__/snapshot-concurrent.test.ts
+++ b/e2e/__tests__/snapshot-concurrent.test.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {skipSuiteOnJasmine} from '@jest/test-utils';
+import runJest from '../runJest';
+
+skipSuiteOnJasmine();
+
+test('Snapshots get correct names in concurrent tests', () => {
+  const result = runJest('snapshot-concurrent', ['--ci']);
+  expect(result.exitCode).toBe(0);
+});

--- a/e2e/snapshot-concurrent/__tests__/__snapshots__/works.test.js.snap
+++ b/e2e/snapshot-concurrent/__tests__/__snapshots__/works.test.js.snap
@@ -12,6 +12,10 @@ exports[`A c 1`] = `"Ac1"`;
 
 exports[`A c 2`] = `"Ac2"`;
 
+exports[`A d 1`] = `"Ad1"`;
+
+exports[`A d 2`] = `"Ad2"`;
+
 exports[`B 1`] = `"B1"`;
 
 exports[`B 2`] = `"B2"`;
@@ -19,3 +23,7 @@ exports[`B 2`] = `"B2"`;
 exports[`C 1`] = `"C1"`;
 
 exports[`C 2`] = `"C2"`;
+
+exports[`D 1`] = `"D1"`;
+
+exports[`D 2`] = `"D2"`;

--- a/e2e/snapshot-concurrent/__tests__/__snapshots__/works.test.js.snap
+++ b/e2e/snapshot-concurrent/__tests__/__snapshots__/works.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`A a 1`] = `"Aa1"`;
+
+exports[`A a 2`] = `"Aa2"`;
+
+exports[`A b 1`] = `"Ab1"`;
+
+exports[`A b 2`] = `"Ab2"`;
+
+exports[`A c 1`] = `"Ac1"`;
+
+exports[`A c 2`] = `"Ac2"`;
+
+exports[`B 1`] = `"B1"`;
+
+exports[`B 2`] = `"B2"`;
+
+exports[`C 1`] = `"C1"`;
+
+exports[`C 2`] = `"C2"`;

--- a/e2e/snapshot-concurrent/__tests__/works.test.js
+++ b/e2e/snapshot-concurrent/__tests__/works.test.js
@@ -26,6 +26,11 @@ describe('A', () => {
     expect('Ac1').toMatchSnapshot();
     expect('Ac2').toMatchSnapshot();
   });
+
+  it('d', () => {
+    expect('Ad1').toMatchSnapshot();
+    expect('Ad2').toMatchSnapshot();
+  });
 });
 
 it.concurrent('B', async () => {
@@ -34,7 +39,12 @@ it.concurrent('B', async () => {
   expect('B2').toMatchSnapshot();
 });
 
-it.concurrent('C', async () => {
+it('C', () => {
   expect('C1').toMatchSnapshot();
   expect('C2').toMatchSnapshot();
+});
+
+it.concurrent('D', async () => {
+  expect('D1').toMatchSnapshot();
+  expect('D2').toMatchSnapshot();
 });

--- a/e2e/snapshot-concurrent/__tests__/works.test.js
+++ b/e2e/snapshot-concurrent/__tests__/works.test.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+describe('A', () => {
+  it.concurrent('a', async () => {
+    await sleep(100);
+    expect('Aa1').toMatchSnapshot();
+    expect('Aa2').toMatchSnapshot();
+  });
+
+  it.concurrent('b', async () => {
+    await sleep(10);
+    expect('Ab1').toMatchSnapshot();
+    expect('Ab2').toMatchSnapshot();
+  });
+
+  it.concurrent('c', async () => {
+    expect('Ac1').toMatchSnapshot();
+    expect('Ac2').toMatchSnapshot();
+  });
+});
+
+it.concurrent('B', async () => {
+  await sleep(10);
+  expect('B1').toMatchSnapshot();
+  expect('B2').toMatchSnapshot();
+});
+
+it.concurrent('C', async () => {
+  expect('C1').toMatchSnapshot();
+  expect('C2').toMatchSnapshot();
+});

--- a/e2e/snapshot-concurrent/package.json
+++ b/e2e/snapshot-concurrent/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@jest/expect-utils": "workspace:^",
+    "@types/node": "*",
     "jest-get-type": "workspace:^",
     "jest-matcher-utils": "workspace:^",
     "jest-message-util": "workspace:^",

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import type {AsyncLocalStorage} from 'async_hooks';
 import type {EqualsFunction, Tester} from '@jest/expect-utils';
 import type * as jestMatcherUtils from 'jest-matcher-utils';
 import {INTERNAL_MATCHER_FLAG} from './jestMatchersObject';
@@ -57,6 +58,7 @@ export interface MatcherUtils {
 
 export interface MatcherState {
   assertionCalls: number;
+  currentConcurrentTestName?: AsyncLocalStorage<string>;
   currentTestName?: string;
   error?: Error;
   expand?: boolean;

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -279,7 +279,9 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
 
   context.dontThrow && context.dontThrow();
 
-  const {currentTestName, isNot, snapshotState} = context;
+  const {currentConcurrentTestName, isNot, snapshotState} = context;
+  const currentTestName =
+    currentConcurrentTestName?.getStore() ?? context.currentTestName;
 
   if (isNot) {
     throw new Error(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9668,6 +9668,7 @@ __metadata:
     "@jest/expect-utils": "workspace:^"
     "@jest/test-utils": "workspace:^"
     "@tsd/typescript": ^5.0.4
+    "@types/node": "*"
     chalk: ^4.0.0
     immutable: ^4.0.0
     jest-get-type: "workspace:^"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This implements support for snapshot matchers in concurrent tests. The long-standing issue with this has been rooted in the fact that because concurrent tests run _in parallel_ there is no concept of a _single currently running test_ and so jest-snapshot is not able to get this information from a global state object.

This problem can however be solved with [`AsyncLocalStorage`](https://nodejs.org/dist/latest-v18.x/docs/api/async_context.html), which is an object that can hold different values for different async contexts. Each concurrent test runs in its own async context and when asking for a value from the storage, gets a result that is unique to it.

Support is added only to jest-circus.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

There is a new integration test for this use-case.

Fixes #2180.
Fixes #5801.
