### PR TITLE
docs: Update Es6ClassMocks.md

### DIFF
--- a/docs/Es6ClassMocks.md
+++ b/docs/Es6ClassMocks.md
@@ -311,7 +311,6 @@ You can mock/spy on them easily, here is an example:
 ```javascript
 // your jest test file below
 import SoundPlayer from './sound-player';
-import SoundPlayerConsumer from './sound-player-consumer';
 
 const staticMethodMock = jest
   .spyOn(SoundPlayer, 'brand')

--- a/website/versioned_docs/version-25.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-25.x/Es6ClassMocks.md
@@ -311,7 +311,6 @@ You can mock/spy on them easily, here is an example:
 ```javascript
 // your jest test file below
 import SoundPlayer from './sound-player';
-import SoundPlayerConsumer from './sound-player-consumer';
 
 const staticMethodMock = jest
   .spyOn(SoundPlayer, 'brand')

--- a/website/versioned_docs/version-26.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-26.x/Es6ClassMocks.md
@@ -311,7 +311,6 @@ You can mock/spy on them easily, here is an example:
 ```javascript
 // your jest test file below
 import SoundPlayer from './sound-player';
-import SoundPlayerConsumer from './sound-player-consumer';
 
 const staticMethodMock = jest
   .spyOn(SoundPlayer, 'brand')

--- a/website/versioned_docs/version-27.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-27.x/Es6ClassMocks.md
@@ -311,7 +311,6 @@ You can mock/spy on them easily, here is an example:
 ```javascript
 // your jest test file below
 import SoundPlayer from './sound-player';
-import SoundPlayerConsumer from './sound-player-consumer';
 
 const staticMethodMock = jest
   .spyOn(SoundPlayer, 'brand')

--- a/website/versioned_docs/version-28.x/Es6ClassMocks.md
+++ b/website/versioned_docs/version-28.x/Es6ClassMocks.md
@@ -311,7 +311,6 @@ You can mock/spy on them easily, here is an example:
 ```javascript
 // your jest test file below
 import SoundPlayer from './sound-player';
-import SoundPlayerConsumer from './sound-player-consumer';
 
 const staticMethodMock = jest
   .spyOn(SoundPlayer, 'brand')

--- a/website/versioned_docs/version-29.0/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.0/Es6ClassMocks.md
@@ -311,7 +311,6 @@ You can mock/spy on them easily, here is an example:
 ```javascript
 // your jest test file below
 import SoundPlayer from './sound-player';
-import SoundPlayerConsumer from './sound-player-consumer';
 
 const staticMethodMock = jest
   .spyOn(SoundPlayer, 'brand')

--- a/website/versioned_docs/version-29.1/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.1/Es6ClassMocks.md
@@ -311,7 +311,6 @@ You can mock/spy on them easily, here is an example:
 ```javascript
 // your jest test file below
 import SoundPlayer from './sound-player';
-import SoundPlayerConsumer from './sound-player-consumer';
 
 const staticMethodMock = jest
   .spyOn(SoundPlayer, 'brand')

--- a/website/versioned_docs/version-29.2/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.2/Es6ClassMocks.md
@@ -311,7 +311,6 @@ You can mock/spy on them easily, here is an example:
 ```javascript
 // your jest test file below
 import SoundPlayer from './sound-player';
-import SoundPlayerConsumer from './sound-player-consumer';
 
 const staticMethodMock = jest
   .spyOn(SoundPlayer, 'brand')

--- a/website/versioned_docs/version-29.3/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.3/Es6ClassMocks.md
@@ -311,7 +311,6 @@ You can mock/spy on them easily, here is an example:
 ```javascript
 // your jest test file below
 import SoundPlayer from './sound-player';
-import SoundPlayerConsumer from './sound-player-consumer';
 
 const staticMethodMock = jest
   .spyOn(SoundPlayer, 'brand')

--- a/website/versioned_docs/version-29.4/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.4/Es6ClassMocks.md
@@ -311,7 +311,6 @@ You can mock/spy on them easily, here is an example:
 ```javascript
 // your jest test file below
 import SoundPlayer from './sound-player';
-import SoundPlayerConsumer from './sound-player-consumer';
 
 const staticMethodMock = jest
   .spyOn(SoundPlayer, 'brand')

--- a/website/versioned_docs/version-29.5/Es6ClassMocks.md
+++ b/website/versioned_docs/version-29.5/Es6ClassMocks.md
@@ -311,7 +311,6 @@ You can mock/spy on them easily, here is an example:
 ```javascript
 // your jest test file below
 import SoundPlayer from './sound-player';
-import SoundPlayerConsumer from './sound-player-consumer';
 
 const staticMethodMock = jest
   .spyOn(SoundPlayer, 'brand')


### PR DESCRIPTION
Removes unnecessary import from an example

## Summary

In ES6ClassMocks there is an example with two imports, the second one shouldn't be there

## Test plan

N/A