### PR TITLE
Prepare website docs content for MDX v2 and Docusaurus v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ module.exports = {
 
 The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+<details>
+  <summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
 Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -243,7 +243,8 @@ This option requires `collectCoverage` to be set to `true` or Jest to be invoked
 
 <details>
   <summary>Help:</summary>
-  If you are seeing coverage output such as...
+
+If you are seeing coverage output such as...
 
 ```
 =============================== Coverage summary ===============================

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -89,7 +89,8 @@ module.exports = {
 
 The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+<details>
+  <summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
 Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -120,7 +120,7 @@ Clears all information stored in the [`mockFn.mock.calls`](#mockfnmockcalls), [`
 
 The [`clearMocks`](configuration#clearmocks-boolean) configuration option is available to clear mocks automatically before each tests.
 
-:::warning
+:::danger
 
 Beware that `mockFn.mockClear()` will replace `mockFn.mock`, not just reset the values of its properties! You should, therefore, avoid assigning `mockFn.mock` to other variables, temporary or not, to make sure you don't access stale data.
 

--- a/website/versioned_docs/version-29.4/Configuration.md
+++ b/website/versioned_docs/version-29.4/Configuration.md
@@ -243,7 +243,8 @@ This option requires `collectCoverage` to be set to `true` or Jest to be invoked
 
 <details>
   <summary>Help:</summary>
-  If you are seeing coverage output such as...
+
+If you are seeing coverage output such as...
 
 ```
 =============================== Coverage summary ===============================

--- a/website/versioned_docs/version-29.4/GettingStarted.md
+++ b/website/versioned_docs/version-29.4/GettingStarted.md
@@ -89,7 +89,8 @@ module.exports = {
 
 The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+<details>
+  <summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
 Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 

--- a/website/versioned_docs/version-29.4/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.4/MockFunctionAPI.md
@@ -120,7 +120,7 @@ Clears all information stored in the [`mockFn.mock.calls`](#mockfnmockcalls), [`
 
 The [`clearMocks`](configuration#clearmocks-boolean) configuration option is available to clear mocks automatically before each tests.
 
-:::warning
+:::danger
 
 Beware that `mockFn.mockClear()` will replace `mockFn.mock`, not just reset the values of its properties! You should, therefore, avoid assigning `mockFn.mock` to other variables, temporary or not, to make sure you don't access stale data.
 

--- a/website/versioned_docs/version-29.5/Configuration.md
+++ b/website/versioned_docs/version-29.5/Configuration.md
@@ -243,7 +243,8 @@ This option requires `collectCoverage` to be set to `true` or Jest to be invoked
 
 <details>
   <summary>Help:</summary>
-  If you are seeing coverage output such as...
+
+If you are seeing coverage output such as...
 
 ```
 =============================== Coverage summary ===============================

--- a/website/versioned_docs/version-29.5/GettingStarted.md
+++ b/website/versioned_docs/version-29.5/GettingStarted.md
@@ -89,7 +89,8 @@ module.exports = {
 
 The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+<details>
+  <summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
 Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 

--- a/website/versioned_docs/version-29.5/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.5/MockFunctionAPI.md
@@ -120,7 +120,7 @@ Clears all information stored in the [`mockFn.mock.calls`](#mockfnmockcalls), [`
 
 The [`clearMocks`](configuration#clearmocks-boolean) configuration option is available to clear mocks automatically before each tests.
 
-:::warning
+:::danger
 
 Beware that `mockFn.mockClear()` will replace `mockFn.mock`, not just reset the values of its properties! You should, therefore, avoid assigning `mockFn.mock` to other variables, temporary or not, to make sure you don't access stale data.
 

--- a/website/versioned_docs/version-29.6/Configuration.md
+++ b/website/versioned_docs/version-29.6/Configuration.md
@@ -243,7 +243,8 @@ This option requires `collectCoverage` to be set to `true` or Jest to be invoked
 
 <details>
   <summary>Help:</summary>
-  If you are seeing coverage output such as...
+
+If you are seeing coverage output such as...
 
 ```
 =============================== Coverage summary ===============================

--- a/website/versioned_docs/version-29.6/GettingStarted.md
+++ b/website/versioned_docs/version-29.6/GettingStarted.md
@@ -89,7 +89,8 @@ module.exports = {
 
 The ideal configuration for Babel will depend on your project. See [Babel's docs](https://babeljs.io/docs/en/) for more details.
 
-<details><summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
+<details>
+  <summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
 Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
 

--- a/website/versioned_docs/version-29.6/MockFunctionAPI.md
+++ b/website/versioned_docs/version-29.6/MockFunctionAPI.md
@@ -120,7 +120,7 @@ Clears all information stored in the [`mockFn.mock.calls`](#mockfnmockcalls), [`
 
 The [`clearMocks`](configuration#clearmocks-boolean) configuration option is available to clear mocks automatically before each tests.
 
-:::warning
+:::danger
 
 Beware that `mockFn.mockClear()` will replace `mockFn.mock`, not just reset the values of its properties! You should, therefore, avoid assigning `mockFn.mock` to other variables, temporary or not, to make sure you don't access stale data.
 


### PR DESCRIPTION
## Summary

Preparation PR to make content compatible with MDX v2 (coming with Docusaurus v3).

Those docs are currently only compatible with MDX v1 (Docusaurus v2).

Now they are compatible with both MDX v1 and v2 (so Docusaurus v2 and v3), and the upgrade won't require to update them.

Follow-up PR that upgrades to Docusaurus v3 and MDX v2: https://github.com/jestjs/jest/pull/14463

## Test plan

Deploy preview
