### PR TITLE
feat(types): Add type definition for default constructor in IJestHasteMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[jest-circus, jest-expect, jest-snapshot]` Pass `test.failing` tests when containing failing snapshot matchers ([#14313](https://github.com/jestjs/jest/pull/14313))
 - `[jest-config]` Make sure to respect `runInBand` option ([#14578](https://github.com/facebook/jest/pull/14578))
 - `[@jest/expect-utils]` Fix comparison of `DataView` ([#14408](https://github.com/jestjs/jest/pull/14408))
+- `[jest-haste-map]` Add type definition for default constructor in `IJestHasteMap` ([#14612](https://github.com/jestjs/jest/pull/14612))
 - `[jest-leak-detector]` Make leak-detector more aggressive when running GC ([#14526](https://github.com/jestjs/jest/pull/14526))
 - `[jest-runtime]` Properly handle re-exported native modules in ESM via CJS ([#14589](https://github.com/jestjs/jest/pull/14589))
 - `[jest-util]` Make sure `isInteractive` works in a browser ([#14552](https://github.com/jestjs/jest/pull/14552))
@@ -44,6 +45,7 @@
 - `[*]` Depend on exact versions of monorepo dependencies instead of `^` range ([#14553](https://github.com/facebook/jest/pull/14553))
 - `[babel-jest, babel-preset-jest]` [**BREAKING**] Increase peer dependency of `@babel/core` to `^7.11` ([#14109](https://github.com/jestjs/jest/pull/14109))
 - `[jest-cli, jest-config, @jest/types]` [**BREAKING**] Remove deprecated `--init` argument ([#14490](https://github.com/jestjs/jest/pull/14490))
+- `[jest-haste-map]` provide docs for jest-haste-map package ([#14613](https://github.com/jestjs/jest/pull/14613))
 
 ## 29.7.0
 

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -1149,7 +1149,9 @@ function copyMap<K, V>(input: Map<K, V>): Map<K, V> {
 type IJestHasteMap = HasteMapStatic & {
   create(options: Options): Promise<IHasteMap>;
   getStatic(config: Config.ProjectConfig): HasteMapStatic;
-  default: (new (options: Options) => IHasteMap);
+  default: new (options: Options) => IHasteMap;
 };
+
+// @ts-expect-error(property `default is missing in  HasteMap class`)
 const JestHasteMap: IJestHasteMap = HasteMap;
 export default JestHasteMap;

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -1149,6 +1149,7 @@ function copyMap<K, V>(input: Map<K, V>): Map<K, V> {
 type IJestHasteMap = HasteMapStatic & {
   create(options: Options): Promise<IHasteMap>;
   getStatic(config: Config.ProjectConfig): HasteMapStatic;
+  default: (new (options: Options) => IHasteMap);
 };
 const JestHasteMap: IJestHasteMap = HasteMap;
 export default JestHasteMap;

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -1152,6 +1152,5 @@ type IJestHasteMap = HasteMapStatic & {
   default: new (options: Options) => IHasteMap;
 };
 
-// @ts-expect-error(property `default is missing in  HasteMap class`)
-const JestHasteMap: IJestHasteMap = HasteMap;
+const JestHasteMap: IJestHasteMap = HasteMap as unknown as IJestHasteMap;
 export default JestHasteMap;


### PR DESCRIPTION
## Summary

This commit adds a type definition for the default constructor in the `IJestHasteMap` interface. Now, the type system will recognize the default constructor as a new instance of `IHasteMap`, allowing for more accurate type checking and improved code assistance.

Before, when initializing a new HasteMap, the result was of type `any`.
After adding type definitions for default constructor, now the result have a type of `IHasteMap`.
This will result in improved developer experience while using `jest-haste-map` package.

## Test plan

Before adding those type definitions, it looked like this : 

<img width="861" alt="image" src="https://github.com/jestjs/jest/assets/96414111/d269387f-5ae1-4f45-a3c4-d257ab7d10e7">

and the resulting `map` had type of `any`

after adding type definitions , now it  looks like this : 

<img width="830" alt="image" src="https://github.com/jestjs/jest/assets/96414111/b4c60ea0-bd06-4eac-8099-e3db6e1d59e4">

And the resulting `map` now has the type of `IHasteMap`

