### PR TITLE
Marks Reporter's hooks as optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[jest-mock]` Revert [#13692](https://github.com/jestjs/jest/pull/13692) as it was a breaking change ([#14429](https://github.com/jestjs/jest/pull/14429))
 - `[jest-mock]` Revert [#13866](https://github.com/jestjs/jest/pull/13866) as it was a breaking change ([#14429](https://github.com/jestjs/jest/pull/14429))
 - `[jest-mock]` Revert [#13867](https://github.com/jestjs/jest/pull/13867) as it was a breaking change ([#14429](https://github.com/jestjs/jest/pull/14429))
+- `[@jest/reporters]` Marks Reporter's hooks as optional ([#14433](https://github.com/jestjs/jest/pull/14433))
 
 ### Chore & Maintenance
 

--- a/packages/jest-reporters/src/types.ts
+++ b/packages/jest-reporters/src/types.ts
@@ -42,7 +42,7 @@ export interface Reporter {
     test: Test,
     testCaseResult: TestCaseResult,
   ) => Promise<void> | void;
-  readonly onRunStart: (
+  readonly onRunStart?: (
     results: AggregatedResult,
     options: ReporterOnStartOptions,
   ) => Promise<void> | void;
@@ -52,7 +52,7 @@ export interface Reporter {
     testContexts: Set<TestContext>,
     results: AggregatedResult,
   ) => Promise<void> | void;
-  readonly getLastError: () => Error | void;
+  readonly getLastError?: () => Error | void;
 }
 
 export type ReporterContext = {

--- a/packages/jest-reporters/src/types.ts
+++ b/packages/jest-reporters/src/types.ts
@@ -48,7 +48,7 @@ export interface Reporter {
   ) => Promise<void> | void;
   readonly onTestStart?: (test: Test) => Promise<void> | void;
   readonly onTestFileStart?: (test: Test) => Promise<void> | void;
-  readonly onRunComplete: (
+  readonly onRunComplete?: (
     testContexts: Set<TestContext>,
     results: AggregatedResult,
   ) => Promise<void> | void;


### PR DESCRIPTION
onRunStart and getLastError should be optional, fixes #14427

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
