### PR TITLE
fix(jest-haste-map): Avoid watch mode failures on windows during git maintenance due to EPERM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[jest-leak-detector]` Make leak-detector more aggressive when running GC ([#14526](https://github.com/jestjs/jest/pull/14526))
+- `[jest-haste-map]` Ignore EPERM while watching on windows ([#14533](https://github.com/jestjs/jest/pull/14533))
 
 ### Performance
 

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -128,7 +128,7 @@ const MAX_WAIT_TIME = 240000;
 const NODE_MODULES = `${path.sep}node_modules${path.sep}`;
 const PACKAGE_JSON = `${path.sep}package.json`;
 const VCS_DIRECTORIES = ['.git', '.hg', '.sl']
-  .map(vcs => escapePathForRegex(path.sep + vcs + path.sep))
+  .map(vcs => escapePathForRegex(`/${vcs}/`))
   .join('|');
 
 /**

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -128,7 +128,7 @@ const MAX_WAIT_TIME = 240000;
 const NODE_MODULES = `${path.sep}node_modules${path.sep}`;
 const PACKAGE_JSON = `${path.sep}package.json`;
 const VCS_DIRECTORIES = ['.git', '.hg', '.sl']
-  .map(vcs => escapePathForRegex(`/${vcs}/`))
+  .map(vcs => escapePathForRegex(path.sep + vcs + path.sep))
   .join('|');
 
 /**

--- a/packages/jest-haste-map/src/watchers/NodeWatcher.js
+++ b/packages/jest-haste-map/src/watchers/NodeWatcher.js
@@ -279,7 +279,7 @@ module.exports = class NodeWatcher extends EventEmitter {
     const relativePath = path.join(path.relative(this.root, dir), file);
 
     fs.lstat(fullPath, (error, stat) => {
-      if (error && error.code !== 'ENOENT') {
+      if (error && !isIgnorableFileError(error)) {
         this.emit('error', error);
       } else if (!error && stat.isDirectory()) {
         // win32 emits usless change events on dirs.
@@ -298,7 +298,7 @@ module.exports = class NodeWatcher extends EventEmitter {
         }
       } else {
         const registered = this.registered(fullPath);
-        if (error && error.code === 'ENOENT') {
+        if (error && isIgnorableFileError(error)) {
           this.unregister(fullPath);
           this.stopWatching(fullPath);
           this.unregisterDir(fullPath);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Fixes #13869 to prevent watch mode from breaking on windows during git maintenance

Implements the two changes noted in the issue

1. Replaces path.sep with `/` due to the anymatch normalization logic mentioned in the issue
2. uses `isIgnorableFileError` to account for allowable EPERM issues on windows. 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Seems to work fine manually making these changes across a couple different setups :)

CI tests seem fine aside from some presumably flaky cases - https://github.com/Zenith00/jest/actions/runs/6202106275 success with enough reruns