### PR TITLE
fix: comparing different `URL` objects now return false

### DIFF
--- a/packages/expect-utils/src/jasmineUtils.ts
+++ b/packages/expect-utils/src/jasmineUtils.ts
@@ -125,6 +125,9 @@ function eq(
     // RegExps are compared by their source patterns and flags.
     case '[object RegExp]':
       return a.source === b.source && a.flags === b.flags;
+    // URLs are compared by their href property which contains the entire url string.
+    case '[object URL]':
+      return a.href === b.href;
   }
   if (typeof a !== 'object' || typeof b !== 'object') {
     return false;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Previously, jest would report this test as **PASS**.
```ts
test('url test', () => {
    expect(new URL("https://jestjs.io/")).toEqual(new URL("https://jestjs.io/docs/getting-started"));
});
```
In this pull request, this gets fixed and jest properly compares the two URL objects and reports **FAIL**.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
```ts
test('url test', () => {
    expect(new URL("https://jestjs.io/")).toEqual(new URL("https://jestjs.io/"));
});
// Results in PASS.
```
```ts
test('hash test', () => {
    expect(new URL("https://jestjs.io/docs/getting-started")).toEqual(new URL("https://jestjs.io/docs/getting-started#using-babel"));
});
// Results in FAIL.
```
