### PR TITLE
chore(docs): include `additionalLanguages` for Prism

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -223,6 +223,7 @@ const config = {
       },
       image: 'img/opengraph.png',
       prism: {
+        additionalLanguages: ['bash', 'diff', 'json'],
         theme: require('./src/prism/themeLight'),
         darkTheme: require('./src/prism/themeDark'),
       },

--- a/website/package.json
+++ b/website/package.json
@@ -32,13 +32,14 @@
     ]
   },
   "dependencies": {
-    "@docusaurus/core": "^3.0.0-beta.0",
+    "@docusaurus/core": "3.0.0-rc.0",
     "@docusaurus/plugin-client-redirects": "3.0.0-rc.0",
     "@docusaurus/plugin-pwa": "3.0.0-rc.0",
     "@docusaurus/preset-classic": "3.0.0-rc.0",
     "@docusaurus/remark-plugin-npm2yarn": "3.0.0-rc.0",
     "clsx": "^2.0.0",
     "docusaurus-remark-plugin-tab-blocks": "^2.0.0-rc.0",
+    "prism-react-renderer": "^2.1.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-github-btn": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2040,7 +2040,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@docusaurus/core@npm:3.0.0-rc.0, @docusaurus/core@npm:^3.0.0-beta.0":
+"@docusaurus/core@npm:3.0.0-rc.0":
   version: 3.0.0-rc.0
   resolution: "@docusaurus/core@npm:3.0.0-rc.0"
   dependencies:
@@ -13276,7 +13276,7 @@ __metadata:
   dependencies:
     "@babel/core": ^7.11.6
     "@crowdin/cli": ^3.5.2
-    "@docusaurus/core": ^3.0.0-beta.0
+    "@docusaurus/core": 3.0.0-rc.0
     "@docusaurus/module-type-aliases": 3.0.0-rc.0
     "@docusaurus/plugin-client-redirects": 3.0.0-rc.0
     "@docusaurus/plugin-pwa": 3.0.0-rc.0
@@ -13289,6 +13289,7 @@ __metadata:
     graphql: ^16.3.0
     graphql-request: ^6.0.0
     js-yaml: ^4.1.0
+    prism-react-renderer: ^2.1.0
     react: 18.2.0
     react-dom: 18.2.0
     react-github-btn: ^1.3.0


### PR DESCRIPTION
Following up #14629

## Summary

Docusaurus upgrade guide is mentioning that new version of `react-prism-render` does not include as many languages as before. It suggested adding those via config: https://docusaurus.io/docs/next/migration/v3#prism-react-renderer-v20

Currently missing highlighting can be seen in [Getting Start](https://jestjs.io/docs/getting-started) page (bash, json) and [upgrading guide](https://jestjs.io/docs/upgrading-to-jest29) page (diff).

## Test plan

Deploy preview.