### PR TITLE
docblock: use flatMap instead of map+reduce

### DIFF
--- a/packages/jest-docblock/src/index.ts
+++ b/packages/jest-docblock/src/index.ts
@@ -91,8 +91,7 @@ export function print({
   const keys = Object.keys(pragmas);
 
   const printedObject = keys
-    .map(key => printKeyValues(key, pragmas[key]))
-    .reduce((arr, next) => arr.concat(next), [])
+    .flatMap(key => printKeyValues(key, pragmas[key]))
     .map(keyValue => `${start} ${keyValue}${line}`)
     .join('');
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

A little optimization. `map` + `reduce` can be replaced by `flatMap` in this case.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
