### PR TITLE
Exposes globalConfig to custom test sequencers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ### Features
 
+- `[jest-test-sequencer, jest-core]` Exposes globalConfig & contexts to TestSequencer ([#14535](https://github.com/jestjs/jest/pull/14535))
+
 ### Fixes
 
 - `[jest-leak-detector]` Make leak-detector more aggressive when running GC ([#14526](https://github.com/jestjs/jest/pull/14526))
-- `[jest-test-sequencer, jest-core]` Exposes globalConfig & contexts to TestSequencer ([#14535](https://github.com/jestjs/jest/pull/14535))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - `[jest-leak-detector]` Make leak-detector more aggressive when running GC ([#14526](https://github.com/jestjs/jest/pull/14526))
-- `[jest-test-sequencer, jest-core]` Exposes globalConfig to TestSequencer ([#14535](https://github.com/jestjs/jest/pull/14535))
+- `[jest-test-sequencer, jest-core]` Exposes globalConfig & contexts to TestSequencer ([#14535](https://github.com/jestjs/jest/pull/14535))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[jest-leak-detector]` Make leak-detector more aggressive when running GC ([#14526](https://github.com/jestjs/jest/pull/14526))
+- `[jest-test-sequencer, jest-core]` Exposes globalConfig to TestSequencer ([#14535](https://github.com/jestjs/jest/pull/14535))
 
 ### Performance
 

--- a/e2e/__tests__/customTestSequencers.test.ts
+++ b/e2e/__tests__/customTestSequencers.test.ts
@@ -79,3 +79,56 @@ test('run failed tests async', () => {
     .split('\n');
   expect(sequence).toEqual(['./c.test.js', './d.test.js']);
 });
+
+test('run tests based on even seed', () => {
+  const result = runJest(
+    dir,
+    [
+      '-i',
+      '--config',
+      JSON.stringify({
+        testSequencer: '<rootDir>/testSequencerWithSeed.js',
+      }),
+      '--seed=2',
+    ],
+    {},
+  );
+  console.log({result});
+  expect(result.exitCode).toBe(0);
+  const sequence = extractSummary(result.stderr)
+    .rest.replace(/PASS /g, '')
+    .split('\n');
+  expect(sequence).toEqual([
+    './a.test.js',
+    './b.test.js',
+    './c.test.js',
+    './d.test.js',
+    './e.test.js',
+  ]);
+});
+
+test('run tests based on odd seed', () => {
+  const result = runJest(
+    dir,
+    [
+      '-i',
+      '--config',
+      JSON.stringify({
+        testSequencer: '<rootDir>/testSequencerWithSeed.js',
+      }),
+      '--seed=1',
+    ],
+    {},
+  );
+  expect(result.exitCode).toBe(0);
+  const sequence = extractSummary(result.stderr)
+    .rest.replace(/PASS /g, '')
+    .split('\n');
+  expect(sequence).toEqual([
+    './e.test.js',
+    './d.test.js',
+    './c.test.js',
+    './b.test.js',
+    './a.test.js',
+  ]);
+});

--- a/e2e/__tests__/customTestSequencers.test.ts
+++ b/e2e/__tests__/customTestSequencers.test.ts
@@ -93,7 +93,6 @@ test('run tests based on even seed', () => {
     ],
     {},
   );
-  console.log({result});
   expect(result.exitCode).toBe(0);
   const sequence = extractSummary(result.stderr)
     .rest.replace(/PASS /g, '')

--- a/e2e/custom-test-sequencer/testSequencerWithSeed.js
+++ b/e2e/custom-test-sequencer/testSequencerWithSeed.js
@@ -8,6 +8,11 @@
 const Sequencer = require('@jest/test-sequencer').default;
 
 class CustomSequencer extends Sequencer {
+  constructor(_options) {
+    super(_options);
+    this.globalConfig = _options.globalConfig;
+  }
+
   sort(tests) {
     const copyTests = Array.from(tests);
     const seed = this.globalConfig.seed;

--- a/e2e/custom-test-sequencer/testSequencerWithSeed.js
+++ b/e2e/custom-test-sequencer/testSequencerWithSeed.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const Sequencer = require('@jest/test-sequencer').default;
 
 class CustomSequencer extends Sequencer {

--- a/e2e/custom-test-sequencer/testSequencerWithSeed.js
+++ b/e2e/custom-test-sequencer/testSequencerWithSeed.js
@@ -1,0 +1,19 @@
+const Sequencer = require('@jest/test-sequencer').default;
+
+class CustomSequencer extends Sequencer {
+  sort(tests) {
+    const copyTests = Array.from(tests);
+    const seed = this.globalConfig.seed;
+    const sortedTests = copyTests.sort((testA, testB) =>
+      testA.path > testB.path ? 1 : -1,
+    );
+
+    if (seed % 2 === 0) {
+      return sortedTests;
+    } else {
+      return sortedTests.reverse();
+    }
+  }
+}
+
+module.exports = CustomSequencer;

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -159,7 +159,7 @@ export default async function runJest({
   const Sequencer: typeof TestSequencer = await requireOrImportModule(
     globalConfig.testSequencer,
   );
-  const sequencer = new Sequencer(globalConfig);
+  const sequencer = new Sequencer({contexts, globalConfig});
   let allTests: Array<Test> = [];
 
   if (changedFilesPromise && globalConfig.watch) {

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -159,7 +159,7 @@ export default async function runJest({
   const Sequencer: typeof TestSequencer = await requireOrImportModule(
     globalConfig.testSequencer,
   );
-  const sequencer = new Sequencer();
+  const sequencer = new Sequencer(globalConfig);
   let allTests: Array<Test> = [];
 
   if (changedFilesPromise && globalConfig.watch) {

--- a/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.ts
+++ b/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 import * as mockedFs from 'graceful-fs';
 import type {AggregatedResult, Test, TestContext} from '@jest/test-result';
 import {makeProjectConfig} from '@jest/test-utils';
-import type {Config} from '@jest/types';
 import TestSequencer from '../index';
 
 jest.mock('graceful-fs', () => ({

--- a/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.ts
+++ b/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.ts
@@ -9,6 +9,7 @@ import * as path from 'path';
 import * as mockedFs from 'graceful-fs';
 import type {AggregatedResult, Test, TestContext} from '@jest/test-result';
 import {makeProjectConfig} from '@jest/test-utils';
+import type {Config} from '@jest/types';
 import TestSequencer from '../index';
 
 jest.mock('graceful-fs', () => ({
@@ -56,7 +57,10 @@ const toTests = (paths: Array<string>) =>
 
 beforeEach(() => {
   jest.clearAllMocks();
-  sequencer = new TestSequencer();
+  sequencer = new TestSequencer({
+    contexts: [],
+    globalConfig: {} as Config.GlobalConfig,
+  });
 });
 
 test('sorts by file size if there is no timing information', () => {

--- a/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.ts
+++ b/packages/jest-test-sequencer/src/__tests__/test_sequencer.test.ts
@@ -57,10 +57,7 @@ const toTests = (paths: Array<string>) =>
 
 beforeEach(() => {
   jest.clearAllMocks();
-  sequencer = new TestSequencer({
-    contexts: [],
-    globalConfig: {} as Config.GlobalConfig,
-  });
+  sequencer = new TestSequencer();
 });
 
 test('sorts by file size if there is no timing information', () => {

--- a/packages/jest-test-sequencer/src/index.ts
+++ b/packages/jest-test-sequencer/src/index.ts
@@ -10,6 +10,7 @@ import * as path from 'path';
 import * as fs from 'graceful-fs';
 import slash = require('slash');
 import type {AggregatedResult, Test, TestContext} from '@jest/test-result';
+import type {Config} from '@jest/types';
 import HasteMap from 'jest-haste-map';
 
 const FAIL = 0;
@@ -45,6 +46,8 @@ type ShardPositionOptions = ShardOptions & {
  */
 export default class TestSequencer {
   private readonly _cache = new Map<TestContext, Cache>();
+
+  constructor(protected readonly globalConfig: Config.GlobalConfig) {}
 
   _getCachePath(testContext: TestContext): string {
     const {config} = testContext;

--- a/packages/jest-test-sequencer/src/index.ts
+++ b/packages/jest-test-sequencer/src/index.ts
@@ -16,6 +16,11 @@ import HasteMap from 'jest-haste-map';
 const FAIL = 0;
 const SUCCESS = 1;
 
+export type TestSequencerOptions = {
+  contexts: Array<TestContext>;
+  globalConfig: Config.GlobalConfig;
+};
+
 type Cache = {
   [key: string]:
     | [testStatus: typeof FAIL | typeof SUCCESS, testDuration: number]
@@ -47,7 +52,13 @@ type ShardPositionOptions = ShardOptions & {
 export default class TestSequencer {
   private readonly _cache = new Map<TestContext, Cache>();
 
-  constructor(protected readonly globalConfig: Config.GlobalConfig) {}
+  protected readonly globalConfig: Config.GlobalConfig;
+  protected readonly contexts: Array<TestContext>;
+
+  constructor({contexts, globalConfig}: TestSequencerOptions) {
+    this.globalConfig = globalConfig;
+    this.contexts = contexts;
+  }
 
   _getCachePath(testContext: TestContext): string {
     const {config} = testContext;

--- a/packages/jest-test-sequencer/src/index.ts
+++ b/packages/jest-test-sequencer/src/index.ts
@@ -52,7 +52,7 @@ type ShardPositionOptions = ShardOptions & {
 export default class TestSequencer {
   private readonly _cache = new Map<TestContext, Cache>();
 
-  constructor(_options?: TestSequencerOptions);
+  constructor(_options?: TestSequencerOptions) {}
 
   _getCachePath(testContext: TestContext): string {
     const {config} = testContext;

--- a/packages/jest-test-sequencer/src/index.ts
+++ b/packages/jest-test-sequencer/src/index.ts
@@ -17,7 +17,7 @@ const FAIL = 0;
 const SUCCESS = 1;
 
 export type TestSequencerOptions = {
-  contexts: Array<TestContext>;
+  contexts: ReadonlyArray<TestContext>;
   globalConfig: Config.GlobalConfig;
 };
 
@@ -52,13 +52,7 @@ type ShardPositionOptions = ShardOptions & {
 export default class TestSequencer {
   private readonly _cache = new Map<TestContext, Cache>();
 
-  protected readonly globalConfig: Config.GlobalConfig;
-  protected readonly contexts: Array<TestContext>;
-
-  constructor({contexts, globalConfig}: TestSequencerOptions) {
-    this.globalConfig = globalConfig;
-    this.contexts = contexts;
-  }
+  constructor(_options?: TestSequencerOptions);
 
   _getCachePath(testContext: TestContext): string {
     const {config} = testContext;

--- a/packages/jest-test-sequencer/src/index.ts
+++ b/packages/jest-test-sequencer/src/index.ts
@@ -52,6 +52,7 @@ type ShardPositionOptions = ShardOptions & {
 export default class TestSequencer {
   private readonly _cache = new Map<TestContext, Cache>();
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   constructor(_options?: TestSequencerOptions) {}
 
   _getCachePath(testContext: TestContext): string {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Adds a way for custom test sequencers to access the global config. This will allow ordering test suites by using the seed which I don't see an easy way to do currently. 


## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Added unit tests to check that we can use globalConfig values, namely `seed`, in a customTestSequencer. 
`yarn jest e2e/__tests__/customTestSequencers.test.ts`