### PR TITLE
Fix jest.spyOn() unit test in JestObjectAPI.md

### DIFF
--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -753,7 +753,7 @@ afterEach(() => {
 
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play', 'get'); // we pass 'get'
-  const isPlaying = video.play();
+  const isPlaying = video.play;
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);

--- a/website/versioned_docs/version-29.4/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.4/JestObjectAPI.md
@@ -753,7 +753,7 @@ afterEach(() => {
 
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play', 'get'); // we pass 'get'
-  const isPlaying = video.play();
+  const isPlaying = video.play;
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);

--- a/website/versioned_docs/version-29.5/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.5/JestObjectAPI.md
@@ -753,7 +753,7 @@ afterEach(() => {
 
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play', 'get'); // we pass 'get'
-  const isPlaying = video.play();
+  const isPlaying = video.play;
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);

--- a/website/versioned_docs/version-29.6/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.6/JestObjectAPI.md
@@ -753,7 +753,7 @@ afterEach(() => {
 
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play', 'get'); // we pass 'get'
-  const isPlaying = video.play();
+  const isPlaying = video.play;
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);

--- a/website/versioned_docs/version-29.7/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.7/JestObjectAPI.md
@@ -753,7 +753,7 @@ afterEach(() => {
 
 test('plays video', () => {
   const spy = jest.spyOn(video, 'play', 'get'); // we pass 'get'
-  const isPlaying = video.play();
+  const isPlaying = video.play;
 
   expect(spy).toHaveBeenCalled();
   expect(isPlaying).toBe(true);


### PR DESCRIPTION
## Summary

Since the exiting unit test mentioned at https://jestjs.io/docs/jest-object#jestspyonobject-methodname-accesstype gets failed dues to `play` being called as function, this PR fixes the test by accessing the play method as property due to its getter definition
