### PR TITLE
Dependency update for jest-reporters, addressing CVE-2022-25883

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-reporters]` Updating istanbul-lib-instrument dependency. istanbul-lib-instrument 6.0.0 has dropped support for node 10 and updated semver addressing CVE-2022-25883
+- `[jest-reporters]` Updating istanbul-lib-instrument dependency. istanbul-lib-instrument 6.0.0 has dropped support for node 10 and updated semver addressing CVE-2022-25883 ([#14401](https://github.com/jestjs/jest/pull/14401))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- `[jest-reporters]` Updating istanbul-lib-instrument dependency. istanbul-lib-instrument 6.0.0 has dropped support for node 10 and updated semver addressing CVE-2022-25883 ([#14401](https://github.com/jestjs/jest/pull/14401))
+- `[jest-reporters]` Update `istanbul-lib-instrument` dependency to v6. ([#14401](https://github.com/jestjs/jest/pull/14401))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Fixes
 
+- `[jest-reporters]` Updating istanbul-lib-instrument dependency. istanbul-lib-instrument 6.0.0 has dropped support for node 10 and updated semver addressing CVE-2022-25883
+
 ### Chore & Maintenance
 
 ### Performance

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1177,6 +1177,7 @@ export default config;
 ```
 
 We hope to support Prettier v3 seamlessly out of the box in a future version of Jest. See [this](https://github.com/jestjs/jest/issues/14305) tracking issue.
+
 </details>
 
 ### `projects` \[array&lt;string | ProjectConfig&gt;]

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -25,7 +25,7 @@
     "glob": "^7.1.3",
     "graceful-fs": "^4.2.9",
     "istanbul-lib-coverage": "^3.0.0",
-    "istanbul-lib-instrument": "^5.1.0",
+    "istanbul-lib-instrument": "^6.0.0",
     "istanbul-lib-report": "^3.0.0",
     "istanbul-lib-source-maps": "^4.0.0",
     "istanbul-reports": "^3.1.3",

--- a/website/versioned_docs/version-29.6/Configuration.md
+++ b/website/versioned_docs/version-29.6/Configuration.md
@@ -1177,6 +1177,7 @@ export default config;
 ```
 
 We hope to support Prettier v3 seamlessly out of the box in a future version of Jest. See [this](https://github.com/jestjs/jest/issues/14305) tracking issue.
+
 </details>
 
 ### `projects` \[array&lt;string | ProjectConfig&gt;]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3096,7 +3096,7 @@ __metadata:
     glob: ^7.1.3
     graceful-fs: ^4.2.9
     istanbul-lib-coverage: ^3.0.0
-    istanbul-lib-instrument: ^5.1.0
+    istanbul-lib-instrument: ^6.0.0
     istanbul-lib-report: ^3.0.0
     istanbul-lib-source-maps: ^4.0.0
     istanbul-reports: ^3.1.3
@@ -12251,7 +12251,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-instrument@npm:^5.0.4, istanbul-lib-instrument@npm:^5.1.0":
+"istanbul-lib-instrument@npm:^5.0.4":
   version: 5.2.1
   resolution: "istanbul-lib-instrument@npm:5.2.1"
   dependencies:
@@ -12261,6 +12261,19 @@ __metadata:
     istanbul-lib-coverage: ^3.2.0
     semver: ^6.3.0
   checksum: bf16f1803ba5e51b28bbd49ed955a736488381e09375d830e42ddeb403855b2006f850711d95ad726f2ba3f1ae8e7366de7e51d2b9ac67dc4d80191ef7ddf272
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-instrument@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "istanbul-lib-instrument@npm:6.0.0"
+  dependencies:
+    "@babel/core": ^7.12.3
+    "@babel/parser": ^7.14.7
+    "@istanbuljs/schema": ^0.1.2
+    istanbul-lib-coverage: ^3.2.0
+    semver: ^7.5.4
+  checksum: b9dc3723a769e65dbe1b912f935088ffc07cf393fa78a3ce79022c91aabb0ad01405ffd56083cdd822e514798e9daae3ea7bfe85633b094ecb335d28eb0a3f97
   languageName: node
   linkType: hard
 
@@ -18193,7 +18206,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.1, semver@npm:^7.5.3, semver@npm:~7.5.4":
+"semver@npm:^7.0.0, semver@npm:^7.1.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.1, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:~7.5.4":
   version: 7.5.4
   resolution: "semver@npm:7.5.4"
   dependencies:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
Addressing https://security.snyk.io/vuln/SNYK-JS-SEMVER-3247795 for semver coming in fromistanbul-lib-instrument@^5.1.0 and below.

See: https://github.com/istanbuljs/istanbuljs/pull/731
  - istanbul-lib-instrument updated from 5.10.0 to 6.0.0
    - istanbul-lib-instrument dropping support for node 10
    - fixing semver vuln. [CVE-2022-25883
](https://www.cve.org/CVERecord?id=CVE-2022-25883)

## Test plan

Green CI.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
