### PR TITLE
fix(test-scheduler): correctly figure out test runtime

### DIFF
--- a/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.ts
+++ b/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.ts
@@ -151,7 +151,8 @@ test('writes the cache based on results without existing cache', async () => {
       },
       {
         numFailingTests: 1,
-        perfStats: {end: 4, runtime: 3, start: 1},
+        // this is missing `runtime` to test that it is calculated
+        perfStats: {end: 4, start: 1},
         testFilePath: '/test-c.js',
       },
       {

--- a/packages/jest-test-sequencer/src/index.ts
+++ b/packages/jest-test-sequencer/src/index.ts
@@ -16,7 +16,9 @@ const FAIL = 0;
 const SUCCESS = 1;
 
 type Cache = {
-  [key: string]: [0 | 1, number] | undefined;
+  [key: string]:
+    | [testStatus: typeof FAIL | typeof SUCCESS, testDuration: number]
+    | undefined;
 };
 
 export type ShardOptions = {
@@ -42,7 +44,7 @@ type ShardPositionOptions = ShardOptions & {
  * is called to store/update this information on the cache map.
  */
 export default class TestSequencer {
-  private readonly _cache: Map<TestContext, Cache> = new Map();
+  private readonly _cache = new Map<TestContext, Cache>();
 
   _getCachePath(testContext: TestContext): string {
     const {config} = testContext;
@@ -191,7 +193,7 @@ export default class TestSequencer {
       const failedB = this.hasFailed(testB);
       const hasTimeA = testA.duration != null;
       if (failedA !== failedB) {
-        return failedA === true ? -1 : 1;
+        return failedA ? -1 : 1;
       } else if (hasTimeA != (testB.duration != null)) {
         // If only one of two tests has timing information, run it last
         return hasTimeA ? 1 : -1;
@@ -219,9 +221,11 @@ export default class TestSequencer {
       if (test != null && !testResult.skipped) {
         const cache = this._getCache(test);
         const perf = testResult.perfStats;
+        const testRuntime =
+          perf.runtime ?? test.duration ?? perf.end - perf.start;
         cache[testResult.testFilePath] = [
           testResult.numFailingTests ? FAIL : SUCCESS,
-          perf.runtime || 0,
+          testRuntime || 0,
         ];
       }
     });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This broke for reporters not reporting the new `runtime` option in https://github.com/jestjs/jest/pull/9366/files#diff-13b8119e2dc016b1f90c8f3dff4d9783a4ab4513ff65e87b3200a7deb3d07427

Brought to my attention via https://github.com/jest-community/jest-runner-eslint/issues/204

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Tweaked the test to show that the value is calculated correctly.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
