### PR TITLE
fixed youtube line issue in architecture markdown

### DIFF
--- a/docs/Architecture.md
+++ b/docs/Architecture.md
@@ -3,14 +3,9 @@ id: architecture
 title: Architecture
 ---
 
-import LiteYouTubeEmbed from 'react-lite-youtube-embed';
 
-If you are interested in learning more about how Jest works, understand its architecture, and how Jest is split up into individual reusable packages, check out this video:
+If you are interested in learning more about how Jest works, understand its architecture, and how Jest is split up into individual reusable packages, [check out this video](https://youtu.be/3YDiloj8_d0)
 
-<LiteYouTubeEmbed id="3YDiloj8_d0" />
-
-If you'd like to learn how to build a testing framework like Jest from scratch, check out this video:
-
-<LiteYouTubeEmbed id="B8FbUK0WpVU" />
+If you'd like to learn how to build a testing framework like Jest from scratch, [check out this video](https://youtu.be/B8FbUK0WpVU)
 
 There is also a [written guide you can follow](https://cpojer.net/posts/building-a-javascript-testing-framework). It teaches the fundamental concepts of Jest and explains how various parts of Jest can be used to compose a custom testing framework.


### PR DESCRIPTION

## Summary
In the architecture markdown the youtube link are not showing which cause problem if someone wants to understand about jest throught those video like me , In the markdown we are using LiteYouTubeEmbed  to embed the video but it is not showing i tried to find solution for it but markdown as convention should not have this I also came across a solution to use Gatsby for solving this but it would be not beneficial you use it in this use case so i just added those links normally , I hope this is helpful and any question please ask to improve this PR

