### PR TITLE
Detect jest custom promisify handlers and replace with separate mock function

### DIFF
--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -173,7 +173,7 @@ export interface MockInstance<T extends FunctionLike = UnknownFunction> {
   mockResolvedValueOnce(value: ResolveType<T>): this;
   mockRejectedValue(value: RejectType<T>): this;
   mockRejectedValueOnce(value: RejectType<T>): this;
-  [nodeCustomPromiseSymbol]?: MockedFunction<any>
+  [nodeCustomPromiseSymbol]?: MockedFunction<any>;
 }
 
 export interface Replaced<T = unknown> {
@@ -880,7 +880,9 @@ export class ModuleMocker {
       }
 
       if (metadata.customPromisifyMeta) {
-        f[nodeCustomPromiseSymbol] = this.generateFromMetadata(metadata.customPromisifyMeta);
+        f[nodeCustomPromiseSymbol] = this.generateFromMetadata(
+          metadata.customPromisifyMeta,
+        );
       }
 
       return f;
@@ -1056,7 +1058,10 @@ export class ModuleMocker {
       if (this.isMockFunction(component)) {
         metadata.mockImpl = component.getMockImplementation() as T;
       }
-      if (typeof component === 'function' && nodeCustomPromiseSymbol in component) {
+      if (
+        typeof component === 'function' &&
+        nodeCustomPromiseSymbol in component
+      ) {
         const meta = this.getMetadata(component[nodeCustomPromiseSymbol]);
         if (meta) {
           metadata.customPromisifyMeta = meta;

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -1062,9 +1062,14 @@ export class ModuleMocker {
         typeof component === 'function' &&
         nodeCustomPromiseSymbol in component
       ) {
-        const meta = this.getMetadata(component[nodeCustomPromiseSymbol]);
-        if (meta) {
-          metadata.customPromisifyMeta = meta;
+        if (!this.isMockFunction(component)) {
+          const meta = this.getMetadata(
+            component[nodeCustomPromiseSymbol],
+            refs,
+          );
+          if (meta) {
+            metadata.customPromisifyMeta = meta;
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

Fixes the issue addressed in #14511: Currently, when automocking functions that provide a custom implementation for node's `util.promisify()`, the type hints for working with the mock function are confusing and must be explicitly ignored if the return types of the promisified variant differ. More in-depth explanation and a minimum example for illustrating the problem in the mentioned issue.

With this fix, the mock function for the non-promisified and promisified variant are now independent. Mocking the implementation of one will not affect the other. Previously, the non-promisified variant would be put though the default `util.promisify()` logic.

The workaround for this was used in one of the `jest-haste-map` tests. Similarly, this workaround would have to be removed in a similar way in downstream test code, because this change breaks that workaround.

## Test plan

The whole jest test suite runs successfully, so this change probably doesn't fundamentally break the jest mocking system.

The minimal reproduction example now behaves as I would expect. The type hints and actual functionality now match up, instead of silently timing out. https://github.com/leftshift/jest-promisify-mre

If this has any chance of getting merged, I would provide additional tests, probably based on the mre.
