### PR TITLE
fix: incorrectly setting the name of currently running concurrent test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- `[jest-circus]` Fix snapshot matchers in concurrent tests when nr of tests exceeds `maxConcurrency` ([#14335](https://github.com/jestjs/jest/pull/14335))
 - `[jest-snapshot]` Move `@types/prettier` from `dependencies` to `devDependencies` ([#14328](https://github.com/jestjs/jest/pull/14328))
 
 ### Chore & Maintenance

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -140,9 +140,8 @@ function startTestsConcurrently(concurrentTests: Array<ConcurrentTestEntry>) {
   jestExpect.setState({currentConcurrentTestName: testNameStorage});
   for (const test of concurrentTests) {
     try {
-      const promise = testNameStorage.run(getTestID(test), () =>
-        mutex(test.fn),
-      );
+      const testFn = test.fn;
+      const promise = mutex(() => testNameStorage.run(getTestID(test), testFn));
       // Avoid triggering the uncaught promise rejection handler in case the
       // test fails before being awaited on.
       // eslint-disable-next-line @typescript-eslint/no-empty-function


### PR DESCRIPTION
## Summary

There was a bug in my previous submission (https://github.com/jestjs/jest/pull/14139).

Test functions lose their async context when throttled by p-limit. This caused snapshot matchers not to work properly when the number of concurrent tests in a file was greater than the `maxConcurrency` config option (which is 5 by default).

The fix is to set `AsyncLocalStorage` inside the throttled function.

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Test plan

Verified manually.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
