### PR TITLE
fix: add missed @babel/preset-env installation

### DIFF
--- a/website/versioned_docs/version-29.7/GettingStarted.md
+++ b/website/versioned_docs/version-29.7/GettingStarted.md
@@ -138,7 +138,7 @@ Jest can be used in projects that use [parcel-bundler](https://parceljs.org/) to
 Jest supports TypeScript, via Babel. First, make sure you followed the instructions on [using Babel](#using-babel) above. Next, install the `@babel/preset-typescript`:
 
 ```bash npm2yarn
-npm install --save-dev @babel/preset-typescript
+npm install --save-dev @babel/preset-typescript @babel/preset-env
 ```
 
 Then add `@babel/preset-typescript` to the list of presets in your `babel.config.js`.


### PR DESCRIPTION
## Summary

I found that the installation of `@babel/preset-env` is not mentioned in the guide but is one of the dependencies.
