### PR TITLE
fix: use right way to reverse state in examples code 'CheckboxWithLabel.js'

### DIFF
--- a/examples/react-testing-library/CheckboxWithLabel.js
+++ b/examples/react-testing-library/CheckboxWithLabel.js
@@ -6,7 +6,7 @@ export default function CheckboxWithLabel({labelOn, labelOff}) {
   const [isChecked, setIsChecked] = useState(false);
 
   const onChange = () => {
-    setIsChecked(!isChecked);
+    setIsChecked((draft) => !draft);
   };
 
   return (

--- a/examples/react-testing-library/CheckboxWithLabel.js
+++ b/examples/react-testing-library/CheckboxWithLabel.js
@@ -6,7 +6,7 @@ export default function CheckboxWithLabel({labelOn, labelOff}) {
   const [isChecked, setIsChecked] = useState(false);
 
   const onChange = () => {
-    setIsChecked((draft) => !draft);
+    setIsChecked(draft => !draft);
   };
 
   return (


### PR DESCRIPTION
## Summary

Fix input event handler function `onChange`: use the callback function to reverse the state

## Test plan
I only edit the examples code for docs, it needn't be tested.
