### PR TITLE
Fix vulnerability of regular expression denial of service by upgrading semver to 7.5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixes
 
+- `[semver]` Fix vulnerability of regular expression denial of service by upgrading semver to 7.5.3 ([#14262](https://github.com/jestjs/jest/pull/14262))
 - `[jest-circus]` Prevent false test failures caused by promise rejections handled asynchronously ([#14110](https://github.com/jestjs/jest/pull/14110))
 - `[jest-config]` Handle frozen config object ([#14054](https://github.com/facebook/jest/pull/14054))
 - `[jest-config]` Allow `coverageDirectory` and `collectCoverageFrom` in project config ([#14180](https://github.com/jestjs/jest/pull/14180))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 
 ### Fixes
 
-- `[*]` Update `semver` dependency to get vulnerability fix ([#14262](https://github.com/jestjs/jest/pull/14262))
 - `[jest-circus]` Prevent false test failures caused by promise rejections handled asynchronously ([#14110](https://github.com/jestjs/jest/pull/14110))
 - `[jest-config]` Handle frozen config object ([#14054](https://github.com/facebook/jest/pull/14054))
 - `[jest-config]` Allow `coverageDirectory` and `collectCoverageFrom` in project config ([#14180](https://github.com/jestjs/jest/pull/14180))
@@ -26,6 +25,7 @@
 
 ### Chore & Maintenance
 
+- `[*]` Update `semver` dependency to get vulnerability fix ([#14262](https://github.com/jestjs/jest/pull/14262))
 - `[docs]` Updated documentation for the `--runTestsByPath` CLI command ([#14004](https://github.com/facebook/jest/pull/14004))
 - `[docs]` Updated documentation regarding the synchronous fallback when asynchronous code transforms are unavailable ([#14056](https://github.com/facebook/jest/pull/14056))
 - `[docs]` Update jest statistics of use and downloads in website Index.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- `[semver]` Fix vulnerability of regular expression denial of service by upgrading semver to 7.5.3 ([#14262](https://github.com/jestjs/jest/pull/14262))
+- `[*]` Update `semver` dependency to get vulnerability fix ([#14262](https://github.com/jestjs/jest/pull/14262))
 - `[jest-circus]` Prevent false test failures caused by promise rejections handled asynchronously ([#14110](https://github.com/jestjs/jest/pull/14110))
 - `[jest-config]` Handle frozen config object ([#14054](https://github.com/facebook/jest/pull/14054))
 - `[jest-config]` Allow `coverageDirectory` and `collectCoverageFrom` in project config ([#14180](https://github.com/jestjs/jest/pull/14180))

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "read-pkg": "^5.2.0",
     "resolve": "^1.20.0",
     "rimraf": "^5.0.0",
-    "semver": "^7.5.2",
+    "semver": "^7.5.3",
     "slash": "^3.0.0",
     "string-length": "^4.0.1",
     "strip-ansi": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "read-pkg": "^5.2.0",
     "resolve": "^1.20.0",
     "rimraf": "^5.0.0",
-    "semver": "^7.3.5",
+    "semver": "^7.5.2",
     "slash": "^3.0.0",
     "string-length": "^4.0.1",
     "strip-ansi": "^6.0.0",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -57,7 +57,7 @@
     "@types/graceful-fs": "^4.1.3",
     "@types/micromatch": "^4.0.1",
     "@types/parse-json": "^4.0.0",
-    "semver": "^7.3.5",
+    "semver": "^7.5.2",
     "ts-node": "^10.5.0",
     "typescript": "^5.0.4"
   },

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -57,7 +57,7 @@
     "@types/graceful-fs": "^4.1.3",
     "@types/micromatch": "^4.0.1",
     "@types/parse-json": "^4.0.0",
-    "semver": "^7.5.2",
+    "semver": "^7.5.3",
     "ts-node": "^10.5.0",
     "typescript": "^5.0.4"
   },

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -37,7 +37,7 @@
     "jest-util": "workspace:^",
     "natural-compare": "^1.4.0",
     "pretty-format": "workspace:^",
-    "semver": "^7.3.5"
+    "semver": "^7.5.2"
   },
   "devDependencies": {
     "@babel/preset-flow": "^7.7.2",

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -37,7 +37,7 @@
     "jest-util": "workspace:^",
     "natural-compare": "^1.4.0",
     "pretty-format": "workspace:^",
-    "semver": "^7.5.2"
+    "semver": "^7.5.3"
   },
   "devDependencies": {
     "@babel/preset-flow": "^7.7.2",

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -18,7 +18,7 @@
     "ansi-regex": "^5.0.1",
     "ansi-styles": "^5.0.0",
     "pretty-format": "workspace:^",
-    "semver": "^7.3.5"
+    "semver": "^7.5.2"
   },
   "devDependencies": {
     "@types/semver": "^7.1.0"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -18,7 +18,7 @@
     "ansi-regex": "^5.0.1",
     "ansi-styles": "^5.0.0",
     "pretty-format": "workspace:^",
-    "semver": "^7.5.2"
+    "semver": "^7.5.3"
   },
   "devDependencies": {
     "@types/semver": "^7.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2905,7 +2905,7 @@ __metadata:
     read-pkg: ^5.2.0
     resolve: ^1.20.0
     rimraf: ^5.0.0
-    semver: ^7.3.5
+    semver: ^7.5.2
     slash: ^3.0.0
     string-length: ^4.0.1
     strip-ansi: ^6.0.0
@@ -3035,7 +3035,7 @@ __metadata:
     ansi-regex: ^5.0.1
     ansi-styles: ^5.0.0
     pretty-format: "workspace:^"
-    semver: ^7.3.5
+    semver: ^7.5.2
   languageName: unknown
   linkType: soft
 
@@ -12541,7 +12541,7 @@ __metadata:
     micromatch: ^4.0.4
     parse-json: ^5.2.0
     pretty-format: "workspace:^"
-    semver: ^7.3.5
+    semver: ^7.5.2
     slash: ^3.0.0
     strip-json-comments: ^3.1.1
     ts-node: ^10.5.0
@@ -12993,7 +12993,7 @@ __metadata:
     natural-compare: ^1.4.0
     prettier: ^2.1.1
     pretty-format: "workspace:^"
-    semver: ^7.3.5
+    semver: ^7.5.2
     tsd-lite: ^0.7.0
   languageName: unknown
   linkType: soft
@@ -18565,14 +18565,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.1":
-  version: 7.5.2
-  resolution: "semver@npm:7.5.2"
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.1, semver@npm:^7.5.2":
+  version: 7.5.3
+  resolution: "semver@npm:7.5.3"
   dependencies:
     lru-cache: ^6.0.0
   bin:
     semver: bin/semver.js
-  checksum: 3fdf5d1e6f170fe8bcc41669e31787649af91af7f54f05c71d0865bb7aa27e8b92f68b3e6b582483e2c1c648008bc84249d2cd86301771fe5cbf7621d1fe5375
+  checksum: 9d58db16525e9f749ad0a696a1f27deabaa51f66e91d2fa2b0db3de3e9644e8677de3b7d7a03f4c15bc81521e0c3916d7369e0572dbde250d9bedf5194e2a8a7
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2905,7 +2905,7 @@ __metadata:
     read-pkg: ^5.2.0
     resolve: ^1.20.0
     rimraf: ^5.0.0
-    semver: ^7.5.2
+    semver: ^7.5.3
     slash: ^3.0.0
     string-length: ^4.0.1
     strip-ansi: ^6.0.0
@@ -3035,7 +3035,7 @@ __metadata:
     ansi-regex: ^5.0.1
     ansi-styles: ^5.0.0
     pretty-format: "workspace:^"
-    semver: ^7.5.2
+    semver: ^7.5.3
   languageName: unknown
   linkType: soft
 
@@ -12541,7 +12541,7 @@ __metadata:
     micromatch: ^4.0.4
     parse-json: ^5.2.0
     pretty-format: "workspace:^"
-    semver: ^7.5.2
+    semver: ^7.5.3
     slash: ^3.0.0
     strip-json-comments: ^3.1.1
     ts-node: ^10.5.0
@@ -12993,7 +12993,7 @@ __metadata:
     natural-compare: ^1.4.0
     prettier: ^2.1.1
     pretty-format: "workspace:^"
-    semver: ^7.5.2
+    semver: ^7.5.3
     tsd-lite: ^0.7.0
   languageName: unknown
   linkType: soft
@@ -18565,7 +18565,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.1, semver@npm:^7.5.2":
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.1, semver@npm:^7.5.3":
   version: 7.5.3
   resolution: "semver@npm:7.5.3"
   dependencies:


### PR DESCRIPTION
### **Summary**
At the moment, Jest uses version 7.3.5 of semver. The problem arises when launching the command 'yarn audit' due to a vulnerability in regular expression denial of service via the function 'new Range'. You can find more information about this vulnerability in the following reference: https://github.com/advisories/GHSA-c2qf-rxjj-qqgw

This pull request (PR) proposes upgrading the semver dependency to version 7.5.2 because it includes the necessary patches for versions greater than or equal to 7.5.2.

### **Test plan**
Green CI

Thanks !