### PR TITLE
chore: `navigator` is defined in Node 21

### DIFF
--- a/e2e/__tests__/__snapshots__/wrongEnv.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/wrongEnv.test.ts.snap
@@ -1,5 +1,29 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Wrong globals for environment on node <21 print useful error for navigator 1`] = `
+"FAIL __tests__/node.js
+  ✕ use navigator
+  ○ skipped use document
+  ○ skipped use window
+
+  ● use navigator
+
+    The error below may be caused by using the wrong test environment, see https://jestjs.io/docs/configuration#testenvironment-string.
+    Consider using the "jsdom" test environment.
+
+    ReferenceError: navigator is not defined
+
+      30 |
+      31 | test('use navigator', () => {
+    > 32 |   const userAgent = navigator.userAgent;
+         |                     ^
+      33 |
+      34 |   console.log(userAgent);
+      35 |
+
+      at Object.navigator (__tests__/node.js:32:21)"
+`;
+
 exports[`Wrong globals for environment print useful error for document 1`] = `
 "FAIL __tests__/node.js
   ✕ use document
@@ -22,30 +46,6 @@ exports[`Wrong globals for environment print useful error for document 1`] = `
       19 |
 
       at Object.document (__tests__/node.js:16:15)"
-`;
-
-exports[`Wrong globals for environment print useful error for navigator 1`] = `
-"FAIL __tests__/node.js
-  ✕ use navigator
-  ○ skipped use document
-  ○ skipped use window
-
-  ● use navigator
-
-    The error below may be caused by using the wrong test environment, see https://jestjs.io/docs/configuration#testenvironment-string.
-    Consider using the "jsdom" test environment.
-
-    ReferenceError: navigator is not defined
-
-      30 |
-      31 | test('use navigator', () => {
-    > 32 |   const userAgent = navigator.userAgent;
-         |                     ^
-      33 |
-      34 |   console.log(userAgent);
-      35 |
-
-      at Object.navigator (__tests__/node.js:32:21)"
 `;
 
 exports[`Wrong globals for environment print useful error for unref 1`] = `

--- a/e2e/__tests__/wrongEnv.test.ts
+++ b/e2e/__tests__/wrongEnv.test.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {onNodeVersions} from '@jest/test-utils';
 import {extractSummary} from '../Utils';
 import runJest from '../runJest';
 
@@ -23,8 +24,10 @@ describe('Wrong globals for environment', () => {
     assertFailuresAndSnapshot(['node', '-t=document']);
   });
 
-  it('print useful error for navigator', () => {
-    assertFailuresAndSnapshot(['node', '-t=navigator']);
+  onNodeVersions('<21', () => {
+    it('print useful error for navigator', () => {
+      assertFailuresAndSnapshot(['node', '-t=navigator']);
+    });
   });
 
   it('print useful error for unref', () => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Noticed this test was failing on the upcoming Node 21, so let's only run it on older versions.

```sh-session
$ ~/Downloads/node --version
v21.0.0-pre

$ ~/Downloads/node -p navigator
Navigator {}
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
