### PR TITLE
Fix typos in change log and docs of jest-validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -633,7 +633,7 @@
 
 ### Fixes
 
-- `[*]` Use `sha256` instead of `md5` as hashing algortihm for compatibility with FIPS systems ([#12722](https://github.com/facebook/jest/pull/12722))
+- `[*]` Use `sha256` instead of `md5` as hashing algorithm for compatibility with FIPS systems ([#12722](https://github.com/facebook/jest/pull/12722))
 - `[babel-jest]` [**BREAKING**] Pass `rootDir` as `root` in Babel's options ([#12689](https://github.com/facebook/jest/pull/12689))
 - `[expect]` Move typings of `.not`, `.rejects` and `.resolves` modifiers outside of `Matchers` interface ([#12346](https://github.com/facebook/jest/pull/12346))
 - `[expect]` Throw useful error if `expect.extend` is called with invalid matchers ([#12488](https://github.com/facebook/jest/pull/12488))
@@ -1440,7 +1440,7 @@
 - `[*]` Upgrade to chalk@4 ([#9752](https://github.com/facebook/jest/pull/9752))
 - `[*]` Remove usage of `realpath-native` ([#9952](https://github.com/facebook/jest/pull/9952))
 - `[docs]` Fix example reference implementation to use Jest with Phabricator ([#8662](https://github.com/facebook/jest/pull/8662))
-- `[docs]` Added default compiler to tranform ([#8583](https://github.com/facebook/jest/pull/8583))
+- `[docs]` Added default compiler to transform ([#8583](https://github.com/facebook/jest/pull/8583))
 - `[docs]` Updated Testing Frameworks guide with React; make it generic ([#9106](https://github.com/facebook/jest/pull/9106))
 - `[expect, jest-mock, pretty-format]` [**BREAKING**] Remove `build-es5` from package ([#9945](https://github.com/facebook/jest/pull/9945))
 - `[@jest/fake-timers, @jest/environment]` [**BREAKING**] Rename `LolexFakeTimers` to `ModernFakeTimers` ([#9960](https://github.com/facebook/jest/pull/9960))
@@ -3480,7 +3480,7 @@ See <https://jestjs.io/blog/2016/12/15/2016-in-jest>
 - Added `--watchAll`, made `--watch` interactive and added the ability to update snapshots and select test patterns in watch mode.
 - Jest uses verbose mode when running a single test file.
 - Console messages are now buffered and printed along with the test results.
-- Fix `testEnvironment` resolution to prefer `jest-environment-{name}` instead of `{name}` only. This prevents a module colision when using `jsdom` as test environment.
+- Fix `testEnvironment` resolution to prefer `jest-environment-{name}` instead of `{name}` only. This prevents a module collision when using `jsdom` as test environment.
 - `moduleNameMapper` now uses a resolution algorithm.
 - Improved performance for small test runs.
 - Improved API documentation.
@@ -3619,7 +3619,7 @@ See <https://jestjs.io/blog/2016/12/15/2016-in-jest>
 - Clear the terminal window when using `--watch`.
 - By default, `--watch` will now only runs tests related to changed files. `--watch=all` can be used to run all tests on file system changes.
 - Debounce `--watch` re-runs to not trigger test runs during a branch switch in version control.
-- Added `jest.fn()` and `jest.fn(implementation)` as convenient shorcuts for `jest.genMockFunction()` and `jest.genMockFunction().mockImplementation()`.
+- Added `jest.fn()` and `jest.fn(implementation)` as convenient shortcuts for `jest.genMockFunction()` and `jest.genMockFunction().mockImplementation()`.
 - Added an `automock` option to turn off automocking globally.
 - Added a "no tests found" message if no tests can be found.
 - Jest sets `process.NODE_ENV` to `test` unless otherwise specified.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 - `[*]` Depend on exact versions of monorepo dependencies instead of `^` range ([#14553](https://github.com/facebook/jest/pull/14553))
 - `[babel-jest, babel-preset-jest]` [**BREAKING**] Increase peer dependency of `@babel/core` to `^7.11` ([#14109](https://github.com/jestjs/jest/pull/14109))
 - `[jest-cli, jest-config, @jest/types]` [**BREAKING**] Remove deprecated `--init` argument ([#14490](https://github.com/jestjs/jest/pull/14490))
+- `[docs]` Fix typos in `CHANGELOG.md` and `packages/jest-validate/README.md` ([#14640](https://github.com/jestjs/jest/pull/14640))
 
 ## 29.7.0
 

--- a/packages/jest-validate/README.md
+++ b/packages/jest-validate/README.md
@@ -203,7 +203,7 @@ import {validate} from 'jest-validate';
 validateCLIOptions(argv, {...allowedOptions, deprecatedOptions});
 ```
 
-If `argv` contains a deprecated option that is not specifid in `allowedOptions`, `validateCLIOptions` will throw an error with the message specified in the `deprecatedOptions` config:
+If `argv` contains a deprecated option that is not specified in `allowedOptions`, `validateCLIOptions` will throw an error with the message specified in the `deprecatedOptions` config:
 
 ```bash
 ● collectCoverageOnlyFrom:
@@ -213,4 +213,4 @@ If `argv` contains a deprecated option that is not specifid in `allowedOptions`,
   CLI Options Documentation: https://jestjs.io/docs/en/cli.html
 ```
 
-If the deprecation option is still listed in the `allowedOptions` config, then `validateCLIOptions` will print the warning wihout throwing an error.
+If the deprecation option is still listed in the `allowedOptions` config, then `validateCLIOptions` will print the warning without throwing an error.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This pull request fixes typos in `CHANGELOG.md` and `packages/jest-validate/README.md`. Following are the fixed typos:
1. algortihm -> algorithm
2. tranform -> transform 
3. colision -> collision
4. shorcuts -> shortcuts
5. specifid -> specified
6. wihout -> without

This pull request enhances the readability of the documentations. I kindly request the repository maintainers to review and merge it. Thanks! :heart: