### PR TITLE
[WIP] Implement new "standalone" snapshots.

### DIFF
--- a/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
+++ b/packages/jest-snapshot/src/__tests__/printSnapshot.test.ts
@@ -35,6 +35,7 @@ import {
   printPropertiesAndReceived,
   printSnapshotAndReceived,
 } from '../printSnapshot';
+import type {InlineSnapshotKind} from '../types';
 import {serialize} from '../utils';
 
 const aOpenForeground1 = styles.magenta.open;
@@ -517,11 +518,11 @@ describe('pass false', () => {
           promise: '',
           snapshotState: {
             expand: false,
-            match({inlineSnapshot, received}) {
+            match({kind, received}) {
               return {
                 actual: format(received),
                 count: 1,
-                expected: inlineSnapshot,
+                expected: (kind as InlineSnapshotKind).value,
                 pass: false,
               };
             },
@@ -711,11 +712,11 @@ describe('pass false', () => {
         promise: '',
         snapshotState: {
           expand: false,
-          match({inlineSnapshot, received}) {
+          match({kind, received}) {
             return {
               actual: format(received),
               count: 1,
-              expected: inlineSnapshot,
+              expected: (kind as InlineSnapshotKind).value,
               pass: false,
             };
           },

--- a/packages/jest-snapshot/src/__tests__/utils.test.ts
+++ b/packages/jest-snapshot/src/__tests__/utils.test.ts
@@ -42,13 +42,13 @@ test('testNameToKey', () => {
   expect(testNameToKey('abc cde ', 12)).toBe('abc cde  12');
 });
 
-test('saveSnapshotFile() works with \r\n', () => {
+test('saveSnapshotFile() works with \\r\\n', () => {
   const filename = path.join(__dirname, 'remove-newlines.snap');
-  const data = {
+  const grouped = {
     myKey: '<div>\r\n</div>',
   };
 
-  saveSnapshotFile(data, filename);
+  saveSnapshotFile({grouped}, filename);
   expect(fs.writeFileSync).toHaveBeenCalledWith(
     filename,
     `// Jest Snapshot v1, ${SNAPSHOT_GUIDE_LINK}\n\n` +
@@ -56,13 +56,13 @@ test('saveSnapshotFile() works with \r\n', () => {
   );
 });
 
-test('saveSnapshotFile() works with \r', () => {
+test('saveSnapshotFile() works with \\r', () => {
   const filename = path.join(__dirname, 'remove-newlines.snap');
-  const data = {
+  const grouped = {
     myKey: '<div>\r</div>',
   };
 
-  saveSnapshotFile(data, filename);
+  saveSnapshotFile({grouped}, filename);
   expect(fs.writeFileSync).toHaveBeenCalledWith(
     filename,
     `// Jest Snapshot v1, ${SNAPSHOT_GUIDE_LINK}\n\n` +
@@ -170,7 +170,7 @@ test('escaping', () => {
   const writeFileSync = jest.mocked(fs.writeFileSync);
 
   writeFileSync.mockReset();
-  saveSnapshotFile({key: data}, filename);
+  saveSnapshotFile({grouped: {key: data}}, filename);
   const writtenData = writeFileSync.mock.calls[0][1];
   expect(writtenData).toBe(
     `// Jest Snapshot v1, ${SNAPSHOT_GUIDE_LINK}\n\n` +

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -202,7 +202,7 @@ export const toMatchSnapshot: MatcherFunctionWithContext<
   return _toMatchSnapshot({
     context: this,
     hint,
-    isInline: false,
+    kind: {kind: 'grouped'},
     matcherName,
     properties,
     received,
@@ -261,11 +261,13 @@ export const toMatchInlineSnapshot: MatcherFunctionWithContext<
 
   return _toMatchSnapshot({
     context: this,
-    inlineSnapshot:
-      inlineSnapshot !== undefined
-        ? stripAddedIndentation(inlineSnapshot)
-        : undefined,
-    isInline: true,
+    kind: {
+      kind: 'inline',
+      value:
+        inlineSnapshot !== undefined
+          ? stripAddedIndentation(inlineSnapshot)
+          : undefined,
+    },
     matcherName,
     properties,
     received,
@@ -273,8 +275,7 @@ export const toMatchInlineSnapshot: MatcherFunctionWithContext<
 };
 
 const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
-  const {context, hint, inlineSnapshot, isInline, matcherName, properties} =
-    config;
+  const {context, hint, kind, matcherName, properties} = config;
   let {received} = config;
 
   context.dontThrow && context.dontThrow();
@@ -356,8 +357,7 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
 
   const result = snapshotState.match({
     error: context.error,
-    inlineSnapshot,
-    isInline,
+    kind,
     received,
     testName: fullTestName,
   });
@@ -420,7 +420,7 @@ export const toThrowErrorMatchingSnapshot: MatcherFunctionWithContext<
     {
       context: this,
       hint,
-      isInline: false,
+      kind: {kind: 'grouped'},
       matcherName,
       received,
     },
@@ -453,11 +453,13 @@ export const toThrowErrorMatchingInlineSnapshot: MatcherFunctionWithContext<
   return _toThrowErrorMatchingSnapshot(
     {
       context: this,
-      inlineSnapshot:
-        inlineSnapshot !== undefined
-          ? stripAddedIndentation(inlineSnapshot)
-          : undefined,
-      isInline: true,
+      kind: {
+        kind: 'inline',
+        value:
+          inlineSnapshot !== undefined
+            ? stripAddedIndentation(inlineSnapshot)
+            : undefined,
+      },
       matcherName,
       received,
     },
@@ -469,8 +471,7 @@ const _toThrowErrorMatchingSnapshot = (
   config: MatchSnapshotConfig,
   fromPromise?: boolean,
 ) => {
-  const {context, hint, inlineSnapshot, isInline, matcherName, received} =
-    config;
+  const {context, hint, kind, matcherName, received} = config;
 
   context.dontThrow && context.dontThrow();
 
@@ -521,8 +522,7 @@ const _toThrowErrorMatchingSnapshot = (
   return _toMatchSnapshot({
     context,
     hint,
-    inlineSnapshot,
-    isInline,
+    kind,
     matcherName,
     received: error.message,
   });

--- a/packages/jest-snapshot/src/printSnapshot.ts
+++ b/packages/jest-snapshot/src/printSnapshot.ts
@@ -95,7 +95,7 @@ export const matcherHintFromConfig = (
   {
     context: {isNot, promise},
     hint,
-    inlineSnapshot,
+    kind,
     matcherName,
     properties,
   }: MatchSnapshotConfig,
@@ -117,7 +117,7 @@ export const matcherHintFromConfig = (
     if (typeof hint === 'string' && hint.length !== 0) {
       options.secondArgument = HINT_ARG;
       options.secondArgumentColor = BOLD_WEIGHT;
-    } else if (typeof inlineSnapshot === 'string') {
+    } else if (kind.kind === 'inline' && kind.value !== undefined) {
       options.secondArgument = SNAPSHOT_ARG;
       if (isUpdatable) {
         options.secondArgumentColor = aSnapshotColor;
@@ -129,7 +129,7 @@ export const matcherHintFromConfig = (
     if (typeof hint === 'string' && hint.length !== 0) {
       expectedArgument = HINT_ARG;
       options.expectedColor = BOLD_WEIGHT;
-    } else if (typeof inlineSnapshot === 'string') {
+    } else if (kind.kind === 'inline' && kind.value !== undefined) {
       expectedArgument = SNAPSHOT_ARG;
       if (isUpdatable) {
         options.expectedColor = aSnapshotColor;

--- a/packages/jest-snapshot/src/types.ts
+++ b/packages/jest-snapshot/src/types.ts
@@ -7,6 +7,7 @@
 
 import type {MatcherContext} from 'expect';
 import type {PrettyFormatOptions} from 'pretty-format';
+import type {InlineSnapshot} from './InlineSnapshots';
 import type SnapshotState from './State';
 
 export interface Context extends MatcherContext {
@@ -21,17 +22,32 @@ export interface FileSystem {
   matchFiles(pattern: RegExp | string): Array<string>;
 }
 
-export type MatchSnapshotConfig = {
+export type SnapshotKind = GroupedSnapshotKind | InlineSnapshotKind;
+
+export interface GroupedSnapshotKind {
+  kind: 'grouped';
+}
+
+export interface InlineSnapshotKind {
+  kind: 'inline';
+  value: string | undefined;
+}
+
+export interface MatchSnapshotConfig {
   context: Context;
   hint?: string;
-  inlineSnapshot?: string;
-  isInline: boolean;
+  kind: SnapshotKind;
   matcherName: string;
   properties?: object;
   received: any;
-};
+}
 
-export type SnapshotData = Record<string, string>;
+export interface SnapshotData {
+  grouped: Record<string, string>;
+  inline: Array<InlineSnapshot>;
+}
+
+export type FilePersistedSnapshotData = Omit<SnapshotData, 'inline'>;
 
 export interface SnapshotMatchers<R extends void | Promise<void>, T> {
   /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

https://github.com/jestjs/jest/issues/6383#issuecomment-1652106204

(More detail coming later.)

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## TODO

- How to name the standalone directory? Currently the PR just tacks `.standalone` onto the end.
  - Originally I wanted the standalone name to be the snapshot name minus `.snap`, but this meshes awkwardly with the `resolveSnapshotPath` API.
- Existing snapshots are versioned. An explicit goal of standalone snapshots is that they don't have any of the Jest export/comment metadata, since they should be legal files in whatever language they're serialized as. Should these be versioned?
- It is an explicit goal that users can provide an arbitrary extension that comes last on the standalone snapshot's file name so that other tools can infer the proper file type based on the file name. How does Jest know which files in the standalone directory are snapshots, and which are not?
  - Currently, the heuristic just looks for `.snap` in the filename. This seems too lax.
  - Even if users don't intend to put other files in these directories, some of their actions can cause files to appear there (`.DS_Store` comes to mind on macOS).
- Bikeshed: I renamed the old snapshots (internally) to "grouped" and the new ones are called "standalone".
