### PR TITLE
Mock node modules with node: URL scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -223,6 +223,7 @@
 
 ### Fixes
 
+- `[jest-runtime, jest-resolve]` Allow core modules to be mocked with the `node:` URL scheme ([#14297](https://github.com/jestjs/jest/pull/14297))
 - `[jest-circus]` Prevent false test failures caused by promise rejections handled asynchronously ([#14110](https://github.com/jestjs/jest/pull/14110))
 - `[jest-config]` Handle frozen config object ([#14054](https://github.com/facebook/jest/pull/14054))
 - `[jest-config]` Allow `coverageDirectory` and `collectCoverageFrom` in project config ([#14180](https://github.com/jestjs/jest/pull/14180))

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -41,7 +41,7 @@ exports[`moduleNameMapper wrong array configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:1177:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:1184:17)
       at Object.require (index.js:10:1)
       at Object.require (__tests__/index.js:10:20)"
 `;
@@ -71,7 +71,7 @@ exports[`moduleNameMapper wrong configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:1177:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:1184:17)
       at Object.require (index.js:10:1)
       at Object.require (__tests__/index.js:10:20)"
 `;

--- a/e2e/__tests__/nodeURLManualMocks.test.js
+++ b/e2e/__tests__/nodeURLManualMocks.test.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import runJest from '../runJest';
+
+test('supports node url manual mocks', () => {
+  const result = runJest('node-url-manual-mocks');
+  expect(result.exitCode).toBe(0);
+});

--- a/e2e/node-url-manual-mocks/__mocks__/fs.js
+++ b/e2e/node-url-manual-mocks/__mocks__/fs.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const {mock} = require('../testUtils');
+console.log(mock);
+module.exports = mock;

--- a/e2e/node-url-manual-mocks/__tests__/importAndMock.test.js
+++ b/e2e/node-url-manual-mocks/__tests__/importAndMock.test.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const fs = require('node:fs');
+const {expectModuleMocked} = require('../testUtils');
+
+jest.mock('node:fs');
+
+it('correctly mocks the module', () => {
+  expectModuleMocked(fs);
+});

--- a/e2e/node-url-manual-mocks/__tests__/importOnly.test.js
+++ b/e2e/node-url-manual-mocks/__tests__/importOnly.test.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const fs = require('node:fs');
+const {expectModuleMocked} = require('../testUtils');
+
+jest.mock('fs');
+
+it('correctly mocks the module', () => {
+  expectModuleMocked(fs);
+});

--- a/e2e/node-url-manual-mocks/__tests__/mockOnly.test.js
+++ b/e2e/node-url-manual-mocks/__tests__/mockOnly.test.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const fs = require('fs');
+const {expectModuleMocked} = require('../testUtils');
+
+jest.mock('node:fs');
+
+it('correctly mocks the module', () => {
+  expectModuleMocked(fs);
+});

--- a/e2e/node-url-manual-mocks/package.json
+++ b/e2e/node-url-manual-mocks/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/e2e/node-url-manual-mocks/testUtils.js
+++ b/e2e/node-url-manual-mocks/testUtils.js
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+const mock = {};
+module.exports.mock = mock;
+
+module.exports.expectModuleMocked = module => {
+  // eslint-disable-next-line no-undef
+  expect(module).toBe(mock);
+};

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -30,6 +30,7 @@ export default {
     'packages/jest-runtime/src/__tests__/test_root.*',
     'website/.*',
     'e2e/runtime-internal-module-registry/__mocks__',
+    'e2e/node-url-manual-mocks/__mocks__',
   ],
   projects: ['<rootDir>', '<rootDir>/examples/*/'],
   snapshotFormat: {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
Allow modules that use `node:` paths, i.e. `node:fs`, to be mocked and mapped to manual mocks appropriately.

With Node adopting the aforementioned URL scheme, more users will migrate to it and expect their tools to support it. 

Jest already incorporates checks for the URL scheme but not for mapping mocks and module names. 

With this change, Jest strips the URL when resolving mocks and assigning `moduleID`s, making any of the following test setups in the next section valid and point to the same module.

[Source issue](https://github.com/jestjs/jest/issues/14040)

## Test plan

The change resolves the URL to the module name, so the following 3 e2e tests were added to verify that by checking if the `fs` module was mocked in the following 3 scenarios.

Realistically, the first scenario is the target use case.

```js
// URL scheme for imports and mocks
const fs = require('node:fs')
jest.mock('node:fs')
```
```js
// URL scheme only when mocking
const fs = require('fs')
jest.mock('node:fs')
```
```js
// URL scheme only when importing
const fs = require('node:fs')
jest.mock('fs')
```
