### PR TITLE
fix: type check for error instance when used toThrowError method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[jest-leak-detector]` Make leak-detector more aggressive when running GC ([#14526](https://github.com/jestjs/jest/pull/14526))
 - `[jest-util]` Make sure `isInteractive` works in a browser ([#14552](https://github.com/jestjs/jest/pull/14552))
 - `[pretty-format]` [**BREAKING**] Print `ArrayBuffer` and `DataView` correctly ([#14290](https://github.com/facebook/jest/pull/14290))
+- `[expect]` Check error instance type for `toThrow/toThrowError` ([#14576](https://github.com/jestjs/jest/pull/14576))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,12 @@
 ### Fixes
 
 - `[babel-plugin-jest-hoist]` Use `denylist` instead of the deprecated `blacklist` for Babel 8 support ([#14109](https://github.com/jestjs/jest/pull/14109))
+- `[expect]` Check error instance type for `toThrow/toThrowError` ([#14576](https://github.com/jestjs/jest/pull/14576))
 - `[jest-circus]` [**BREAKING**] Prevent false test failures caused by promise rejections handled asynchronously ([#14315](https://github.com/jestjs/jest/pull/14315))
 - `[@jest/expect-utils]` Fix comparison of `DataView` ([#14408](https://github.com/jestjs/jest/pull/14408))
 - `[jest-leak-detector]` Make leak-detector more aggressive when running GC ([#14526](https://github.com/jestjs/jest/pull/14526))
 - `[jest-util]` Make sure `isInteractive` works in a browser ([#14552](https://github.com/jestjs/jest/pull/14552))
 - `[pretty-format]` [**BREAKING**] Print `ArrayBuffer` and `DataView` correctly ([#14290](https://github.com/facebook/jest/pull/14290))
-- `[expect]` Check error instance type for `toThrow/toThrowError` ([#14576](https://github.com/jestjs/jest/pull/14576))
 
 ### Performance
 

--- a/packages/expect/src/__tests__/toThrowMatchers.test.ts
+++ b/packages/expect/src/__tests__/toThrowMatchers.test.ts
@@ -170,9 +170,15 @@ describe.each(['toThrowError', 'toThrow'] as const)('%s', toThrow => {
         throw new Err();
       })[toThrow](CustomError);
       jestExpect(() => {
+        throw new SubErr();
+      })[toThrow](new SubErr());
+      jestExpect(() => {
         throw new Err();
       }).not[toThrow](Err2);
       jestExpect(() => {}).not[toThrow](Err);
+      jestExpect(() => {
+        throw new SubErr();
+      }).not[toThrow](new SubSubErr());
     });
 
     test('did not throw at all', () => {

--- a/packages/expect/src/toThrowMatchers.ts
+++ b/packages/expect/src/toThrowMatchers.ts
@@ -228,10 +228,13 @@ const toThrowExpectedObject = (
   const expectedMessageAndCause = createMessageAndCause(expected);
   const thrownMessageAndCause =
     thrown === null ? null : createMessageAndCause(thrown.value);
+  const isCompareErrorInstance = thrown?.isError && expected instanceof Error;
+
   const pass =
     thrown !== null &&
     thrown.message === expected.message &&
-    thrownMessageAndCause === expectedMessageAndCause;
+    thrownMessageAndCause === expectedMessageAndCause &&
+    (!isCompareErrorInstance || thrown.value instanceof expected.constructor);
 
   const message = pass
     ? () =>

--- a/packages/expect/src/toThrowMatchers.ts
+++ b/packages/expect/src/toThrowMatchers.ts
@@ -229,12 +229,16 @@ const toThrowExpectedObject = (
   const thrownMessageAndCause =
     thrown === null ? null : createMessageAndCause(thrown.value);
   const isCompareErrorInstance = thrown?.isError && expected instanceof Error;
+  const isExpectedCustomErrorInstance =
+    expected.constructor.name !== Error.name;
 
   const pass =
     thrown !== null &&
     thrown.message === expected.message &&
     thrownMessageAndCause === expectedMessageAndCause &&
-    (!isCompareErrorInstance || thrown.value instanceof expected.constructor);
+    (!isCompareErrorInstance ||
+      !isExpectedCustomErrorInstance ||
+      thrown.value instanceof expected.constructor);
 
   const message = pass
     ? () =>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`toThrow/toThrowError` method does not type checking when expected value is error instance.

**current behavior**
```ts
class ErrorA extends Error { }
class ErrorB extends Error { }

const throwErrorA = () => {
  throw new ErrorA();
};

expect(throwErrorA).toThrowError(ErrorA); // pass
expect(throwErrorA).toThrowError(new ErrorA()); // pass
expect(throwErrorA).not.toThrowError(ErrorB); // pass
expect(throwErrorA).not.toThrowError(new ErrorB()); // fail, but this test should be passed
```

**expect behavior**
```ts
expect(throwErrorA).not.toThrowError(new ErrorB()); // pass
```

I added some codes that compare type for this problem.
When comparing, need to check error instance is custom error or not.
Because in some tests like this:
```ts
// jest-runtime/src/__test__/runtime_internal_module.test.js >> internalModule
it('loads modules and applies transforms', async () => {
  const runtime = await createRuntime(__filename, {
    transform: {'\\.js$': './test_preprocessor'},
  });
  const modulePath = path.resolve(
    path.dirname(runtime.__mockRootPath),
    'internal-root.js',
  );
  expect(() => {
    runtime.requireModule(modulePath);
  }).toThrow(new Error('preprocessor must not run.'));
});
```
In this case, both `thrown.value` and `expected` are `Error` instances.
But their constructor is not same.
```ts
console.log(thrown.value.constructor); // [Function: Error] { stackTraceLimit: 100 }
console.log(expected.constructor); 
/*
[Function: Error] {
    stackTraceLimit: 100,
     prepareStackTrace: [Function: prepareStackTrace]
}
*/
```

It's no wonder that `thrown.value instanceof expected.constructor` is false, thus test will fail.
So I checked expected error is custom error or not before comparing type of instance.
