### PR TITLE
chore: import WriteStream explicitly

### DIFF
--- a/packages/jest-console/src/CustomConsole.ts
+++ b/packages/jest-console/src/CustomConsole.ts
@@ -7,6 +7,7 @@
 
 import {AssertionError, strict as assert} from 'assert';
 import {Console} from 'console';
+import type {WriteStream} from 'tty';
 import {InspectOptions, format, formatWithOptions, inspect} from 'util';
 import chalk = require('chalk');
 import {clearLine, formatTime} from 'jest-util';
@@ -15,8 +16,8 @@ import type {LogCounters, LogMessage, LogTimers, LogType} from './types';
 type Formatter = (type: LogType, message: LogMessage) => string;
 
 export default class CustomConsole extends Console {
-  private readonly _stdout: NodeJS.WriteStream;
-  private readonly _stderr: NodeJS.WriteStream;
+  private readonly _stdout: WriteStream;
+  private readonly _stderr: WriteStream;
   private readonly _formatBuffer: Formatter;
   private _counters: LogCounters = {};
   private _timers: LogTimers = {};
@@ -25,8 +26,8 @@ export default class CustomConsole extends Console {
   override Console: typeof Console = Console;
 
   constructor(
-    stdout: NodeJS.WriteStream,
-    stderr: NodeJS.WriteStream,
+    stdout: WriteStream,
+    stderr: WriteStream,
     formatBuffer: Formatter = (_type, message) => message,
   ) {
     super(stdout, stderr);

--- a/packages/jest-console/src/__tests__/CustomConsole.test.ts
+++ b/packages/jest-console/src/__tests__/CustomConsole.test.ts
@@ -6,6 +6,7 @@
  */
 
 import {Writable} from 'stream';
+import type {WriteStream} from 'tty';
 import chalk = require('chalk');
 import CustomConsole from '../CustomConsole';
 
@@ -23,14 +24,14 @@ describe('CustomConsole', () => {
         _stdout += chunk.toString();
         callback();
       },
-    }) as NodeJS.WriteStream;
+    }) as WriteStream;
 
     const stderr = new Writable({
       write(chunk: string, _encoding, callback) {
         _stderr += chunk.toString();
         callback();
       },
-    }) as NodeJS.WriteStream;
+    }) as WriteStream;
 
     _console = new CustomConsole(stdout, stderr);
   });

--- a/packages/jest-core/src/__tests__/watchFileChanges.test.ts
+++ b/packages/jest-core/src/__tests__/watchFileChanges.test.ts
@@ -8,6 +8,7 @@
 
 import {tmpdir} from 'os';
 import * as path from 'path';
+import type {WriteStream} from 'tty';
 import * as fs from 'graceful-fs';
 import type {AggregatedResult} from '@jest/test-result';
 import {normalize} from 'jest-config';
