### PR TITLE
fix(jest-worker): `postMessage` error handler in child threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - `[expect]` Remove `@types/node` from dependencies ([#14385](https://github.com/jestjs/jest/pull/14385))
 - `[jest-core]` Use workers in watch mode by default to avoid crashes ([#14059](https://github.com/facebook/jest/pull/14059) & [#14085](https://github.com/facebook/jest/pull/14085)).
 - `[jest-reporters]` Update `istanbul-lib-instrument` dependency to v6. ([#14401](https://github.com/jestjs/jest/pull/14401))
+- `[jest-worker]` Additional error wrapper for `parentPort.postMessage` to fix unhandled `DataCloneError`. ([#14437](https://github.com/jestjs/jest/pull/14437))
 
 ### Chore & Maintenance
 

--- a/packages/jest-worker/src/workers/__tests__/threadChild.test.ts
+++ b/packages/jest-worker/src/workers/__tests__/threadChild.test.ts
@@ -365,3 +365,24 @@ it('throws if child is not forked', () => {
     messagePort.emit('message', [CHILD_MESSAGE_CALL, true, 'fooThrows', []]);
   }).toThrow('_worker_threads.parentPort.postMessage is not a function');
 });
+
+it('handle error if `postMessage` throws an error', () => {
+  messagePort.emit('message', [
+    CHILD_MESSAGE_INITIALIZE,
+    true,
+    './my-fancy-worker',
+  ]);
+
+  jest.mocked(messagePort.postMessage).mockImplementationOnce(() => {
+    throw mockError;
+  });
+
+  messagePort.emit('message', [CHILD_MESSAGE_CALL, true, 'fooWorks', []]);
+  expect(jest.mocked(messagePort.postMessage).mock.calls[1][0]).toEqual([
+    PARENT_MESSAGE_CLIENT_ERROR,
+    'TypeError',
+    'Boo',
+    mockError.stack,
+    {},
+  ]);
+});

--- a/packages/jest-worker/src/workers/threadChild.ts
+++ b/packages/jest-worker/src/workers/threadChild.ts
@@ -112,7 +112,14 @@ function reportSuccess(result: unknown) {
     throw new Error('Child can only be used on a forked process');
   }
 
-  parentPort!.postMessage([PARENT_MESSAGE_OK, result]);
+  try {
+    parentPort!.postMessage([PARENT_MESSAGE_OK, result]);
+  } catch (err: any) {
+    // Handling it here to avoid unhandled `DataCloneError` rejection
+    // which is hard to distinguish on the parent side
+    // (such error doesn't have any message or stack trace)
+    reportClientError(err);
+  }
 }
 
 function reportClientError(error: Error) {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

`postMessage` errors in `threadChild` is hard to investigate (for example `DataCloneError` errors), I added additional handler for this behavior in `threadChild.ts`. 

This was a part of [this PR](https://github.com/jestjs/jest/pull/14436), extracted for sooner merge

## Test plan

Add this testcase to any testcase from the `example` directory, e.g. `examples/typescript/__tests__/sum.test.js` 

```js
it('should not explode', () => {
    const foo = () => {}
    const bar = () => {}
    expect(foo).toBe(bar)
})
```

Config:
```
// examples/typescript/package.json
 "jest": {
    "testEnvironment": "jsdom",
    "workerThreads": true,
    "maxWorkers": 1
  }
```

Command:
```
yarn test --watch
```

The result:

| Before changes | After changes |
|--------|--------|
| <img width="430" alt="image" src="https://github.com/jestjs/jest/assets/21976058/f663623f-9d2d-4017-bcb0-ca04c7555179"> | <img width="426" alt="image" src="https://github.com/jestjs/jest/assets/21976058/79f8c3a0-0975-4bfb-8b40-9bc688964e96"> |
