### PR TITLE
fix: add ESM exports of all modules manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 ### Performance
 
-- `[*]` [**BREAKING**] Bundle all of Jest's modules into `index.js` ([#12348](https://github.com/jestjs/jest/pull/12348), [#14550](https://github.com/jestjs/jest/pull/14550) & [#14661](https://github.com/jestjs/jest/pull/14661))
+- `[*]` [**BREAKING**] Bundle all of Jest's modules into `index.js`, and export proper ESM wrapper ([#12348](https://github.com/jestjs/jest/pull/12348), [#14550](https://github.com/jestjs/jest/pull/14550) & [#14661](https://github.com/jestjs/jest/pull/14661))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@
 
 ### Performance
 
-- `[*]` [**BREAKING**] Bundle all of Jest's modules into `index.js` ([#12348](https://github.com/jestjs/jest/pull/12348) & [#14550](https://github.com/jestjs/jest/pull/14550))
+- `[*]` [**BREAKING**] Bundle all of Jest's modules into `index.js` ([#12348](https://github.com/jestjs/jest/pull/12348), [#14550](https://github.com/jestjs/jest/pull/14550) & [#14661](https://github.com/jestjs/jest/pull/14661))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,13 +35,14 @@
 
 ### Performance
 
-- `[*]` [**BREAKING**] Bundle all of Jest's modules into `index.js`, and export proper ESM wrapper ([#12348](https://github.com/jestjs/jest/pull/12348), [#14550](https://github.com/jestjs/jest/pull/14550) & [#14661](https://github.com/jestjs/jest/pull/14661))
+- `[*]` [**BREAKING**] Bundle all of Jest's modules into `index.js` ([#12348](https://github.com/jestjs/jest/pull/12348), [#14550](https://github.com/jestjs/jest/pull/14550) & [#14661](https://github.com/jestjs/jest/pull/14661))
 
 ### Chore & Maintenance
 
 - `[*]` [**BREAKING**] Drop support for Node.js versions 14 and 19 ([#14460](https://github.com/jestjs/jest/pull/14460))
 - `[*]` [**BREAKING**] Drop support for `typescript@4.3`, minimum version is now `5.0` ([#14542](https://github.com/facebook/jest/pull/14542))
 - `[*]` Depend on exact versions of monorepo dependencies instead of `^` range ([#14553](https://github.com/facebook/jest/pull/14553))
+- `[*]` [**BREAKING**] Add ESM wrapper for all of Jest's modules ([#14661](https://github.com/jestjs/jest/pull/14661))
 - `[babel-jest, babel-preset-jest]` [**BREAKING**] Increase peer dependency of `@babel/core` to `^7.11` ([#14109](https://github.com/jestjs/jest/pull/14109))
 - `[jest-cli, jest-config, @jest/types]` [**BREAKING**] Remove deprecated `--init` argument ([#14490](https://github.com/jestjs/jest/pull/14490))
 - `[docs]` Fix typos in `CHANGELOG.md` and `packages/jest-validate/README.md` ([#14640](https://github.com/jestjs/jest/pull/14640))

--- a/e2e/custom-esm-test-sequencer/testSequencer.mjs
+++ b/e2e/custom-esm-test-sequencer/testSequencer.mjs
@@ -7,7 +7,7 @@
 
 import Sequencer from '@jest/test-sequencer';
 
-export default class CustomSequencer extends Sequencer.default {
+export default class CustomSequencer extends Sequencer {
   sort(tests) {
     const copyTests = Array.from(tests);
     return copyTests.sort((testA, testB) => (testA.path > testB.path ? 1 : -1));

--- a/e2e/global-setup-esm/setup.js
+++ b/e2e/global-setup-esm/setup.js
@@ -8,9 +8,7 @@ import * as crypto from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
 import fs from 'graceful-fs';
-import jestUtil from 'jest-util';
-
-const {createDirectory} = jestUtil;
+import {createDirectory} from 'jest-util';
 
 const DIR = path.join(os.tmpdir(), 'jest-global-setup-esm');
 

--- a/e2e/global-teardown-esm/teardown.js
+++ b/e2e/global-teardown-esm/teardown.js
@@ -8,9 +8,7 @@ import * as crypto from 'crypto';
 import * as os from 'os';
 import * as path from 'path';
 import fs from 'graceful-fs';
-import jestUtil from 'jest-util';
-
-const {createDirectory} = jestUtil;
+import {createDirectory} from 'jest-util';
 
 const DIR = path.join(os.tmpdir(), 'jest-global-teardown-esm');
 

--- a/e2e/transform/transform-esm-runner/runner.mjs
+++ b/e2e/transform/transform-esm-runner/runner.mjs
@@ -5,9 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import testResult from '@jest/test-result';
-
-const {createEmptyTestResult} = testResult;
+import {createEmptyTestResult} from '@jest/test-result';
 
 export default class BaseTestRunner {
   constructor(globalConfig, context) {

--- a/e2e/transform/transform-esm-testrunner/test-runner.mjs
+++ b/e2e/transform/transform-esm-testrunner/test-runner.mjs
@@ -4,9 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import testResult from '@jest/test-result';
 
-const {createEmptyTestResult} = testResult;
+import {createEmptyTestResult} from '@jest/test-result';
 
 export default async function testRunner(
   globalConfig,

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "rimraf": "^5.0.0",
     "semver": "^7.5.3",
     "slash": "^3.0.0",
-    "string-length": "^4.0.1",
     "strip-ansi": "^6.0.0",
     "strip-json-comments": "^3.1.1",
     "tempy": "^1.0.0",

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -13,6 +13,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -13,6 +13,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/create-jest/package.json
+++ b/packages/create-jest/package.json
@@ -14,6 +14,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json",

--- a/packages/create-jest/package.json
+++ b/packages/create-jest/package.json
@@ -14,6 +14,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/diff-sequences/package.json
+++ b/packages/diff-sequences/package.json
@@ -23,6 +23,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/diff-sequences/package.json
+++ b/packages/diff-sequences/package.json
@@ -23,6 +23,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/expect-utils/package.json
+++ b/packages/expect-utils/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/expect-utils/package.json
+++ b/packages/expect-utils/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json",

--- a/packages/expect/package.json
+++ b/packages/expect/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json",

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json",

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-create-cache-key-function/package.json
+++ b/packages/jest-create-cache-key-function/package.json
@@ -22,6 +22,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-create-cache-key-function/package.json
+++ b/packages/jest-create-cache-key-function/package.json
@@ -22,6 +22,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-docblock/package.json
+++ b/packages/jest-docblock/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-docblock/package.json
+++ b/packages/jest-docblock/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-each/package.json
+++ b/packages/jest-each/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-each/package.json
+++ b/packages/jest-each/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-expect/package.json
+++ b/packages/jest-expect/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-expect/package.json
+++ b/packages/jest-expect/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-fake-timers/package.json
+++ b/packages/jest-fake-timers/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-fake-timers/package.json
+++ b/packages/jest-fake-timers/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-get-type/package.json
+++ b/packages/jest-get-type/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-get-type/package.json
+++ b/packages/jest-get-type/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-leak-detector/package.json
+++ b/packages/jest-leak-detector/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-matcher-utils/package.json
+++ b/packages/jest-matcher-utils/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -15,6 +15,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-phabricator/package.json
+++ b/packages/jest-phabricator/package.json
@@ -10,6 +10,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-phabricator/package.json
+++ b/packages/jest-phabricator/package.json
@@ -10,6 +10,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-regex-util/package.json
+++ b/packages/jest-regex-util/package.json
@@ -18,6 +18,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-regex-util/package.json
+++ b/packages/jest-regex-util/package.json
@@ -18,6 +18,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json",

--- a/packages/jest-repl/package.json
+++ b/packages/jest-repl/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-resolve-dependencies/package.json
+++ b/packages/jest-resolve-dependencies/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-schemas/package.json
+++ b/packages/jest-schemas/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-schemas/package.json
+++ b/packages/jest-schemas/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-snapshot/package.json
+++ b/packages/jest-snapshot/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-source-map/package.json
+++ b/packages/jest-source-map/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-source-map/package.json
+++ b/packages/jest-source-map/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-test-result/package.json
+++ b/packages/jest-test-result/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-test-result/package.json
+++ b/packages/jest-test-result/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-test-sequencer/package.json
+++ b/packages/jest-test-sequencer/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-test-sequencer/package.json
+++ b/packages/jest-test-sequencer/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-validate/package.json
+++ b/packages/jest-validate/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-watcher/package.json
+++ b/packages/jest-watcher/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-watcher/package.json
+++ b/packages/jest-watcher/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/jest-worker/package.json
+++ b/packages/jest-worker/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -13,6 +13,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -13,6 +13,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "import": "./build/index.mjs",
       "default": "./build/index.js"
     },
     "./package.json": "./package.json"

--- a/packages/test-utils/package.json
+++ b/packages/test-utils/package.json
@@ -7,6 +7,7 @@
   "exports": {
     ".": {
       "types": "./build/index.d.ts",
+      "require": "./build/index.js",
       "import": "./build/index.mjs",
       "default": "./build/index.js"
     },

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -65,6 +65,7 @@ async function buildNodePackages() {
       continue;
     }
 
+    // TODO: can we get exports from a file from webpack's `stats`?
     const cjsModule = require(entryPointFile);
     const exportStatements = Object.keys(cjsModule)
       .filter(name => name !== '__esModule' && name !== 'default')

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -66,13 +66,13 @@ async function buildNodePackages() {
       continue;
     }
 
-    const entryPoint = require(entryPointFile);
-    const exportStatements = Object.keys(entryPoint)
+    const cjsModule = require(entryPointFile);
+    const exportStatements = Object.keys(cjsModule)
       .filter(name => name !== '__esModule' && name !== 'default')
-      .map(name => `export const ${name} = cjsExports.${name};`);
+      .map(name => `export const ${name} = cjsModule.${name};`);
 
-    if (entryPoint.default) {
-      exportStatements.push('export default cjsExports.default;');
+    if (cjsModule.default) {
+      exportStatements.push('export default cjsModule.default;');
     }
 
     if (exportStatements.length === 0) {
@@ -82,8 +82,7 @@ async function buildNodePackages() {
     const mjsEntryFile = entryPointFile.replace(/\.js$/, '.mjs');
 
     const esSource = dedent`
-      const entryPoint = await import('./index.js');
-      const cjsExports = entryPoint.default;
+      import cjsModule from './index.js';
 
       ${exportStatements.join('\n')}
     `;

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -61,7 +61,6 @@ async function buildNodePackages() {
       `Main file "${pkg.main}" in "${pkg.name}" should exist`,
     );
 
-    // type only packages
     if (typeOnlyPackages.has(pkg.name)) {
       continue;
     }

--- a/scripts/build.mjs
+++ b/scripts/build.mjs
@@ -69,10 +69,10 @@ async function buildNodePackages() {
     const entryPoint = require(entryPointFile);
     const exportStatements = Object.keys(entryPoint)
       .filter(name => name !== '__esModule' && name !== 'default')
-      .map(name => `export const ${name} = entryPoint.${name};`);
+      .map(name => `export const ${name} = cjsExports.${name};`);
 
     if (entryPoint.default) {
-      exportStatements.push('export default entryPoint.default;');
+      exportStatements.push('export default cjsExports.default;');
     }
 
     if (exportStatements.length === 0) {
@@ -82,11 +82,8 @@ async function buildNodePackages() {
     const mjsEntryFile = entryPointFile.replace(/\.js$/, '.mjs');
 
     const esSource = dedent`
-      import {createRequire} from 'module';
-
-      const require = createRequire(import.meta.url);
-
-      const entryPoint = require('./index.js');
+      const entryPoint = await import('./index.js');
+      const cjsExports = entryPoint.default;
 
       ${exportStatements.join('\n')}
     `;

--- a/scripts/buildUtils.mjs
+++ b/scripts/buildUtils.mjs
@@ -12,7 +12,6 @@ import {fileURLToPath} from 'url';
 import chalk from 'chalk';
 import fs from 'graceful-fs';
 import {sync as readPkg} from 'read-pkg';
-import stringLength from 'string-length';
 import webpack from 'webpack';
 import nodeExternals from 'webpack-node-externals';
 import babelConfig from '../babel.config.js';

--- a/scripts/buildUtils.mjs
+++ b/scripts/buildUtils.mjs
@@ -74,6 +74,7 @@ export function getPackages() {
               }
             : {
                 types: pkg.types,
+                require: pkg.main,
                 import: pkg.main.replace(/\.js$/, '.mjs'),
                 default: pkg.main,
               },

--- a/scripts/buildUtils.mjs
+++ b/scripts/buildUtils.mjs
@@ -26,6 +26,14 @@ const require = createRequire(import.meta.url);
 export const OK = chalk.reset.inverse.bold.green(' DONE ');
 export const ERROR = chalk.reset.inverse.bold.red(' BOOM ');
 
+export const typeOnlyPackages = new Set([
+  'babel-preset-jest',
+  '@jest/environment',
+  '@jest/globals',
+  '@jest/types',
+  '@jest/test-globals',
+]);
+
 // Get absolute paths of all directories under packages/*
 export function getPackages() {
   const packages = fs
@@ -58,11 +66,18 @@ export function getPackages() {
         '.':
           pkg.types == null
             ? pkg.main
+            : typeOnlyPackages.has(pkg.name)
+            ? /* eslint-disable sort-keys */
+              {
+                types: pkg.types,
+                default: pkg.main,
+              }
             : {
                 types: pkg.types,
-                // eslint-disable-next-line sort-keys
+                import: pkg.main.replace(/\.js$/, '.mjs'),
                 default: pkg.main,
               },
+        /* eslint-enable */
         './package.json': './package.json',
         ...Object.values(pkg.bin || {}).reduce(
           (mem, curr) =>
@@ -115,17 +130,6 @@ export function getPackages() {
 
     return {packageDir, pkg};
   });
-}
-
-export function adjustToTerminalWidth(str) {
-  const columns = process.stdout.columns || 80;
-  const WIDTH = columns - stringLength(OK) + 1;
-  const strs = str.match(new RegExp(`(.{1,${WIDTH}})`, 'g'));
-  let lastString = strs[strs.length - 1];
-  if (lastString.length < WIDTH) {
-    lastString += Array(WIDTH - lastString.length).join(chalk.dim('.'));
-  }
-  return strs.slice(0, -1).concat(lastString).join('\n');
 }
 
 export function getPackagesWithTsConfig() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3012,7 +3012,6 @@ __metadata:
     rimraf: ^5.0.0
     semver: ^7.5.3
     slash: ^3.0.0
-    string-length: ^4.0.1
     strip-ansi: ^6.0.0
     strip-json-comments: ^3.1.1
     tempy: ^1.0.0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This is to work around https://github.com/nodejs/cjs-module-lexer/issues/88. We don't need to rely on a lexer as we can just check our exports at build time and create manual ESM export.

This should avoid the [dual package hazard](https://nodejs.org/api/packages.html#dual-package-hazard) as the wrapper is pretty much their recommendation.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
