### PR TITLE
chore: use glob@10 in buils scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-prettier": "^4.0.0",
     "execa": "^5.0.0",
     "find-process": "^1.4.1",
-    "glob": "^8.0.0",
+    "glob": "^10.0.0",
     "graceful-fs": "^4.2.9",
     "isbinaryfile": "^5.0.0",
     "istanbul-lib-coverage": "^3.0.0",

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -21,7 +21,7 @@ import * as path from 'path';
 import {fileURLToPath} from 'url';
 import babel from '@babel/core';
 import chalk from 'chalk';
-import glob from 'glob';
+import {sync as globSync} from 'glob';
 import fs from 'graceful-fs';
 import micromatch from 'micromatch';
 import prettier from 'prettier';
@@ -62,7 +62,7 @@ function getBuildPath(file, buildFolder) {
 
 function buildNodePackage({packageDir, pkg}) {
   const srcDir = path.resolve(packageDir, SRC_DIR);
-  const files = glob.sync('**/*', {absolute: true, cwd: srcDir, nodir: true});
+  const files = globSync('**/*', {absolute: true, cwd: srcDir, nodir: true});
 
   process.stdout.write(adjustToTerminalWidth(`${pkg.name}\n`));
 

--- a/scripts/buildTs.mjs
+++ b/scripts/buildTs.mjs
@@ -10,7 +10,7 @@ import * as os from 'os';
 import * as path from 'path';
 import chalk from 'chalk';
 import execa from 'execa';
-import glob from 'glob';
+import {sync as globSync} from 'glob';
 import fs from 'graceful-fs';
 import pLimit from 'p-limit';
 import stripJsonComments from 'strip-json-comments';
@@ -107,7 +107,7 @@ packagesWithTs.forEach(({packageDir, pkg}) => {
     '@jest/test-utils',
   );
 
-  const tsConfigPaths = glob.sync('**/__tests__/tsconfig.json', {
+  const tsConfigPaths = globSync('**/__tests__/tsconfig.json', {
     absolute: true,
     cwd: packageDir,
   });
@@ -185,7 +185,7 @@ try {
   await Promise.all(
     packagesWithTs.map(({packageDir, pkg}) =>
       mutex(async () => {
-        const matched = glob.sync('build/**/*.d.ts', {
+        const matched = globSync('build/**/*.d.ts', {
           absolute: true,
           cwd: packageDir,
         });

--- a/scripts/cleanE2e.mjs
+++ b/scripts/cleanE2e.mjs
@@ -7,7 +7,7 @@
 
 import {dirname, normalize, resolve} from 'path';
 import {fileURLToPath} from 'url';
-import glob from 'glob';
+import {sync as globSync} from 'glob';
 import fs from 'graceful-fs';
 
 const excludedModules = [
@@ -23,7 +23,7 @@ const excludedModules = [
 
 const rootDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
-const e2eNodeModules = glob.sync('e2e/{*,*/*}/node_modules/', {
+const e2eNodeModules = globSync('e2e/{*,*/*}/node_modules/', {
   absolute: true,
   cwd: rootDir,
   ignore: excludedModules,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2876,7 +2876,7 @@ __metadata:
     eslint-plugin-prettier: ^4.0.0
     execa: ^5.0.0
     find-process: ^1.4.1
-    glob: ^8.0.0
+    glob: ^10.0.0
     graceful-fs: ^4.2.9
     isbinaryfile: ^5.0.0
     istanbul-lib-coverage: ^3.0.0
@@ -10621,7 +10621,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.2.5":
+"glob@npm:^10.0.0, glob@npm:^10.2.5":
   version: 10.3.0
   resolution: "glob@npm:10.3.0"
   dependencies:
@@ -10650,7 +10650,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.0, glob@npm:^8.0.1":
+"glob@npm:^8.0.1":
   version: 8.1.0
   resolution: "glob@npm:8.1.0"
   dependencies:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

`glob@9+` only supports Node 16, so this needs to wait for Jest 30. But I wanna upgrade our own usage of it separately from the published packages.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
