### PR TITLE
fix: log unhandled error even if its stack is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[jest-cli]` When specifying paths on the command line, only match against the relative paths of the test files ([#12519](https://github.com/facebook/jest/pull/12519))
   - [**BREAKING**] Changes `testPathPattern` configuration option to `testPathPatterns`, which now takes a list of patterns instead of the regex.
   - [**BREAKING**] `--testPathPattern` is now `--testPathPatterns`
+- `[jest-reporters, jest-runner]` Unhandled errors without stack get correctly logged to console ([#14619](https://github.com/facebook/jest/pull/14619))
 
 ### Performance
 

--- a/packages/jest-reporters/src/CoverageWorker.ts
+++ b/packages/jest-reporters/src/CoverageWorker.ts
@@ -33,7 +33,11 @@ export type CoverageWorkerData = {
 
 // Make sure uncaught errors are logged before we exit.
 process.on('uncaughtException', err => {
-  console.error(err.stack);
+  if (err.stack) {
+    console.error(err.stack);
+  } else {
+    console.error(err);
+  }
   exit(1);
 });
 

--- a/packages/jest-runner/src/testWorker.ts
+++ b/packages/jest-runner/src/testWorker.ts
@@ -35,7 +35,11 @@ type WorkerData = {
 
 // Make sure uncaught errors are logged before we exit.
 process.on('uncaughtException', err => {
-  console.error(err.stack);
+  if (err.stack) {
+    console.error(err.stack);
+  } else {
+    console.error(err);
+  }
   exit(1);
 });
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I ran into an issue when jest (`jest --coverage --runInBand --testTimeout=120000`) would stop with exit code 1 without any error message.

Upon further investigation, I found it's caused by `uncaughtException` handler in `CoverageWorker.ts` that only logs `err.stack` and the error I was encountering didn't have any stack (it was set to an empty string).
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I ran `jest --coverage --runInBand --testTimeout=120000` again and the error message got printed to console as expected:
```
error TS2307: Cannot find module '[redacted]' or its corresponding type declarations.
```

I didn't find any automated tests covering this behavior and I can't think of a good way to implement one.