### PR TITLE
fix: add error instance type check to toThrowError

### DIFF
--- a/packages/expect/src/__tests__/toThrowMatchers.test.ts
+++ b/packages/expect/src/__tests__/toThrowMatchers.test.ts
@@ -171,8 +171,14 @@ describe.each(['toThrowError', 'toThrow'] as const)('%s', toThrow => {
       })[toThrow](CustomError);
       jestExpect(() => {
         throw new Err();
+      })[toThrow](new Err());
+      jestExpect(() => {
+        throw new Err();
       }).not[toThrow](Err2);
       jestExpect(() => {}).not[toThrow](Err);
+      jestExpect(() => {
+        throw new Err();
+      }).not[toThrow](new Err2());
     });
 
     test('did not throw at all', () => {

--- a/packages/expect/src/toThrowMatchers.ts
+++ b/packages/expect/src/toThrowMatchers.ts
@@ -228,10 +228,17 @@ const toThrowExpectedObject = (
   const expectedMessageAndCause = createMessageAndCause(expected);
   const thrownMessageAndCause =
     thrown === null ? null : createMessageAndCause(thrown.value);
+  const isThrownErrorInstance =
+    thrown?.isError === true && thrown.value.constructor.name !== 'Object';
+  const isSameType =
+    !isThrownErrorInstance ||
+    thrown.value.constructor.name === expected.constructor.name;
+
   const pass =
     thrown !== null &&
     thrown.message === expected.message &&
-    thrownMessageAndCause === expectedMessageAndCause;
+    thrownMessageAndCause === expectedMessageAndCause &&
+    isSameType;
 
   const message = pass
     ? () =>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`toThrowError` method does not type checking when expected value is error instance.
So I added some codes that compare constructor name (both thrown value and expect value).

**current behavior**
```ts
class CustomError extends Error {
    constructor(message?: string) {
        super(message);
        this.name = this.constructor.name;
    }
}

class Err extends CustomError { }
class Err2 extends CustomError { }

it('to throw Err', () => {
    expect(() => {
        throw new Err('apple');
    }).toThrowError(new Err('apple')); // pass
})

it('to throw Err', () => {
    expect(() => {
        throw new Err('apple');
    }).toThrowError(new Err2('apple')); // pass
})
```

**expect behavior**
```ts
it('to throw Err', () => {
    expect(() => {
        throw new Err('apple');
    }).toThrowError(new Err2('apple')); // pass
})

it('to throw Err', () => {
    expect(() => {
        throw new Err('apple');
    }).toThrowError(new Err2('apple')); // fail
})
```