### PR TITLE
Update MongoDB.md docs to reflect MongoDB Node.js driver 4.0 api 

### DIFF
--- a/website/versioned_docs/version-29.5/MongoDB.md
+++ b/website/versioned_docs/version-29.5/MongoDB.md
@@ -33,10 +33,7 @@ describe('insert', () => {
   let db;
 
   beforeAll(async () => {
-    connection = await MongoClient.connect(globalThis.__MONGO_URI__, {
-      useNewUrlParser: true,
-      useUnifiedTopology: true,
-    });
+    connection = await MongoClient.connect(globalThis.__MONGO_URI__);
     db = await connection.db(globalThis.__MONGO_DB_NAME__);
   });
 


### PR DESCRIPTION
The arguments 'useNewUrlParser', 'useUnifiedTopology'  are no longer available  from MongoDB Node.js Driver 4.0.

sources: https://www.mongodb.com/community/forums/t/argument-of-type-usenewurlparser-boolean-useunifiedtopology-boolean-is-not-assignable-to-parameter-of-type/169033

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The documentation [here](https://jestjs.io/docs/mongodb)  provided here is no longer up to date as it provides instructions that no longer work.
