### PR TITLE
Added expect.satisfies(predicate) matcher

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1037,31 +1037,36 @@ describe('not.objectContaining', () => {
 });
 ```
 
-### `expect.satisfies(predicate)`
+### `expect.satisfies([description,] predicate)`
 
 `expect.satisfies(predicate)` matches the received value if an abitrary predicate returns a truthy value when passed the received value as an argument.
 
 ```js
 describe('satisfies', () => {
-  it('matches if the received value satisfies a predicate', () => {
+  it('matches if the received value is even', () => {
     const isEven = (n) => n % 2 === 0;
+    // Expected value is printed as 'Satisfies isEven'
     expect(42).toEqual(expect.satisfies(isEven));
   })
 })
 ```
 
-### `expect.not.satisfies(predicate)`
-
-`expect.not.satisfies(predicate)` matches the received value if an abitrary predicate returns a falsy value when passed the received value as an argument.
+If a description is given, it is used to format test failure messages (otherwise Jest attempts to find a name for the predicate).
 
 ```js
-describe('not.satisfies', () => {
-  it('matches if the received value does not satisfy a predicate', () => {
-    const isEven = n => n % 2 === 0;
-    expect(41).toEqual(expect.not.satisfies(isEven));
+describe('satisfies', () => {
+  it('matches if the received value is even', () => {
+    // Expected value is printed as 'Satisfies "number is even"'
+    expect(42).toEqual(expect.satisfies('number is even', n => n % 2 === 0));
   })
 })
 ```
+
+### `expect.not.satisfies([description,] predicate)`
+
+`expect.not.satisfies(predicate)` matches the received value if an abitrary predicate returns a falsy value when passed the received value as an argument.
+
+It is the inverse of `expect.satisfies`.
 
 ### `expect.stringContaining(string)`
 

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1037,6 +1037,32 @@ describe('not.objectContaining', () => {
 });
 ```
 
+### `expect.satisfies(predicate)`
+
+`expect.satisfies(predicate)` matches the received value if an abitrary predicate returns a truthy value when passed the received value as an argument.
+
+```js
+describe('satisfies', () => {
+  it('matches if the received value satisfies a predicate', () => {
+    const isEven = (n) => n % 2 === 0;
+    expect(42).toEqual(expect.satisfies(isEven));
+  })
+})
+```
+
+### `expect.not.satisfies(predicate)`
+
+`expect.not.satisfies(predicate)` matches the received value if an abitrary predicate returns a falsy value when passed the received value as an argument.
+
+```js
+describe('not.satisfies', () => {
+  it('matches if the received value does not satisfy a predicate', () => {
+    const isEven = n => n % 2 === 0;
+    expect(41).toEqual(expect.not.satisfies(isEven));
+  })
+})
+```
+
 ### `expect.stringContaining(string)`
 
 `expect.stringContaining(string)` matches the received value if it is a string that contains the exact expected string.

--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -332,12 +332,18 @@ test('Satisfies matches when predicate returns a truthy value', () => {
     jestExpect(expectSatisfies(() => value).asymmetricMatch(null)).toBe(
       Boolean(value),
     );
+    jestExpect(
+      expectSatisfies('description', () => value).asymmetricMatch(null),
+    ).toBe(Boolean(value));
   });
 });
 
 test('NotSatisfies matches when predicate returns a falsy value', () => {
   [true, 'a', 1, false, null, undefined, '', 0].forEach(value => {
     jestExpect(notSatisfies(() => value).asymmetricMatch(null)).toBe(!value);
+    jestExpect(
+      notSatisfies('description', () => value).asymmetricMatch(null),
+    ).toBe(!value);
   });
 });
 
@@ -352,7 +358,13 @@ test('Satisfies and NotSatisfies pass the received value to the predicate', () =
     jestExpect(() =>
       matcher(assertIsSentinel).asymmetricMatch(sentinel),
     ).not.toThrow();
+    jestExpect(() =>
+      matcher('description', assertIsSentinel).asymmetricMatch(sentinel),
+    ).not.toThrow();
     jestExpect(() => matcher(assertIsSentinel).asymmetricMatch(null)).toThrow();
+    jestExpect(() =>
+      matcher('description', assertIsSentinel).asymmetricMatch(null),
+    ).toThrow();
   });
 });
 
@@ -361,6 +373,17 @@ test('Satisfies throws if the predicate is not a function', () => {
     // @ts-expect-error: Testing runtime error
     expectSatisfies(42);
   }).toThrow('Predicate is not a function');
+  jestExpect(() => {
+    // @ts-expect-error: Testing runtime error
+    expectSatisfies('description', 42);
+  }).toThrow('Predicate is not a function');
+});
+
+test('Satisfies throws if the description is not a string', () => {
+  jestExpect(() => {
+    // @ts-expect-error: Testing runtime error
+    expectSatisfies(42, () => 1);
+  }).toThrow('Description is not a string');
 });
 
 test('StringContaining matches string against string', () => {

--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -328,48 +328,32 @@ test('ObjectNotContaining throws for non-objects', () => {
 });
 
 test('Satisfies matches when predicate returns a truthy value', () => {
-  jestExpect(expectSatisfies(() => true).asymmetricMatch(null)).toBe(true);
-  jestExpect(expectSatisfies(() => 'a').asymmetricMatch(null)).toBe(true);
-  jestExpect(expectSatisfies(() => 1).asymmetricMatch(null)).toBe(true);
-  jestExpect(expectSatisfies(() => false).asymmetricMatch(null)).toBe(false);
-  jestExpect(expectSatisfies(() => null).asymmetricMatch(null)).toBe(false);
-  jestExpect(expectSatisfies(() => undefined).asymmetricMatch(null)).toBe(
-    false,
-  );
-  jestExpect(expectSatisfies(() => 0).asymmetricMatch(null)).toBe(false);
-  jestExpect(expectSatisfies(() => '').asymmetricMatch(null)).toBe(false);
+  [true, 'a', 1, false, null, undefined, '', 0].forEach(value => {
+    jestExpect(expectSatisfies(() => value).asymmetricMatch(null)).toBe(
+      Boolean(value),
+    );
+  });
 });
 
 test('NotSatisfies matches when predicate returns a falsy value', () => {
-  jestExpect(notSatisfies(() => true).asymmetricMatch(null)).toBe(false);
-  jestExpect(notSatisfies(() => 'a').asymmetricMatch(null)).toBe(false);
-  jestExpect(notSatisfies(() => 1).asymmetricMatch(null)).toBe(false);
-  jestExpect(notSatisfies(() => false).asymmetricMatch(null)).toBe(true);
-  jestExpect(notSatisfies(() => null).asymmetricMatch(null)).toBe(true);
-  jestExpect(notSatisfies(() => undefined).asymmetricMatch(null)).toBe(true);
-  jestExpect(notSatisfies(() => 0).asymmetricMatch(null)).toBe(true);
-  jestExpect(notSatisfies(() => '').asymmetricMatch(null)).toBe(true);
+  [true, 'a', 1, false, null, undefined, '', 0].forEach(value => {
+    jestExpect(notSatisfies(() => value).asymmetricMatch(null)).toBe(!value);
+  });
 });
 
-test('Satisfies and NotSatisfies pass the tested value to the predicate', () => {
+test('Satisfies and NotSatisfies pass the received value to the predicate', () => {
   const sentinel = ['a unique value'];
   const assertIsSentinel = (sample: Array<string>) => {
     if (sample !== sentinel) {
       throw new Error('expected sentinel');
     }
   };
-  jestExpect(() =>
-    expectSatisfies(assertIsSentinel).asymmetricMatch(sentinel),
-  ).not.toThrow();
-  jestExpect(() =>
-    notSatisfies(assertIsSentinel).asymmetricMatch(sentinel),
-  ).not.toThrow();
-  jestExpect(() =>
-    expectSatisfies(assertIsSentinel).asymmetricMatch(null),
-  ).toThrow();
-  jestExpect(() =>
-    notSatisfies(assertIsSentinel).asymmetricMatch(null),
-  ).toThrow();
+  [expectSatisfies, notSatisfies].forEach(matcher => {
+    jestExpect(() =>
+      matcher(assertIsSentinel).asymmetricMatch(sentinel),
+    ).not.toThrow();
+    jestExpect(() => matcher(assertIsSentinel).asymmetricMatch(null)).toThrow();
+  });
 });
 
 test('Satisfies throws if the predicate is not a function', () => {

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -259,22 +259,9 @@ class ObjectContaining extends AsymmetricMatcher<Record<string, unknown>> {
 }
 
 class Satisfies<T> extends AsymmetricMatcher<void> {
-  private description: string;
-  private predicate: (sample: T) => unknown;
-
-  constructor(
-    descriptionOrPredicate: ((sample: T) => unknown) | string,
-    predicate: ((sample: T) => unknown) | undefined,
-    inverse: boolean = false
-  ) {
+  constructor(private predicate: (sample: T) => unknown, inverse = false) {
     super(void 0, inverse);
-    if (typeof descriptionOrPredicate === 'function') {
-      this.description = 'a value satisfying the predicate';
-      this.predicate = descriptionOrPredicate;
-    } else if (typeof predicate === 'function') {
-      this.description = descriptionOrPredicate;
-      this.predicate = predicate;
-    } else {
+    if (typeof predicate !== 'function') {
       throw new Error('Predicate is not a function');
     }
   }
@@ -285,10 +272,6 @@ class Satisfies<T> extends AsymmetricMatcher<void> {
 
   toString(): string {
     return `${this.inverse ? 'Not' : ''}Satisfies`;
-  }
-
-  override getExpectedType(): string {
-    return this.description;
   }
 }
 
@@ -394,36 +377,17 @@ export const arrayContaining = (sample: Array<unknown>): ArrayContaining =>
   new ArrayContaining(sample);
 export const arrayNotContaining = (sample: Array<unknown>): ArrayContaining =>
   new ArrayContaining(sample, true);
-export function notSatisfies<T>(
-  predicate: (sample: unknown) => unknown,
-): Satisfies<T>;
-export function notSatisfies<T>(
-  description: string,
+export const notSatisfies = <T>(
   predicate: (sample: T) => unknown,
-): Satisfies<T>;
-export function notSatisfies<T>(
-  descriptionOrPredicate: string | ((sample: T) => unknown),
-  predicate?: (sample: T) => unknown,
-): Satisfies<T> {
-  return new Satisfies<T>(descriptionOrPredicate, predicate, true);
-}
+): Satisfies<T> => new Satisfies<T>(predicate, true);
 export const objectContaining = (
   sample: Record<string, unknown>,
 ): ObjectContaining => new ObjectContaining(sample);
 export const objectNotContaining = (
   sample: Record<string, unknown>,
 ): ObjectContaining => new ObjectContaining(sample, true);
-export function satisfies<T>(predicate: (sample: T) => unknown): Satisfies<T>;
-export function satisfies<T>(
-  description: string,
-  predicate: (sample: T) => unknown,
-): Satisfies<T>;
-export function satisfies<T>(
-  descriptionOrPredicate: string | ((sample: T) => unknown),
-  predicate?: (sample: T) => unknown,
-): Satisfies<T> {
-  return new Satisfies<T>(descriptionOrPredicate, predicate);
-}
+export const satisfies = <T>(predicate: (sample: T) => unknown): Satisfies<T> =>
+  new Satisfies<T>(predicate);
 export const stringContaining = (expected: string): StringContaining =>
   new StringContaining(expected);
 export const stringNotContaining = (expected: string): StringContaining =>

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -273,6 +273,10 @@ class Satisfies<T> extends AsymmetricMatcher<void> {
   toString(): string {
     return `${this.inverse ? 'Not' : ''}Satisfies`;
   }
+
+  override toAsymmetricMatcher(): string {
+    return this.toString();
+  }
 }
 
 class StringContaining extends AsymmetricMatcher<string> {

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -18,8 +18,10 @@ import {
   arrayNotContaining,
   closeTo,
   notCloseTo,
+  notSatisfies,
   objectContaining,
   objectNotContaining,
+  satisfies,
   stringContaining,
   stringMatching,
   stringNotContaining,
@@ -399,6 +401,7 @@ expect.not = {
   arrayContaining: arrayNotContaining,
   closeTo: notCloseTo,
   objectContaining: objectNotContaining,
+  satisfies: notSatisfies,
   stringContaining: stringNotContaining,
   stringMatching: stringNotMatching,
 };
@@ -406,6 +409,7 @@ expect.not = {
 expect.arrayContaining = arrayContaining;
 expect.closeTo = closeTo;
 expect.objectContaining = objectContaining;
+expect.satisfies = satisfies;
 expect.stringContaining = stringContaining;
 expect.stringMatching = stringMatching;
 

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -118,10 +118,6 @@ export interface AsymmetricMatchers {
   closeTo(sample: number, precision?: number): AsymmetricMatcher;
   objectContaining(sample: Record<string, unknown>): AsymmetricMatcher;
   satisfies<T>(predicate: (sample: T) => boolean): AsymmetricMatcher;
-  satisfies<T>(
-    description: string,
-    predicate: (sample: T) => boolean,
-  ): AsymmetricMatcher;
   stringContaining(sample: string): AsymmetricMatcher;
   stringMatching(sample: string | RegExp): AsymmetricMatcher;
 }

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -118,6 +118,10 @@ export interface AsymmetricMatchers {
   closeTo(sample: number, precision?: number): AsymmetricMatcher;
   objectContaining(sample: Record<string, unknown>): AsymmetricMatcher;
   satisfies<T>(predicate: (sample: T) => unknown): AsymmetricMatcher;
+  satisfies<T>(
+    description: string,
+    predicate: (sample: T) => unknown,
+  ): AsymmetricMatcher;
   stringContaining(sample: string): AsymmetricMatcher;
   stringMatching(sample: string | RegExp): AsymmetricMatcher;
 }

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -117,7 +117,7 @@ export interface AsymmetricMatchers {
   arrayContaining(sample: Array<unknown>): AsymmetricMatcher;
   closeTo(sample: number, precision?: number): AsymmetricMatcher;
   objectContaining(sample: Record<string, unknown>): AsymmetricMatcher;
-  satisfies<T>(predicate: (sample: T) => boolean): AsymmetricMatcher;
+  satisfies<T>(predicate: (sample: T) => unknown): AsymmetricMatcher;
   stringContaining(sample: string): AsymmetricMatcher;
   stringMatching(sample: string | RegExp): AsymmetricMatcher;
 }

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -117,6 +117,11 @@ export interface AsymmetricMatchers {
   arrayContaining(sample: Array<unknown>): AsymmetricMatcher;
   closeTo(sample: number, precision?: number): AsymmetricMatcher;
   objectContaining(sample: Record<string, unknown>): AsymmetricMatcher;
+  satisfies<T>(predicate: (sample: T) => boolean): AsymmetricMatcher;
+  satisfies<T>(
+    description: string,
+    predicate: (sample: T) => boolean,
+  ): AsymmetricMatcher;
   stringContaining(sample: string): AsymmetricMatcher;
   stringMatching(sample: string | RegExp): AsymmetricMatcher;
 }

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -48,12 +48,44 @@ expectError(expect({a: 1}).toEqual(expect.not.objectContaining()));
 expectType<void>(
   expect('x').toEqual(expect.satisfies((_sample: string): unknown => 1)),
 );
+expectType<void>(
+  expect('x').toEqual(
+    expect.satisfies('description', (_sample: string): unknown => 1),
+  ),
+);
 expectError(expect('x').toEqual(expect.satisfies('not a function')));
+expectError(
+  expect('x').toEqual(expect.satisfies('description', 'not a function')),
+);
+expectError(
+  expect('x').toEqual(
+    expect.satisfies(
+      () => 42,
+      () => 1,
+    ),
+  ),
+);
 expectError(expect('x').toEqual(expect.satisfies()));
 expectType<void>(
   expect('x').toEqual(expect.not.satisfies((_sample: string): unknown => 1)),
 );
+expectType<void>(
+  expect('x').toEqual(
+    expect.not.satisfies('description', (_sample: string): unknown => 1),
+  ),
+);
 expectError(expect('x').toEqual(expect.not.satisfies('not a function')));
+expectError(
+  expect('x').toEqual(expect.not.satisfies('description', 'not a function')),
+);
+expectError(
+  expect('x').toEqual(
+    expect.not.satisfies(
+      () => 42,
+      () => 1,
+    ),
+  ),
+);
 expectError(expect('x').toEqual(expect.not.satisfies()));
 
 expectType<void>(expect('one').toEqual(expect.stringContaining('n')));

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -45,11 +45,16 @@ expectType<void>(expect({b: 2}).toEqual(expect.not.objectContaining({a: 1})));
 expectError(expect({a: 1}).toEqual(expect.not.objectContaining(1)));
 expectError(expect({a: 1}).toEqual(expect.not.objectContaining()));
 
-const predicate = (s: string) => s.length === 1;
-expectType<void>(expect('x').toEqual(expect.satisfies(predicate)));
-expectError(expect('xx').toEqual(expect.satisfies(predicate)));
-expectType<void>(expect('xx').toEqual(expect.not.satisfies(predicate)));
-expectError(expect('x').toEqual(expect.not.satisfies(predicate)));
+expectType<void>(
+  expect('x').toEqual(expect.satisfies((_sample: string): unknown => 1)),
+);
+expectError(expect('x').toEqual(expect.satisfies('not a function')));
+expectError(expect('x').toEqual(expect.satisfies()));
+expectType<void>(
+  expect('x').toEqual(expect.not.satisfies((_sample: string): unknown => 1)),
+);
+expectError(expect('x').toEqual(expect.not.satisfies('not a function')));
+expectError(expect('x').toEqual(expect.not.satisfies()));
 
 expectType<void>(expect('one').toEqual(expect.stringContaining('n')));
 expectError(expect('two').toEqual(expect.stringContaining(2)));

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -45,6 +45,12 @@ expectType<void>(expect({b: 2}).toEqual(expect.not.objectContaining({a: 1})));
 expectError(expect({a: 1}).toEqual(expect.not.objectContaining(1)));
 expectError(expect({a: 1}).toEqual(expect.not.objectContaining()));
 
+const predicate = (s: string) => s.length === 1;
+expectType<void>(expect('x').toEqual(expect.satisfies(predicate)));
+expectError(expect('xx').toEqual(expect.satisfies(predicate)));
+expectType<void>(expect('xx').toEqual(expect.not.satisfies(predicate)));
+expectError(expect('x').toEqual(expect.not.satisfies(predicate)));
+
 expectType<void>(expect('one').toEqual(expect.stringContaining('n')));
 expectError(expect('two').toEqual(expect.stringContaining(2)));
 expectError(expect('three').toEqual(expect.stringContaining()));

--- a/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
+++ b/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
@@ -95,6 +95,22 @@ test('objectNotContaining()', () => {
 }`);
 });
 
+test('satisfies(predicate)', () => {
+  const result = prettyFormat(
+    expect.satisfies(_sample => true),
+    options,
+  );
+  expect(result).toBe('Satisfies a value satisfying the predicate');
+});
+
+test('satisfies(string, predicate)', () => {
+  const result = prettyFormat(
+    expect.satisfies('a description', _sample => true),
+    options,
+  );
+  expect(result).toBe('Satisfies a description');
+});
+
 test('stringContaining(string)', () => {
   const result = prettyFormat(expect.stringContaining('jest'), options);
   expect(result).toBe('StringContaining "jest"');

--- a/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
+++ b/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
@@ -100,15 +100,15 @@ test('satisfies(predicate)', () => {
     expect.satisfies(_sample => true),
     options,
   );
-  expect(result).toBe('Satisfies a value satisfying the predicate');
+  expect(result).toBe('Satisfies');
 });
 
-test('satisfies(string, predicate)', () => {
+test('not.satisfies(predicate)', () => {
   const result = prettyFormat(
-    expect.satisfies('a description', _sample => true),
+    expect.satisfies(_sample => true),
     options,
   );
-  expect(result).toBe('Satisfies a description');
+  expect(result).toBe('NotSatisfies');
 });
 
 test('stringContaining(string)', () => {
@@ -196,6 +196,7 @@ test('supports multiple nested asymmetric matchers', () => {
           d: expect.stringContaining('jest'),
           e: expect.stringMatching('jest'),
           f: expect.objectContaining({test: 'case'}),
+          g: expect.satisfies(() => true),
         }),
       },
     },
@@ -214,6 +215,7 @@ test('supports multiple nested asymmetric matchers', () => {
       "f": ObjectContaining {
         "test": "case",
       },
+      "g": Satisfies
     },
   },
 }`);

--- a/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
+++ b/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
@@ -105,7 +105,7 @@ test('satisfies(predicate)', () => {
 
 test('not.satisfies(predicate)', () => {
   const result = prettyFormat(
-    expect.satisfies(_sample => true),
+    expect.not.satisfies(_sample => true),
     options,
   );
   expect(result).toBe('NotSatisfies');

--- a/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
+++ b/packages/pretty-format/src/__tests__/AsymmetricMatcher.test.ts
@@ -95,20 +95,60 @@ test('objectNotContaining()', () => {
 }`);
 });
 
-test('satisfies(predicate)', () => {
+test('satisfies(description, predicate)', () => {
   const result = prettyFormat(
-    expect.satisfies(_sample => true),
+    expect.satisfies('xyzzy', () => true),
+    options,
+  );
+  expect(result).toBe('Satisfies "xyzzy"');
+});
+
+test('satisfies(anonymous predicate)', () => {
+  const result = prettyFormat(
+    expect.satisfies(() => true),
     options,
   );
   expect(result).toBe('Satisfies');
 });
 
-test('not.satisfies(predicate)', () => {
+test('satisfies(named predicate)', () => {
+  function myPredicate() {}
+  const result = prettyFormat(expect.satisfies(myPredicate), options);
+  expect(result).toBe('Satisfies myPredicate');
+});
+
+test('satisfies(named const predicate)', () => {
+  const myPredicate = () => true;
+  const result = prettyFormat(expect.satisfies(myPredicate), options);
+  expect(result).toBe('Satisfies myPredicate');
+});
+
+test('not.satisfies(description, predicate)', () => {
   const result = prettyFormat(
-    expect.not.satisfies(_sample => true),
+    expect.not.satisfies('xyzzy', () => true),
+    options,
+  );
+  expect(result).toBe('NotSatisfies "xyzzy"');
+});
+
+test('not.satisfies(anonymous predicate)', () => {
+  const result = prettyFormat(
+    expect.not.satisfies(() => true),
     options,
   );
   expect(result).toBe('NotSatisfies');
+});
+
+test('not.satisfies(named predicate)', () => {
+  function myPredicate() {}
+  const result = prettyFormat(expect.not.satisfies(myPredicate), options);
+  expect(result).toBe('NotSatisfies myPredicate');
+});
+
+test('not.satisfies(named const predicate)', () => {
+  const myPredicate = () => true;
+  const result = prettyFormat(expect.not.satisfies(myPredicate), options);
+  expect(result).toBe('NotSatisfies myPredicate');
 });
 
 test('stringContaining(string)', () => {
@@ -215,7 +255,7 @@ test('supports multiple nested asymmetric matchers', () => {
       "f": ObjectContaining {
         "test": "case",
       },
-      "g": Satisfies
+      "g": Satisfies,
     },
   },
 }`);


### PR DESCRIPTION
<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This PR adds a new matcher, `expect.satisfies(predicate)`, similar to `toSatisfy` matcher from the `jest-extended` package but implemented as an asymmetric matcher for more flexibility. It is useful for composing with other expectation functions to test for arbitrary conditions without going outside the `expect(subject).toVerb(object)` pattern.

For example, consider the example code for `expect.objectContaining(object)`, but modified to accept only even numbers:

```js
test('onPress gets called with the right thing', () => {
  const onPress = jest.fn();
  simulatePresses(onPress);
  const isEven = (n) => n % 2 === 0;
  expect(onPress).toHaveBeenCalledWith(
    expect.objectContaining({
      x: expect.satisfies(isEven), // Prints as "Satisfies isEven"
      y: expect.satisfies(isEven),
    }),
  );
});
```

Without `expect.satisfies`, the `expect` call has to be totally rewritten in a way that's harder to read and produces much less helpful error messages:

```js
let isOk = false;
for (const [arg] of onPress.mock.calls) {
  if (isEven(arg.x) && isEven(arg.y)) {
    isOk = true;
    break;
  }
}
expect(isOk).toBe(true);
```

For further motivation, consider the [Truly](https://github.com/google/googletest/blob/main/docs/reference/matchers.md#adapters-for-matchers) matcher from Gtest, which is used [in numerous places in Chromium](https://source.chromium.org/search?q=Truly%5C\(%20file:.*test.cc%20-file:third_party&sq=&ss=chromium).

## Test plan

This PR includes full unit tests for the new functionality.