### PR TITLE
chore: use `@tsconfig/node16`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@jest/test-utils": "workspace:^",
     "@lerna-lite/cli": "1.13.0",
     "@microsoft/api-extractor": "^7.35.0",
-    "@tsconfig/node14": "^14.1.0",
+    "@tsconfig/node16": "^16.1.0",
     "@tsd/typescript": "^5.0.4",
     "@types/babel__core": "^7.1.14",
     "@types/babel__generator": "^7.0.0",

--- a/packages/jest-core/src/collectHandles.ts
+++ b/packages/jest-core/src/collectHandles.ts
@@ -42,7 +42,6 @@ function stackIsFromUser(stack: string) {
 
 const alwaysActive = () => true;
 
-// @ts-expect-error: doesn't exist in v12 typings
 const hasWeakRef = typeof WeakRef === 'function';
 
 const asyncSleep = promisify(setTimeout);
@@ -115,7 +114,6 @@ export default function collectHandles(): HandleCollectionResult {
         // Handle that supports hasRef
         if ('hasRef' in resource) {
           if (hasWeakRef) {
-            // @ts-expect-error: doesn't exist in v12 typings
             const ref = new WeakRef(resource);
             isActive = () => {
               return ref.deref()?.hasRef() ?? false;

--- a/scripts/verifyOldTs.mjs
+++ b/scripts/verifyOldTs.mjs
@@ -12,8 +12,21 @@ import chalk from 'chalk';
 import execa from 'execa';
 import fs from 'graceful-fs';
 import stripJsonComments from 'strip-json-comments';
+/* eslint-disable import/order */
 import tempy from 'tempy';
 const require = createRequire(import.meta.url);
+
+const rootPackageJson = require('../package.json');
+
+const currentTsdTypescriptVersion =
+  rootPackageJson.devDependencies['@tsd/typescript'];
+const currentTypescriptVersion = rootPackageJson.devDependencies['typescript'];
+const tsconfigBasePackage = Object.keys(rootPackageJson.devDependencies).find(
+  packageName => packageName.startsWith('@tsconfig'),
+);
+const apiExtractorTypescriptVersion =
+  require('@microsoft/api-extractor/package.json').dependencies['typescript'];
+/* eslint-enable import/order */
 
 const baseTsConfig = JSON.parse(
   stripJsonComments(
@@ -31,7 +44,7 @@ const tsConfig = {
     noEmit: true,
   },
 };
-/* eslint-enable */
+/* eslint-enable sort-keys */
 
 const tsVersion = '5.0';
 
@@ -51,8 +64,7 @@ function smoketest() {
     execa.sync('yarn', ['init', '--yes'], {cwd, stdio: 'inherit'});
     execa.sync(
       'yarn',
-      // TODO: do not set version of @tsconfig/node14 after we upgrade to a version of TS that supports `"moduleResolution": "node16"` (https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/)
-      ['add', `typescript@~${tsVersion}`, '@tsconfig/node14@1'],
+      ['add', `typescript@~${tsVersion}`, tsconfigBasePackage],
       {cwd, stdio: 'inherit'},
     );
     fs.writeFileSync(
@@ -77,14 +89,6 @@ function smoketest() {
 
 function typeTests() {
   const cwd = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../');
-  const rootPackageJson = require('../package.json');
-
-  const currentTsdTypescriptVersion =
-    rootPackageJson.devDependencies['@tsd/typescript'];
-  const currentTypescriptVersion =
-    rootPackageJson.devDependencies['typescript'];
-  const apiExtractorTypescriptVersion =
-    require('@microsoft/api-extractor/package.json').dependencies['typescript'];
 
   try {
     const {stdout: statusStdout} = execa.sync(
@@ -99,8 +103,7 @@ function typeTests() {
       );
     }
 
-    // TODO: do not set version of @tsconfig/node14 after we upgrade to a version of TS that supports `"moduleResolution": "node16"` (https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/)
-    execa.sync('yarn', ['add', '@tsconfig/node14@1'], {cwd});
+    execa.sync('yarn', ['add', tsconfigBasePackage], {cwd});
 
     execa.sync(
       'yarn',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2933,7 +2933,7 @@ __metadata:
     "@jest/test-utils": "workspace:^"
     "@lerna-lite/cli": 1.13.0
     "@microsoft/api-extractor": ^7.35.0
-    "@tsconfig/node14": ^14.1.0
+    "@tsconfig/node16": ^16.1.0
     "@tsd/typescript": ^5.0.4
     "@types/babel__core": ^7.1.14
     "@types/babel__generator": ^7.0.0
@@ -4615,17 +4615,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tsconfig/node14@npm:^14.1.0":
-  version: 14.1.0
-  resolution: "@tsconfig/node14@npm:14.1.0"
-  checksum: 8342dc30edbfaed11d1659b1a9819779bb69df210974a9e8a337b0624b1d9f5026f37e2dcc1d555adb3e4246a0ec35896b3ae5fe3fc69f3382d3bc11069cecc1
-  languageName: node
-  linkType: hard
-
 "@tsconfig/node16@npm:^1.0.2":
   version: 1.0.4
   resolution: "@tsconfig/node16@npm:1.0.4"
   checksum: 202319785901f942a6e1e476b872d421baec20cf09f4b266a1854060efbf78cde16a4d256e8bc949d31e6cd9a90f1e8ef8fb06af96a65e98338a2b6b0de0a0ff
+  languageName: node
+  linkType: hard
+
+"@tsconfig/node16@npm:^16.1.0":
+  version: 16.1.1
+  resolution: "@tsconfig/node16@npm:16.1.1"
+  checksum: 26d83db06866083b543e73eda33585464362fd0835229b9a5b1185f0353b9b5db9ca4f66a4be53d4ec5d4c219be42b0a7582f8bcc7268f2f77b1c643375e490f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Following up #14460

## Summary

The lowest supported Node.js version got increased. It’s time to move to `@tsconfig/node16` as well (;

## Test plan

Green CI.