### PR TITLE
fix: coverage badge is broken at readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://github.com/jestjs/jest/actions/workflows/nodejs.yml"><img alt="GitHub CI Status" src="https://img.shields.io/github/actions/workflow/status/facebook/jest/nodejs.yml?label=CI&logo=GitHub"></a>
-  <a href="https://codecov.io/github/facebook/jest"><img alt="Coverage Status" src="https://img.shields.io/codecov/c/github/facebook/jest/main.svg?maxAge=43200"></a>
+  <a href="https://github.com/jestjs/jest/actions/workflows/nodejs.yml"><img alt="GitHub CI Status" src="https://img.shields.io/github/actions/workflow/status/jestjs/jest/nodejs.yml?label=CI&logo=GitHub"></a>
+  <a href="https://codecov.io/github/jestjs/jest"><img alt="Coverage Status" src="https://img.shields.io/codecov/c/github/jestjs/jest/main.svg?maxAge=43200"></a>
 </p>
 <p align="center">
   <a href="https://gitpod.io/#https://github.com/jestjs/jest"><img alt="Gitpod ready-to-code" src="https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod"></a>


### PR DESCRIPTION
## Summary

Fixes readme links pointing to incorrect URLs. 
This will make the coverage badge provided by shields.io to work back again, see:
![imagen](https://github.com/jestjs/jest/assets/1280022/aed9d179-a7de-4182-8580-54a13eb6d6ba)



## Test plan

N/A
