### PR TITLE
fix(expect): remove @types/node from dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[expect]` Remove `@types/node` from dependencies
+
 ### Chore & Maintenance
 
 ### Performance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[expect]` Remove `@types/node` from dependencies
+- `[expect]` Remove `@types/node` from dependencies ([#14385](https://github.com/jestjs/jest/pull/14385))
 
 ### Chore & Maintenance
 

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@jest/expect-utils": "workspace:^",
-    "@types/node": "*",
     "jest-get-type": "workspace:^",
     "jest-matcher-utils": "workspace:^",
     "jest-message-util": "workspace:^",

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -6,7 +6,6 @@
  *
  */
 
-import type {AsyncLocalStorage} from 'async_hooks';
 import type {EqualsFunction, Tester} from '@jest/expect-utils';
 import type * as jestMatcherUtils from 'jest-matcher-utils';
 import {INTERNAL_MATCHER_FLAG} from './jestMatchersObject';
@@ -58,7 +57,7 @@ export interface MatcherUtils {
 
 export interface MatcherState {
   assertionCalls: number;
-  currentConcurrentTestName?: AsyncLocalStorage<string>;
+  currentConcurrentTestName?: () => string | undefined;
   currentTestName?: string;
   error?: Error;
   expand?: boolean;

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -137,7 +137,9 @@ function collectConcurrentTests(
 function startTestsConcurrently(concurrentTests: Array<ConcurrentTestEntry>) {
   const mutex = pLimit(getState().maxConcurrency);
   const testNameStorage = new AsyncLocalStorage<string>();
-  jestExpect.setState({currentConcurrentTestName: testNameStorage});
+  jestExpect.setState({
+    currentConcurrentTestName: () => testNameStorage.getStore(),
+  });
   for (const test of concurrentTests) {
     try {
       const testFn = test.fn;

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -281,7 +281,7 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
 
   const {currentConcurrentTestName, isNot, snapshotState} = context;
   const currentTestName =
-    currentConcurrentTestName?.getStore() ?? context.currentTestName;
+    currentConcurrentTestName?.() ?? context.currentTestName;
 
   if (isNot) {
     throw new Error(

--- a/yarn.lock
+++ b/yarn.lock
@@ -9776,7 +9776,6 @@ __metadata:
     "@jest/expect-utils": "workspace:^"
     "@jest/test-utils": "workspace:^"
     "@tsd/typescript": ^5.0.4
-    "@types/node": "*"
     chalk: ^4.0.0
     immutable: ^4.0.0
     jest-get-type: "workspace:^"


### PR DESCRIPTION
## Summary

Remove `@types/node` from dependencies of `expect`. This package can be used in non-Node.js environments.

The dependency was introduced in #14139.
