### PR TITLE
fix(jest-core): Correct typo in `performance.mark()` label for `scheduleAndRun:end`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+- `[jest-core]` Fix typo in `scheduleAndRun` performance marker ([#14434](https://github.com/jestjs/jest/pull/14434))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 ### Fixes
+
 - `[jest-core]` Fix typo in `scheduleAndRun` performance marker ([#14434](https://github.com/jestjs/jest/pull/14434))
 
 ### Chore & Maintenance

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -299,7 +299,7 @@ export default async function runJest({
     detail: {numTests: allTests.length},
   });
   const results = await scheduler.scheduleTests(allTests, testWatcher);
-  performance.mark('jest/scheduleAndRun:start');
+  performance.mark('jest/scheduleAndRun:end');
 
   performance.mark('jest/cacheResults:start');
   sequencer.cacheResults(allTests, results);


### PR DESCRIPTION
## Summary

Fixes my typo from https://github.com/jestjs/jest/pull/13859 - I'd accidentally marked `jest/scheduleAndRun:start` both before *and after* `await scheduleTests()`.

## Test plan

Since upgrading to Jest 29.6.3 we now have instrumentation running for Jest at Meta and will be able to measure any startup improvements or regressions - happy to share aggregate data :). Thanks @SimenB in particular for your support on this.

(Ok, that wasn't really a test plan. 👀  for this one, I guess.)