### PR TITLE
docs: remove github-actions-cpu-cores recommendation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Chore & Maintenance
 
+- `[docs]` Update `github-actions-cpu-cores` recommendation as unnecessary with Node 18 or newer ([#14421](https://github.com/jestjs/jest/pull/14421))
+
 ### Performance
 
 ## 29.6.2

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -185,17 +185,15 @@ jest --maxWorkers=4
 npm test -- --maxWorkers=4
 ```
 
-If you use GitHub Actions, you can use [`github-actions-cpu-cores`](https://github.com/SimenB/github-actions-cpu-cores) to detect number of CPUs, and pass that to Jest.
-
-```yaml
-- name: Get number of CPU cores
-  id: cpu-cores
-  uses: SimenB/github-actions-cpu-cores@v1
-- name: run tests
-  run: yarn jest --max-workers ${{ steps.cpu-cores.outputs.count }}
-```
-
 Another thing you can do is use the [`shard`](CLI.md#--shard) flag to parallelize the test run across multiple machines.
+
+:::info
+
+If your project uses Node 14 or 16, you can use you can use [`github-actions-cpu-cores`](https://github.com/SimenB/github-actions-cpu-cores) to accurately detect the number of CPUs to use.
+
+Refer to [`github-actions-cpu-cores` README](https://github.com/SimenB/github-actions-cpu-cores#readme) for more information.
+
+:::
 
 ## `coveragePathIgnorePatterns` seems to not have any effect.
 


### PR DESCRIPTION
## Summary

As of Jest 29.4.0, you no longer need to use the `github-actions-cpu-cores` action to properly set `--max-workers`. All that action does is use `os.availableParallelism()`, which jest now does natively after #13738.


## Test plan

Docs only