### PR TITLE
docs: remove un-necessary \ in older blog post

### DIFF
--- a/website/blog/2018-06-27-supporting-jest-open-source.md
+++ b/website/blog/2018-06-27-supporting-jest-open-source.md
@@ -45,7 +45,7 @@ There are two levels of support for the collective: Backer and Sponsor.
 
 #### Backers
 
-Backers of the collective are individuals contributing at least \$2/month. We'll include a list of backers on the Jest homepage, README on github/yarn/npm, and Contributors page.
+Backers of the collective are individuals contributing at least $2/month. We'll include a list of backers on the Jest homepage, README on github/yarn/npm, and Contributors page.
 
 #### Sponsors
 


### PR DESCRIPTION

## Summary

Prod: https://jestjs.io/blog/2018/06/27/supporting-jest-open-source#backers:~:text=contributing%20at%20least%20%5C-,%242/month,-.%20We%27ll%20include%20a

There is an un-necessary \ here:

![CleanShot 2023-09-01 at 15 55 08@2x](https://github.com/jestjs/jest/assets/749374/77f8d38a-bc42-4f8d-911f-2f6d83c132ea)

