### PR TITLE
chore: extend from the `@tsconfig/node16` base for type tests

### DIFF
--- a/tsconfig.typetest.json
+++ b/tsconfig.typetest.json
@@ -1,5 +1,5 @@
 {
-  "extends": "@tsconfig/node14/tsconfig.json",
+  "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
     "module": "commonjs",
     "moduleResolution": "node",


### PR DESCRIPTION
## Summary

It would be good to extend from the `@tsconfig/node16` base for type tests as well. Somehow missed it before (;

## Test plan

Green CI.