### PR TITLE
chore: replace `peter-evans/close-issue` action with gh CLI usage

### DIFF
--- a/.github/workflows/issues.yml
+++ b/.github/workflows/issues.yml
@@ -12,17 +12,15 @@ jobs:
     name: Questions
     runs-on: ubuntu-latest
     steps:
-      - name: Close Issue
-        uses: peter-evans/close-issue@v2
-        if: "${{ github.event.label.name == ':speech_balloon: Question' }}"
-        with:
-          comment: Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/jestjs) or our [discord channel](https://discord.gg/j6FKKQQrW9) for questions.
+      - if: "${{ github.event.label.name == ':speech_balloon: Question' }}"
+        run: gh issue close ${{ github.event.issue.number }} --comment "Please note this issue tracker is not a help forum. We recommend using [StackOverflow](https://stackoverflow.com/questions/tagged/jestjs) or our [discord channel](https://discord.gg/j6FKKQQrW9) for questions."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   bug-without-repro:
     name: Bug reports without reproductions
     runs-on: ubuntu-latest
     steps:
-      - name: Close Issue
-        uses: peter-evans/close-issue@v2
-        if: "${{ github.event.label.name == 'Needs Reproduction' }}"
-        with:
-          comment: As noted in the [Bug Report template](https://github.com/facebook/jest/blob/main/.github/ISSUE_TEMPLATE/bug.yml), all bug reports requires a minimal reproduction. Please open up a new issue providing one. Read more at https://stackoverflow.com/help/minimal-reproducible-example.
+      - if: "${{ github.event.label.name == 'Needs Reproduction' }}"
+        run: gh issue close ${{ github.event.issue.number }} --comment "As noted in the [Bug Report template](https://github.com/jestjs/jest/blob/main/.github/ISSUE_TEMPLATE/bug.yml), all bug reports requires a minimal reproduction. Please open up a new issue providing one. Read more at https://stackoverflow.com/help/minimal-reproducible-example."
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

As noted in its readme, the action isn't needed: https://github.com/peter-evans/close-issue

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

🤷 

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