@@ -20,7 +21,7 @@ describe('Watch mode flows with changed files', () => {
   jest.resetModules();
 
   let watch: typeof import('../watch').default;
-  let pipe: NodeJS.WriteStream;
+  let pipe: WriteStream;
   let stdin: MockStdin;
   const testDirectory = path.resolve(tmpdir(), 'jest-tmp');
   const fileTargetPath = path.resolve(testDirectory, 'lost-file.js');

--- a/packages/jest-core/src/cli/index.ts
+++ b/packages/jest-core/src/cli/index.ts
@@ -6,6 +6,7 @@
  */
 
 import {performance} from 'perf_hooks';
+import type {WriteStream} from 'tty';
 import chalk = require('chalk');
 import exit = require('exit');
 import * as fs from 'graceful-fs';
@@ -142,7 +143,7 @@ export async function runCLI(
 const buildContextsAndHasteMaps = async (
   configs: Array<Config.ProjectConfig>,
   globalConfig: Config.GlobalConfig,
-  outputStream: NodeJS.WriteStream,
+  outputStream: WriteStream,
 ) => {
   const hasteMapInstances = Array(configs.length);
   const contexts = await Promise.all(
@@ -171,7 +172,7 @@ const _run10000 = async (
   globalConfig: Config.GlobalConfig,
   configs: Array<Config.ProjectConfig>,
   hasDeprecationWarnings: boolean,
-  outputStream: NodeJS.WriteStream,
+  outputStream: WriteStream,
   onComplete: OnCompleteCallback,
 ) => {
   // Queries to hg/git can take a while, so we need to start the process
@@ -247,7 +248,7 @@ const runWatch = async (
   _configs: Array<Config.ProjectConfig>,
   hasDeprecationWarnings: boolean,
   globalConfig: Config.GlobalConfig,
-  outputStream: NodeJS.WriteStream,
+  outputStream: WriteStream,
   hasteMapInstances: Array<IHasteMap>,
   filter?: Filter,
 ) => {
@@ -282,7 +283,7 @@ const runWatch = async (
 const runWithoutWatch = async (
   globalConfig: Config.GlobalConfig,
   contexts: Array<TestContext>,
-  outputStream: NodeJS.WriteStream,
+  outputStream: WriteStream,
   onComplete: OnCompleteCallback,
   changedFilesPromise?: ChangedFilesPromise,
   filter?: Filter,

--- a/packages/jest-core/src/lib/__tests__/logDebugMessages.test.ts
+++ b/packages/jest-core/src/lib/__tests__/logDebugMessages.test.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import type {WriteStream} from 'tty';
 import {makeGlobalConfig, makeProjectConfig} from '@jest/test-utils';
 import logDebugMessages from '../logDebugMessages';
 
@@ -18,7 +19,7 @@ const getOutputStream = (resolve: (message: string) => void) =>
     write(message: string) {
       resolve(message);
     },
-  }) as NodeJS.WriteStream;
+  }) as WriteStream;
 
 it('prints the jest version', async () => {
   expect.assertions(1);

--- a/packages/jest-core/src/lib/handleDeprecationWarnings.ts
+++ b/packages/jest-core/src/lib/handleDeprecationWarnings.ts
@@ -5,12 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {ReadStream, WriteStream} from 'tty';
 import chalk = require('chalk');
 import {KEYS} from 'jest-watcher';
 
 export default function handleDeprecationWarnings(
-  pipe: NodeJS.WriteStream,
-  stdin: NodeJS.ReadStream = process.stdin,
+  pipe: WriteStream,
+  stdin: ReadStream = process.stdin,
 ): Promise<void> {
   return new Promise((resolve, reject) => {
     if (typeof stdin.setRawMode === 'function') {

--- a/packages/jest-core/src/lib/logDebugMessages.ts
+++ b/packages/jest-core/src/lib/logDebugMessages.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {WriteStream} from 'tty';
 import type {Config} from '@jest/types';
 const VERSION = require('../../package.json').version;
 
@@ -12,7 +13,7 @@ const VERSION = require('../../package.json').version;
 export default function logDebugMessages(
   globalConfig: Config.GlobalConfig,
   configs: Array<Config.ProjectConfig> | Config.ProjectConfig,
-  outputStream: NodeJS.WriteStream,
+  outputStream: WriteStream,
 ): void {
   const output = {
     configs,

--- a/packages/jest-core/src/plugins/Quit.ts
+++ b/packages/jest-core/src/plugins/Quit.ts
@@ -5,12 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {ReadStream, WriteStream} from 'tty';
 import {BaseWatchPlugin, UsageData} from 'jest-watcher';
 
 class QuitPlugin extends BaseWatchPlugin {
   isInternal: true;
 
-  constructor(options: {stdin: NodeJS.ReadStream; stdout: NodeJS.WriteStream}) {
+  constructor(options: {stdin: ReadStream; stdout: WriteStream}) {
     super(options);
     this.isInternal = true;
   }

--- a/packages/jest-core/src/plugins/TestNamePattern.ts
+++ b/packages/jest-core/src/plugins/TestNamePattern.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {ReadStream, WriteStream} from 'tty';
 import type {Config} from '@jest/types';
 import {
   BaseWatchPlugin,
@@ -19,7 +20,7 @@ class TestNamePatternPlugin extends BaseWatchPlugin {
   _prompt: Prompt;
   isInternal: true;
 
-  constructor(options: {stdin: NodeJS.ReadStream; stdout: NodeJS.WriteStream}) {
+  constructor(options: {stdin: ReadStream; stdout: WriteStream}) {
     super(options);
     this._prompt = new Prompt();
     this.isInternal = true;

--- a/packages/jest-core/src/plugins/TestPathPattern.ts
+++ b/packages/jest-core/src/plugins/TestPathPattern.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {ReadStream, WriteStream} from 'tty';
 import type {Config} from '@jest/types';
 import {
   BaseWatchPlugin,
@@ -19,7 +20,7 @@ class TestPathPatternPlugin extends BaseWatchPlugin {
   private readonly _prompt: Prompt;
   isInternal: true;
 
-  constructor(options: {stdin: NodeJS.ReadStream; stdout: NodeJS.WriteStream}) {
+  constructor(options: {stdin: ReadStream; stdout: WriteStream}) {
     super(options);
     this._prompt = new Prompt();
     this.isInternal = true;

--- a/packages/jest-core/src/plugins/UpdateSnapshots.ts
+++ b/packages/jest-core/src/plugins/UpdateSnapshots.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {ReadStream, WriteStream} from 'tty';
 import type {Config} from '@jest/types';
 import {
   BaseWatchPlugin,
@@ -17,7 +18,7 @@ class UpdateSnapshotsPlugin extends BaseWatchPlugin {
   private _hasSnapshotFailure: boolean;
   isInternal: true;
 
-  constructor(options: {stdin: NodeJS.ReadStream; stdout: NodeJS.WriteStream}) {
+  constructor(options: {stdin: ReadStream; stdout: WriteStream}) {
     super(options);
     this.isInternal = true;
     this._hasSnapshotFailure = false;

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -7,6 +7,7 @@
 
 import * as path from 'path';
 import {performance} from 'perf_hooks';
+import type {WriteStream} from 'tty';
 import chalk = require('chalk');
 import exit = require('exit');
 import * as fs from 'graceful-fs';
@@ -36,7 +37,7 @@ import type {Filter, TestRunData} from './types';
 const getTestPaths = async (
   globalConfig: Config.GlobalConfig,
   source: SearchSource,
-  outputStream: NodeJS.WriteStream,
+  outputStream: WriteStream,
   changedFiles: ChangedFiles | undefined,
   jestHooks: JestHookEmitter,
   filter?: Filter,
@@ -74,7 +75,7 @@ type ProcessResultOptions = Pick<
 > & {
   collectHandles?: HandleCollectionResult;
   onComplete?: (result: AggregatedResult) => void;
-  outputStream: NodeJS.WriteStream;
+  outputStream: WriteStream;
 };
 
 const processResults = async (
@@ -142,7 +143,7 @@ export default async function runJest({
 }: {
   globalConfig: Config.GlobalConfig;
   contexts: Array<TestContext>;
-  outputStream: NodeJS.WriteStream;
+  outputStream: WriteStream;
   testWatcher: TestWatcher;
   jestHooks?: JestHookEmitter;
   startRun: (globalConfig: Config.GlobalConfig) => void;

--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -6,6 +6,7 @@
  */
 
 import * as path from 'path';
+import type {WriteStream} from 'tty';
 import ansiEscapes = require('ansi-escapes');
 import chalk = require('chalk');
 import exit = require('exit');
@@ -90,7 +91,7 @@ const RESERVED_KEY_PLUGINS = new Map<
 export default async function watch(
   initialGlobalConfig: Config.GlobalConfig,
   contexts: Array<TestContext>,
-  outputStream: NodeJS.WriteStream,
+  outputStream: WriteStream,
   hasteMapInstances: Array<HasteMap>,
   stdin: NodeJS.ReadStream = process.stdin,
   hooks: JestHook = new JestHook(),

--- a/packages/jest-reporters/src/DefaultReporter.ts
+++ b/packages/jest-reporters/src/DefaultReporter.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {WriteStream} from 'tty';
 import chalk = require('chalk');
 import {getConsoleOutput} from '@jest/console';
 import type {
@@ -26,7 +27,7 @@ import getResultHeader from './getResultHeader';
 import getSnapshotStatus from './getSnapshotStatus';
 import type {ReporterOnStartOptions} from './types';
 
-type write = NodeJS.WriteStream['write'];
+type write = WriteStream['write'];
 type FlushBufferedOutput = () => void;
 
 const TITLE_BULLET = chalk.bold('\u25cf ');
@@ -57,9 +58,7 @@ export default class DefaultReporter extends BaseReporter {
     });
   }
 
-  protected __wrapStdio(
-    stream: NodeJS.WritableStream | NodeJS.WriteStream,
-  ): void {
+  protected __wrapStdio(stream: NodeJS.WritableStream | WriteStream): void {
     const write = stream.write.bind(stream);
 
     let buffer: Array<string> = [];

--- a/packages/jest-reporters/src/VerboseReporter.ts
+++ b/packages/jest-reporters/src/VerboseReporter.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {WriteStream} from 'tty';
 import chalk = require('chalk');
 import type {
   AggregatedResult,
@@ -32,7 +33,7 @@ export default class VerboseReporter extends DefaultReporter {
   // Verbose mode is for debugging. Buffering of output is undesirable.
   // See https://github.com/jestjs/jest/issues/8208
   protected override __wrapStdio(
-    stream: NodeJS.WritableStream | NodeJS.WriteStream,
+    stream: NodeJS.WritableStream | WriteStream,
   ): void {
     const write = stream.write.bind(stream);
 

--- a/packages/jest-util/src/clearLine.ts
+++ b/packages/jest-util/src/clearLine.ts
@@ -5,7 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-export default function clearLine(stream: NodeJS.WriteStream): void {
+import type {WriteStream} from 'tty';
+
+export default function clearLine(stream: WriteStream): void {
   if (stream.isTTY) {
     stream.write('\x1b[999D\x1b[K');
   }

--- a/packages/jest-util/src/preRunMessage.ts
+++ b/packages/jest-util/src/preRunMessage.ts
@@ -5,17 +5,18 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {WriteStream} from 'tty';
 import chalk = require('chalk');
 import clearLine from './clearLine';
 import isInteractive from './isInteractive';
 
-export function print(stream: NodeJS.WriteStream): void {
+export function print(stream: WriteStream): void {
   if (isInteractive) {
     stream.write(chalk.bold.dim('Determining test suites to run...'));
   }
 }
 
-export function remove(stream: NodeJS.WriteStream): void {
+export function remove(stream: WriteStream): void {
   if (isInteractive) {
     clearLine(stream);
   }

--- a/packages/jest-watcher/src/BaseWatchPlugin.ts
+++ b/packages/jest-watcher/src/BaseWatchPlugin.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {ReadStream, WriteStream} from 'tty';
 import type {Config} from '@jest/types';
 import type {
   JestHookSubscriber,
@@ -14,16 +15,10 @@ import type {
 } from './types';
 
 abstract class BaseWatchPlugin implements WatchPlugin {
-  protected _stdin: NodeJS.ReadStream;
-  protected _stdout: NodeJS.WriteStream;
+  protected _stdin: ReadStream;
+  protected _stdout: WriteStream;
 
-  constructor({
-    stdin,
-    stdout,
-  }: {
-    stdin: NodeJS.ReadStream;
-    stdout: NodeJS.WriteStream;
-  }) {
+  constructor({stdin, stdout}: {stdin: ReadStream; stdout: WriteStream}) {
     this._stdin = stdin;
     this._stdout = stdout;
   }

--- a/packages/jest-watcher/src/types.ts
+++ b/packages/jest-watcher/src/types.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {ReadStream, WriteStream} from 'tty';
 import type {AggregatedResult} from '@jest/test-result';
 import type {Config} from '@jest/types';
 
@@ -83,8 +84,8 @@ export interface WatchPlugin {
 export interface WatchPluginClass {
   new (options: {
     config: Record<string, unknown>;
-    stdin: NodeJS.ReadStream;
-    stdout: NodeJS.WriteStream;
+    stdin: ReadStream;
+    stdout: WriteStream;
   }): WatchPlugin;
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Using `NodeJS` namespace oftentimes has unintended consequences. In this specific case, it pulls in the `pnpapi` as it enhances `ProcessVersions` in https://github.com/jestjs/jest/pull/14062/files#r1343566361

Migrating to explicit imports circumvents this

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
