### PR TITLE
feat(draft): custom folder to avoid repetitions with `__mocks__`

### DIFF
--- a/e2e/custom-mocks-pattern/__tests__/useMockedAddWithCustomPath.test.js
+++ b/e2e/custom-mocks-pattern/__tests__/useMockedAddWithCustomPath.test.js
@@ -1,0 +1,6 @@
+jest.mock('add');
+
+test('use mocked add method with custom path', () => {
+  const result = require('add')(1, 1);
+  expect(result).toBe(2);
+});

--- a/e2e/custom-mocks-pattern/jest.config.js
+++ b/e2e/custom-mocks-pattern/jest.config.js
@@ -1,0 +1,8 @@
+const path = require('node:path');
+
+/** @type {import('jest').Config} */
+const config = {
+  customMockPath: path.resolve(__dirname, 'myMocks'),
+};
+
+module.exports = config;

--- a/e2e/custom-mocks-pattern/myMocks/add.js
+++ b/e2e/custom-mocks-pattern/myMocks/add.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = (x, y) => x + y;

--- a/packages/jest-resolve-dependencies/src/index.ts
+++ b/packages/jest-resolve-dependencies/src/index.ts
@@ -79,10 +79,9 @@ export class DependencyResolver {
       }
 
       if (resolvedMockDependency != null) {
-        const dependencyMockDir = path.resolve(
-          path.dirname(resolvedDependency),
-          '__mocks__',
-        );
+        const dependencyMockDir = options?.customMockPath != null 
+          ? path.resolve(path.dirname(resolvedDependency), '__mocks__')
+          : options?.customMockPath;
 
         resolvedMockDependency = path.resolve(resolvedMockDependency);
 

--- a/packages/jest-resolve-dependencies/src/index.ts
+++ b/packages/jest-resolve-dependencies/src/index.ts
@@ -79,9 +79,12 @@ export class DependencyResolver {
       }
 
       if (resolvedMockDependency != null) {
-        const dependencyMockDir = options?.customMockPath != null 
-          ? path.resolve(path.dirname(resolvedDependency), '__mocks__')
-          : options?.customMockPath;
+        // eslint-disable-next-line no-console
+        console.log(options?.customMockPath);
+        const dependencyMockDir =
+          options?.customMockPath != null
+            ? path.resolve(path.dirname(resolvedDependency), '__mocks__')
+            : options?.customMockPath;
 
         resolvedMockDependency = path.resolve(resolvedMockDependency);
 

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -39,6 +39,7 @@ export type ResolveModuleConfig = {
   conditions?: Array<string>;
   skipNodeResolution?: boolean;
   paths?: Array<string>;
+  customMockPath?: string;
 };
 
 const NATIVE_PLATFORM = 'native';

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -239,6 +239,7 @@ export type InitialOptions = Partial<{
   coverageProvider: CoverageProvider;
   coverageReporters: CoverageReporters;
   coverageThreshold: CoverageThreshold;
+  customMockPath?: string;
   dependencyExtractor: string;
   detectLeaks: boolean;
   detectOpenHandles: boolean;

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -438,6 +438,7 @@ export type ProjectConfig = {
   collectCoverageFrom: Array<string>;
   coverageDirectory: string;
   coveragePathIgnorePatterns: Array<string>;
+  customMockPath?: string;
   cwd: string;
   dependencyExtractor?: string;
   detectLeaks: boolean;


### PR DESCRIPTION
## Summary

Implement `customMocks` folder feature to avoid `__mocks__` folder repetition in monorepos or similar situations (see issue #13647).

Work in progress.

## Test plan

 - [ ] current tests are passing
 - [ ]  add units tests
 - [x] add e2e tests
 - [ ] add type tests
 - [ ] documentation
