### PR TITLE
chore: cleanup imports in `d.ts` files

### DIFF
--- a/scripts/buildUtils.mjs
+++ b/scripts/buildUtils.mjs
@@ -34,7 +34,7 @@ export const typeOnlyPackages = new Set([
 ]);
 
 // Get absolute paths of all directories under packages/*
-export function getPackages() {
+function getPackages() {
   const packages = fs
     .readdirSync(PACKAGES_DIR)
     .map(file => path.resolve(PACKAGES_DIR, file))

--- a/scripts/bundleTs.mjs
+++ b/scripts/bundleTs.mjs
@@ -14,16 +14,12 @@ import {
   ExtractorConfig,
 } from '@microsoft/api-extractor';
 import chalk from 'chalk';
+import {ESLint} from 'eslint';
 import {glob} from 'glob';
 import fs from 'graceful-fs';
 import pkgDir from 'pkg-dir';
-import prettier from 'prettier';
 import {rimraf} from 'rimraf';
 import {copyrightSnippet, getPackages} from './buildUtils.mjs';
-
-const prettierConfig = await prettier.resolveConfig(
-  fileURLToPath(import.meta.url).replace(/\.js$/, '.d.ts'),
-);
 
 const require = createRequire(import.meta.url);
 const typescriptCompilerFolder = await pkgDir(require.resolve('typescript'));
@@ -107,6 +103,20 @@ await fs.promises.writeFile(
   ),
   JSON.stringify(sharedExtractorConfig, null, 2),
 );
+
+const eslint = new ESLint({
+  cwd: process.cwd(),
+  fix: true,
+  overrideConfig: {
+    rules: {
+      // `d.ts` files are by nature `type` only imports, so it's just noise when looking at the file
+      '@typescript-eslint/consistent-type-imports': [
+        'error',
+        {prefer: 'no-type-imports'},
+      ],
+    },
+  },
+});
 
 let compilerState;
 
@@ -205,13 +215,16 @@ await Promise.all(
 
     definitionFile = [
       copyrightSnippet,
+      '',
       ...definitionFile.split(copyrightSnippet),
     ].join('\n');
 
-    const formattedContent = await prettier.format(definitionFile, {
-      ...prettierConfig,
-      filepath,
+    const [lintResult] = await eslint.lintText(definitionFile, {
+      filePath: 'some-file.ts',
     });
+
+    // if the autofixer did anything, the result is in `output`
+    const formattedContent = lintResult.output || definitionFile;
 
     await fs.promises.writeFile(
       filepath.replace(

--- a/scripts/bundleTs.mjs
+++ b/scripts/bundleTs.mjs
@@ -19,7 +19,7 @@ import {glob} from 'glob';
 import fs from 'graceful-fs';
 import pkgDir from 'pkg-dir';
 import {rimraf} from 'rimraf';
-import {copyrightSnippet, getPackages} from './buildUtils.mjs';
+import {copyrightSnippet, getPackagesWithTsConfig} from './buildUtils.mjs';
 
 const require = createRequire(import.meta.url);
 const typescriptCompilerFolder = await pkgDir(require.resolve('typescript'));
@@ -28,13 +28,8 @@ const typesNodeReferenceDirective = '/// <reference types="node" />';
 
 const excludedPackages = new Set(['@jest/globals', '@jest/test-globals']);
 
-const packages = getPackages();
-
-const isTsPackage = p =>
-  fs.existsSync(path.resolve(p.packageDir, 'tsconfig.json'));
-
-const packagesToBundle = packages.filter(
-  p => isTsPackage(p) && !excludedPackages.has(p.pkg.name),
+const packagesToBundle = getPackagesWithTsConfig().filter(
+  p => !excludedPackages.has(p.pkg.name),
 );
 
 console.log(chalk.inverse(' Extracting TypeScript definition files '));


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I looked at the bundled file, and it's quite noisy with a bunch of duplicate imports, and very inconsistent use of `type` keyword in imports.

This PR simply runs ESLint over the bundled file (replacing the `prettier` invocation that `eslint-plugin-prettier` has already run for us).

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

In addition, this is the full diff before and after this PR

<details>
<summary>Diff</summary>

```diff
diff --git i/packages/babel-jest/build/index.d.ts w/packages/babel-jest/build/index.d.ts
index 387df633fe..2fb824c961 100644
--- i/packages/babel-jest/build/index.d.ts
+++ w/packages/babel-jest/build/index.d.ts
@@ -4,9 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {SyncTransformer} from '@jest/transform';
-import type {TransformerCreator} from '@jest/transform';
+
 import {TransformOptions} from '@babel/core';
+import {SyncTransformer, TransformerCreator} from '@jest/transform';
 
 export declare const createTransformer: TransformerCreator<
   SyncTransformer<TransformOptions>,
diff --git i/packages/babel-plugin-jest-hoist/build/index.d.ts w/packages/babel-plugin-jest-hoist/build/index.d.ts
index a898e8ff7f..36b1781257 100644
--- i/packages/babel-plugin-jest-hoist/build/index.d.ts
+++ w/packages/babel-plugin-jest-hoist/build/index.d.ts
@@ -4,8 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+import {PluginObj} from '@babel/core';
 import {Identifier} from '@babel/types';
-import type {PluginObj} from '@babel/core';
 
 declare function jestHoist(): PluginObj<{
   declareJestObjGetterIdentifier: () => Identifier;
diff --git i/packages/diff-sequences/build/index.d.ts w/packages/diff-sequences/build/index.d.ts
index 9e9c3db85e..e04f4aa0aa 100644
--- i/packages/diff-sequences/build/index.d.ts
+++ w/packages/diff-sequences/build/index.d.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 export declare type Callbacks = {
   foundSubsequence: FoundSubsequence;
   isCommon: IsCommon;
diff --git i/packages/expect-utils/build/index.d.ts w/packages/expect-utils/build/index.d.ts
index 53cae2e30e..ba1f2c8c99 100644
--- i/packages/expect-utils/build/index.d.ts
+++ w/packages/expect-utils/build/index.d.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 export declare const arrayBufferEquality: (
   a: unknown,
   b: unknown,
@@ -60,9 +61,9 @@ export declare const iterableEquality: (
 ) => boolean | undefined;
 
 export declare const partition: <T>(
-  items: T[],
+  items: Array<T>,
   predicate: (arg: T) => boolean,
-) => [T[], T[]];
+) => [Array<T>, Array<T>];
 
 export declare const pathAsArray: (propertyPath: string) => Array<any>;
 
diff --git i/packages/expect/build/index.d.ts w/packages/expect/build/index.d.ts
index 71dc7c9876..6ec2e2ae44 100644
--- i/packages/expect/build/index.d.ts
+++ w/packages/expect/build/index.d.ts
@@ -4,10 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {EqualsFunction} from '@jest/expect-utils';
-import type * as jestMatcherUtils from 'jest-matcher-utils';
-import {Tester} from '@jest/expect-utils';
-import {TesterContext} from '@jest/expect-utils';
+
+import {EqualsFunction, Tester, TesterContext} from '@jest/expect-utils';
+import * as jestMatcherUtils from 'jest-matcher-utils';
 
 export declare abstract class AsymmetricMatcher<T>
   implements AsymmetricMatcher_2
diff --git i/packages/jest-changed-files/build/index.d.ts w/packages/jest-changed-files/build/index.d.ts
index fd8e08bf3c..630d8d94e2 100644
--- i/packages/jest-changed-files/build/index.d.ts
+++ w/packages/jest-changed-files/build/index.d.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 export declare type ChangedFiles = {
   repos: Repos;
   changedFiles: Paths;
diff --git i/packages/jest-circus/build/index.d.ts w/packages/jest-circus/build/index.d.ts
index 6a2414fac5..c9467e811e 100644
--- i/packages/jest-circus/build/index.d.ts
+++ w/packages/jest-circus/build/index.d.ts
@@ -4,8 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Circus} from '@jest/types';
-import type {Global as Global_2} from '@jest/types';
+
+import {Circus, Global as Global_2} from '@jest/types';
 
 export declare const afterAll: THook;
 
diff --git i/packages/jest-cli/build/index.d.ts w/packages/jest-cli/build/index.d.ts
index 886800935e..9e4ead1d66 100644
--- i/packages/jest-cli/build/index.d.ts
+++ w/packages/jest-cli/build/index.d.ts
@@ -4,7 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Options} from 'yargs';
+
+import {Options} from 'yargs';
 
 export declare function run(
   maybeArgv?: Array<string>,
diff --git i/packages/jest-config/build/index.d.ts w/packages/jest-config/build/index.d.ts
index e3165e0f48..27427a5b2b 100644
--- i/packages/jest-config/build/index.d.ts
+++ w/packages/jest-config/build/index.d.ts
@@ -4,8 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Config} from '@jest/types';
-import type {DeprecatedOptions} from 'jest-validate';
+
+import {Config} from '@jest/types';
+import {DeprecatedOptions} from 'jest-validate';
 
 declare type AllOptions = Config.ProjectConfig & Config.GlobalConfig;
 
@@ -49,7 +50,7 @@ declare const JEST_CONFIG_EXT_JSON = '.json';
 
 declare const JEST_CONFIG_EXT_MJS = '.mjs';
 
-declare const JEST_CONFIG_EXT_ORDER: readonly string[];
+declare const JEST_CONFIG_EXT_ORDER: ReadonlyArray<string>;
 
 declare const JEST_CONFIG_EXT_TS = '.ts';
 
diff --git i/packages/jest-console/build/index.d.ts w/packages/jest-console/build/index.d.ts
index f3d9e903ab..2a7093edf3 100644
--- i/packages/jest-console/build/index.d.ts
+++ w/packages/jest-console/build/index.d.ts
@@ -4,13 +4,14 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /// <reference types="node" />
 
-import type {Config} from '@jest/types';
 import {Console as Console_2} from 'console';
+import {WriteStream} from 'tty';
 import {InspectOptions} from 'util';
+import {Config} from '@jest/types';
 import {StackTraceConfig} from 'jest-message-util';
-import type {WriteStream} from 'tty';
 
 export declare class BufferedConsole extends Console_2 {
   private readonly _buffer;
diff --git i/packages/jest-core/build/index.d.ts w/packages/jest-core/build/index.d.ts
index 20733841b3..926f7dbfb5 100644
--- i/packages/jest-core/build/index.d.ts
+++ w/packages/jest-core/build/index.d.ts
@@ -4,17 +4,14 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import {AggregatedResult} from '@jest/test-result';
-import {BaseReporter} from '@jest/reporters';
-import type {ChangedFiles} from 'jest-changed-files';
-import type {Config} from '@jest/types';
-import {Reporter} from '@jest/reporters';
-import {ReporterContext} from '@jest/reporters';
-import {Test} from '@jest/test-result';
-import type {TestContext} from '@jest/test-result';
+
+import {BaseReporter, Reporter, ReporterContext} from '@jest/reporters';
+import {AggregatedResult, Test, TestContext} from '@jest/test-result';
+import {Config} from '@jest/types';
+import {ChangedFiles} from 'jest-changed-files';
+import {TestRunnerContext} from 'jest-runner';
 import {TestPathPatterns} from 'jest-util';
-import type {TestRunnerContext} from 'jest-runner';
-import type {TestWatcher} from 'jest-watcher';
+import {TestWatcher} from 'jest-watcher';
 
 export declare function createTestScheduler(
   globalConfig: Config.GlobalConfig,
diff --git i/packages/jest-create-cache-key-function/build/index.d.ts w/packages/jest-create-cache-key-function/build/index.d.ts
index 45249b62a4..ea3433204f 100644
--- i/packages/jest-create-cache-key-function/build/index.d.ts
+++ w/packages/jest-create-cache-key-function/build/index.d.ts
@@ -4,7 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Config} from '@jest/types';
+
+import {Config} from '@jest/types';
 
 /**
  * Returns a function that can be used to generate cache keys based on source code of provided files and provided values.
diff --git i/packages/jest-diff/build/index.d.ts w/packages/jest-diff/build/index.d.ts
index f84a803c21..0365f18e73 100644
--- i/packages/jest-diff/build/index.d.ts
+++ w/packages/jest-diff/build/index.d.ts
@@ -4,7 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {CompareKeys} from 'pretty-format';
+
+import {CompareKeys} from 'pretty-format';
 
 /**
  * Class representing one diff tuple.
diff --git i/packages/jest-docblock/build/index.d.ts w/packages/jest-docblock/build/index.d.ts
index b4e72f5a8f..a79a796ac3 100644
--- i/packages/jest-docblock/build/index.d.ts
+++ w/packages/jest-docblock/build/index.d.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 export declare function extract(contents: string): string;
 
 export declare function parse(docblock: string): Pragmas;
diff --git i/packages/jest-each/build/index.d.ts w/packages/jest-each/build/index.d.ts
index 7c4586fc98..919e13ff70 100644
--- i/packages/jest-each/build/index.d.ts
+++ w/packages/jest-each/build/index.d.ts
@@ -4,7 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Global as Global_2} from '@jest/types';
+
+import {Global as Global_2} from '@jest/types';
 
 export declare function bind<EachCallback extends Global_2.TestCallback>(
   cb: GlobalCallback,
diff --git i/packages/jest-environment-jsdom/build/index.d.ts w/packages/jest-environment-jsdom/build/index.d.ts
index 56071cae27..fce708effd 100644
--- i/packages/jest-environment-jsdom/build/index.d.ts
+++ w/packages/jest-environment-jsdom/build/index.d.ts
@@ -4,16 +4,18 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /// <reference types="node" />
 
-import type {Context} from 'vm';
-import type {EnvironmentContext} from '@jest/environment';
-import type {Global as Global_2} from '@jest/types';
-import type {JestEnvironment} from '@jest/environment';
-import type {JestEnvironmentConfig} from '@jest/environment';
+import {Context} from 'vm';
 import {JSDOM} from 'jsdom';
-import {LegacyFakeTimers} from '@jest/fake-timers';
-import {ModernFakeTimers} from '@jest/fake-timers';
+import {
+  EnvironmentContext,
+  JestEnvironment,
+  JestEnvironmentConfig,
+} from '@jest/environment';
+import {LegacyFakeTimers, ModernFakeTimers} from '@jest/fake-timers';
+import {Global as Global_2} from '@jest/types';
 import {ModuleMocker} from 'jest-mock';
 
 declare class JSDOMEnvironment implements JestEnvironment<number> {
@@ -23,7 +25,7 @@ declare class JSDOMEnvironment implements JestEnvironment<number> {
   global: Win;
   private errorEventListener;
   moduleMocker: ModuleMocker | null;
-  customExportConditions: string[];
+  customExportConditions: Array<string>;
   private readonly _configuredExportConditions?;
   constructor(config: JestEnvironmentConfig, context: EnvironmentContext);
   setup(): Promise<void>;
diff --git i/packages/jest-environment-node/build/index.d.ts w/packages/jest-environment-node/build/index.d.ts
index 81fb4c59fa..52f5df8ed1 100644
--- i/packages/jest-environment-node/build/index.d.ts
+++ w/packages/jest-environment-node/build/index.d.ts
@@ -4,15 +4,17 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /// <reference types="node" />
 
 import {Context} from 'vm';
-import type {EnvironmentContext} from '@jest/environment';
-import type {Global as Global_2} from '@jest/types';
-import type {JestEnvironment} from '@jest/environment';
-import type {JestEnvironmentConfig} from '@jest/environment';
-import {LegacyFakeTimers} from '@jest/fake-timers';
-import {ModernFakeTimers} from '@jest/fake-timers';
+import {
+  EnvironmentContext,
+  JestEnvironment,
+  JestEnvironmentConfig,
+} from '@jest/environment';
+import {LegacyFakeTimers, ModernFakeTimers} from '@jest/fake-timers';
+import {Global as Global_2} from '@jest/types';
 import {ModuleMocker} from 'jest-mock';
 
 declare class NodeEnvironment implements JestEnvironment<Timer> {
@@ -21,7 +23,7 @@ declare class NodeEnvironment implements JestEnvironment<Timer> {
   fakeTimersModern: ModernFakeTimers | null;
   global: Global_2.Global;
   moduleMocker: ModuleMocker | null;
-  customExportConditions: string[];
+  customExportConditions: Array<string>;
   private readonly _configuredExportConditions?;
   constructor(config: JestEnvironmentConfig, _context: EnvironmentContext);
   setup(): Promise<void>;
diff --git i/packages/jest-environment/build/index.d.ts w/packages/jest-environment/build/index.d.ts
index da1068da96..edd604bc04 100644
--- i/packages/jest-environment/build/index.d.ts
+++ w/packages/jest-environment/build/index.d.ts
@@ -4,16 +4,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /// <reference types="node" />
 
-import type {Circus} from '@jest/types';
-import type {Config} from '@jest/types';
-import type {Context} from 'vm';
-import type {Global as Global_2} from '@jest/types';
-import type {LegacyFakeTimers} from '@jest/fake-timers';
-import type {Mocked} from 'jest-mock';
-import type {ModernFakeTimers} from '@jest/fake-timers';
-import type {ModuleMocker} from 'jest-mock';
+import {Context} from 'vm';
+import {LegacyFakeTimers, ModernFakeTimers} from '@jest/fake-timers';
+import {Circus, Config, Global as Global_2} from '@jest/types';
+import {Mocked, ModuleMocker} from 'jest-mock';
 
 export declare type EnvironmentContext = {
   console: Console;
diff --git i/packages/jest-expect/build/index.d.ts w/packages/jest-expect/build/index.d.ts
index ba63c95202..d8d2f4081f 100644
--- i/packages/jest-expect/build/index.d.ts
+++ w/packages/jest-expect/build/index.d.ts
@@ -4,16 +4,18 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {addSerializer} from 'jest-snapshot';
-import {AsymmetricMatchers} from 'expect';
-import type {BaseExpect} from 'expect';
-import {MatcherContext} from 'expect';
-import {MatcherFunction} from 'expect';
-import {MatcherFunctionWithContext} from 'expect';
-import {Matchers} from 'expect';
-import {MatcherState} from 'expect';
-import {MatcherUtils} from 'expect';
-import type {SnapshotMatchers} from 'jest-snapshot';
+
+import {
+  AsymmetricMatchers,
+  BaseExpect,
+  MatcherContext,
+  MatcherFunction,
+  MatcherFunctionWithContext,
+  MatcherState,
+  MatcherUtils,
+  Matchers,
+} from 'expect';
+import {SnapshotMatchers, addSerializer} from 'jest-snapshot';
 
 export {AsymmetricMatchers};
 
diff --git i/packages/jest-fake-timers/build/index.d.ts w/packages/jest-fake-timers/build/index.d.ts
index 64272cab86..b83051fc58 100644
--- i/packages/jest-fake-timers/build/index.d.ts
+++ w/packages/jest-fake-timers/build/index.d.ts
@@ -4,9 +4,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Config} from '@jest/types';
-import type {ModuleMocker} from 'jest-mock';
+
+import {Config} from '@jest/types';
 import {StackTraceConfig} from 'jest-message-util';
+import {ModuleMocker} from 'jest-mock';
 
 declare type Callback = (...args: Array<unknown>) => void;
 
diff --git i/packages/jest-get-type/build/index.d.ts w/packages/jest-get-type/build/index.d.ts
index 20931392d2..4e08a9a9a5 100644
--- i/packages/jest-get-type/build/index.d.ts
+++ w/packages/jest-get-type/build/index.d.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 export declare function getType(value: unknown): ValueType;
 
 export declare const isPrimitive: (value: unknown) => boolean;
diff --git i/packages/jest-haste-map/build/index.d.ts w/packages/jest-haste-map/build/index.d.ts
index 60c50973e7..f5d6e5a26d 100644
--- i/packages/jest-haste-map/build/index.d.ts
+++ w/packages/jest-haste-map/build/index.d.ts
@@ -4,10 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /// <reference types="node" />
 
-import type {Config} from '@jest/types';
-import type {Stats} from 'fs';
+import {Stats} from 'fs';
+import {Config} from '@jest/types';
 
 declare type ChangeEvent = {
   eventsQueue: EventsQueue;
diff --git i/packages/jest-jasmine2/build/index.d.ts w/packages/jest-jasmine2/build/index.d.ts
index 0303b1f32e..8df8c56ed5 100644
--- i/packages/jest-jasmine2/build/index.d.ts
+++ w/packages/jest-jasmine2/build/index.d.ts
@@ -4,18 +4,16 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /// <reference types="node" />
 
-import type {AssertionError} from 'assert';
-import type {AsymmetricMatchers} from '@jest/expect';
-import type {Circus} from '@jest/types';
-import type {Config} from '@jest/types';
-import type {FailedAssertion} from '@jest/test-result';
-import type {JestEnvironment} from '@jest/environment';
-import type * as Process from 'process';
-import type Runtime from 'jest-runtime';
-import type {Status} from '@jest/test-result';
-import type {TestResult} from '@jest/test-result';
+import {AssertionError} from 'assert';
+import * as Process from 'process';
+import {JestEnvironment} from '@jest/environment';
+import {AsymmetricMatchers} from '@jest/expect';
+import {FailedAssertion, Status, TestResult} from '@jest/test-result';
+import {Circus, Config} from '@jest/types';
+import Runtime from 'jest-runtime';
 
 declare interface AssertionErrorWithStack extends AssertionError {
   stack: string;
diff --git i/packages/jest-leak-detector/build/index.d.ts w/packages/jest-leak-detector/build/index.d.ts
index 53555839a1..355a83d077 100644
--- i/packages/jest-leak-detector/build/index.d.ts
+++ w/packages/jest-leak-detector/build/index.d.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /// <reference lib="es2021.weakref" />
 
 /// <reference lib="es2021.weakref" />
diff --git i/packages/jest-matcher-utils/build/index.d.ts w/packages/jest-matcher-utils/build/index.d.ts
index a84b60b109..1cf04d2858 100644
--- i/packages/jest-matcher-utils/build/index.d.ts
+++ w/packages/jest-matcher-utils/build/index.d.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 import chalk = require('chalk');
 import {DiffOptions as DiffOptions_2} from 'jest-diff';
 
diff --git i/packages/jest-message-util/build/index.d.ts w/packages/jest-message-util/build/index.d.ts
index 0559179480..fd9060750e 100644
--- i/packages/jest-message-util/build/index.d.ts
+++ w/packages/jest-message-util/build/index.d.ts
@@ -4,9 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Config} from '@jest/types';
-import type {StackData} from 'stack-utils';
-import type {TestResult} from '@jest/types';
+
+import {StackData} from 'stack-utils';
+import {Config, TestResult} from '@jest/types';
 
 export declare const formatExecError: (
   error: Error | TestResult.SerializableError | string | number | undefined,
diff --git i/packages/jest-mock/build/index.d.ts w/packages/jest-mock/build/index.d.ts
index 2374fc6d85..9726a6dc59 100644
--- i/packages/jest-mock/build/index.d.ts
+++ w/packages/jest-mock/build/index.d.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 export declare type ClassLike = {
   new (...args: any): any;
 };
@@ -349,8 +350,8 @@ export declare type SpiedGetter<T> = MockInstance<() => T>;
 
 export declare type SpiedSetter<T> = MockInstance<(arg: T) => void>;
 
-export declare interface SpyInstance<T extends FunctionLike = UnknownFunction>
-  extends MockInstance<T> {}
+export type SpyInstance<T extends FunctionLike = UnknownFunction> =
+  MockInstance<T>;
 
 export declare const spyOn: {
   <
diff --git i/packages/jest-phabricator/build/index.d.ts w/packages/jest-phabricator/build/index.d.ts
index 9e8a431baa..90a296c84a 100644
--- i/packages/jest-phabricator/build/index.d.ts
+++ w/packages/jest-phabricator/build/index.d.ts
@@ -4,7 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {AggregatedResult} from '@jest/test-result';
+
+import {AggregatedResult} from '@jest/test-result';
 
 declare function PhabricatorProcessor(
   results: AggregatedResult,
diff --git i/packages/jest-regex-util/build/index.d.ts w/packages/jest-regex-util/build/index.d.ts
index 8de7081045..0f98591d5a 100644
--- i/packages/jest-regex-util/build/index.d.ts
+++ w/packages/jest-regex-util/build/index.d.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  *
diff --git i/packages/jest-repl/build/index.d.ts w/packages/jest-repl/build/index.d.ts
index 1020290c71..16827ed24a 100644
--- i/packages/jest-repl/build/index.d.ts
+++ w/packages/jest-repl/build/index.d.ts
@@ -4,7 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Config} from '@jest/types';
+
+import {Config} from '@jest/types';
 
 /**
  * Copyright (c) Meta Platforms, Inc. and affiliates.
diff --git i/packages/jest-reporters/build/index.d.ts w/packages/jest-reporters/build/index.d.ts
index e2bea2d0e0..7d976ae53e 100644
--- i/packages/jest-reporters/build/index.d.ts
+++ w/packages/jest-reporters/build/index.d.ts
@@ -4,19 +4,21 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /// <reference types="node" />
 
-import {AggregatedResult} from '@jest/test-result';
-import type {AssertionResult} from '@jest/test-result';
-import type {Circus} from '@jest/types';
-import {Config} from '@jest/types';
-import {SnapshotSummary} from '@jest/test-result';
-import type {Suite} from '@jest/test-result';
-import {Test} from '@jest/test-result';
-import {TestCaseResult} from '@jest/test-result';
-import {TestContext} from '@jest/test-result';
-import {TestResult} from '@jest/test-result';
-import type {WriteStream} from 'tty';
+import {WriteStream} from 'tty';
+import {
+  AggregatedResult,
+  AssertionResult,
+  SnapshotSummary,
+  Suite,
+  Test,
+  TestCaseResult,
+  TestContext,
+  TestResult,
+} from '@jest/test-result';
+import {Circus, Config} from '@jest/types';
 
 export {AggregatedResult};
 
diff --git i/packages/jest-resolve-dependencies/build/index.d.ts w/packages/jest-resolve-dependencies/build/index.d.ts
index 267bfc6188..d4c61d89d2 100644
--- i/packages/jest-resolve-dependencies/build/index.d.ts
+++ w/packages/jest-resolve-dependencies/build/index.d.ts
@@ -4,9 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {default as default_2} from 'jest-resolve';
-import type {IHasteFS} from 'jest-haste-map';
-import type {ResolveModuleConfig} from 'jest-resolve';
+
+import {IHasteFS} from 'jest-haste-map';
+import {ResolveModuleConfig, default as default_2} from 'jest-resolve';
 import {SnapshotResolver} from 'jest-snapshot';
 
 /**
diff --git i/packages/jest-resolve/build/index.d.ts w/packages/jest-resolve/build/index.d.ts
index 6ec1e44332..37cda9e43b 100644
--- i/packages/jest-resolve/build/index.d.ts
+++ w/packages/jest-resolve/build/index.d.ts
@@ -4,7 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {IModuleMap} from 'jest-haste-map';
+
+import {IModuleMap} from 'jest-haste-map';
 
 export declare type AsyncResolver = (
   path: string,
diff --git i/packages/jest-runner/build/index.d.ts w/packages/jest-runner/build/index.d.ts
index 2e46f45852..9d6d4bb626 100644
--- i/packages/jest-runner/build/index.d.ts
+++ w/packages/jest-runner/build/index.d.ts
@@ -4,11 +4,14 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
+import {
+  SerializableError,
+  Test,
+  TestEvents,
+  TestResult,
+} from '@jest/test-result';
 import {Config} from '@jest/types';
-import type {SerializableError} from '@jest/test-result';
-import {Test} from '@jest/test-result';
-import {TestEvents} from '@jest/test-result';
-import type {TestResult} from '@jest/test-result';
 import {TestWatcher} from 'jest-watcher';
 
 declare abstract class BaseTestRunner {
diff --git i/packages/jest-runtime/build/index.d.ts w/packages/jest-runtime/build/index.d.ts
index f82264d441..cd2f69edf4 100644
--- i/packages/jest-runtime/build/index.d.ts
+++ w/packages/jest-runtime/build/index.d.ts
@@ -4,20 +4,20 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import {CallerTransformOptions} from '@jest/transform';
-import type {Config} from '@jest/types';
-import type {expect} from '@jest/globals';
-import type {Global as Global_2} from '@jest/types';
-import {IHasteMap} from 'jest-haste-map';
-import {IModuleMap} from 'jest-haste-map';
-import type {JestEnvironment} from '@jest/environment';
+
+import {JestEnvironment} from '@jest/environment';
+import {expect} from '@jest/globals';
+import {SourceMapRegistry} from '@jest/source-map';
+import {TestContext, V8CoverageResult} from '@jest/test-result';
+import {
+  CallerTransformOptions,
+  ScriptTransformer,
+  ShouldInstrumentOptions,
+  shouldInstrument,
+} from '@jest/transform';
+import {Config, Global as Global_2} from '@jest/types';
+import {IHasteMap, IModuleMap} from 'jest-haste-map';
 import Resolver from 'jest-resolve';
-import {ScriptTransformer} from '@jest/transform';
-import {shouldInstrument} from '@jest/transform';
-import {ShouldInstrumentOptions} from '@jest/transform';
-import type {SourceMapRegistry} from '@jest/source-map';
-import type {TestContext} from '@jest/test-result';
-import type {V8CoverageResult} from '@jest/test-result';
 
 declare type HasteMapOptions = {
   console?: Console;
diff --git i/packages/jest-schemas/build/index.d.ts w/packages/jest-schemas/build/index.d.ts
index a1341e8cfc..65df0c0656 100644
--- i/packages/jest-schemas/build/index.d.ts
+++ w/packages/jest-schemas/build/index.d.ts
@@ -4,14 +4,17 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import {Static} from '@sinclair/typebox';
-import {TBoolean} from '@sinclair/typebox';
-import {TNull} from '@sinclair/typebox';
-import {TNumber} from '@sinclair/typebox';
-import {TObject} from '@sinclair/typebox';
-import {TOptional} from '@sinclair/typebox';
-import {TReadonly} from '@sinclair/typebox';
-import {TString} from '@sinclair/typebox';
+
+import {
+  Static,
+  TBoolean,
+  TNull,
+  TNumber,
+  TObject,
+  TOptional,
+  TReadonly,
+  TString,
+} from '@sinclair/typebox';
 
 declare const RawSnapshotFormat: TObject<{
   callToJSON: TOptional<TReadonly<TBoolean>>;
diff --git i/packages/jest-snapshot/build/index.d.ts w/packages/jest-snapshot/build/index.d.ts
index cee0842358..f930c1cc2a 100644
--- i/packages/jest-snapshot/build/index.d.ts
+++ w/packages/jest-snapshot/build/index.d.ts
@@ -4,12 +4,10 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Config} from '@jest/types';
-import type {MatcherContext} from 'expect';
-import type {MatcherFunctionWithContext} from 'expect';
-import {Plugin as Plugin_2} from 'pretty-format';
-import {Plugins} from 'pretty-format';
-import type {PrettyFormatOptions} from 'pretty-format';
+
+import {Config} from '@jest/types';
+import {MatcherContext, MatcherFunctionWithContext} from 'expect';
+import {Plugin as Plugin_2, Plugins, PrettyFormatOptions} from 'pretty-format';
 
 export declare const addSerializer: (plugin: Plugin_2) => void;
 
diff --git i/packages/jest-source-map/build/index.d.ts w/packages/jest-source-map/build/index.d.ts
index 7a421847a6..04d4476e9c 100644
--- i/packages/jest-source-map/build/index.d.ts
+++ w/packages/jest-source-map/build/index.d.ts
@@ -4,6 +4,7 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 import callsites = require('callsites');
 
 export declare function getCallsite(
diff --git i/packages/jest-test-result/build/index.d.ts w/packages/jest-test-result/build/index.d.ts
index 8d922fb29d..d04f1eb3aa 100644
--- i/packages/jest-test-result/build/index.d.ts
+++ w/packages/jest-test-result/build/index.d.ts
@@ -4,17 +4,18 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Circus} from '@jest/types';
-import type {Config} from '@jest/types';
-import type {ConsoleBuffer} from '@jest/console';
-import type {CoverageMap} from 'istanbul-lib-coverage';
-import type {CoverageMapData} from 'istanbul-lib-coverage';
-import type {IHasteFS} from 'jest-haste-map';
-import type {IModuleMap} from 'jest-haste-map';
-import type Resolver from 'jest-resolve';
-import type {TestResult as TestResult_2} from '@jest/types';
-import type {TransformTypes} from '@jest/types';
-import type {V8Coverage} from 'collect-v8-coverage';
+
+import {V8Coverage} from 'collect-v8-coverage';
+import {CoverageMap, CoverageMapData} from 'istanbul-lib-coverage';
+import {ConsoleBuffer} from '@jest/console';
+import {
+  Circus,
+  Config,
+  TestResult as TestResult_2,
+  TransformTypes,
+} from '@jest/types';
+import {IHasteFS, IModuleMap} from 'jest-haste-map';
+import Resolver from 'jest-resolve';
 
 export declare const addResult: (
   aggregatedResults: AggregatedResult,
diff --git i/packages/jest-test-sequencer/build/index.d.ts w/packages/jest-test-sequencer/build/index.d.ts
index 48f4664004..f394095a16 100644
--- i/packages/jest-test-sequencer/build/index.d.ts
+++ w/packages/jest-test-sequencer/build/index.d.ts
@@ -4,10 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {AggregatedResult} from '@jest/test-result';
-import type {Config} from '@jest/types';
-import type {Test} from '@jest/test-result';
-import type {TestContext} from '@jest/test-result';
+
+import {AggregatedResult, Test, TestContext} from '@jest/test-result';
+import {Config} from '@jest/types';
 
 declare type Cache_2 = {
   [key: string]:
diff --git i/packages/jest-transform/build/index.d.ts w/packages/jest-transform/build/index.d.ts
index a5065488fc..7f5952ba9d 100644
--- i/packages/jest-transform/build/index.d.ts
+++ w/packages/jest-transform/build/index.d.ts
@@ -4,9 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Config} from '@jest/types';
-import type {EncodedSourceMap} from '@jridgewell/trace-mapping';
-import type {TransformTypes} from '@jest/types';
+
+import {EncodedSourceMap} from '@jridgewell/trace-mapping';
+import {Config, TransformTypes} from '@jest/types';
 
 export declare interface AsyncTransformer<TransformerConfig = unknown> {
   /**
diff --git i/packages/jest-types/build/index.d.ts w/packages/jest-types/build/index.d.ts
index 2254da0c37..77ab3ea58f 100644
--- i/packages/jest-types/build/index.d.ts
+++ w/packages/jest-types/build/index.d.ts
@@ -4,14 +4,15 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /// <reference types="node" />
 
-import type {Arguments} from 'yargs';
-import type {CoverageMapData} from 'istanbul-lib-coverage';
-import type {ForegroundColor} from 'chalk';
-import type * as ProcessModule from 'process';
-import type {ReportOptions} from 'istanbul-reports';
-import type {SnapshotFormat} from '@jest/schemas';
+import * as ProcessModule from 'process';
+import {ForegroundColor} from 'chalk';
+import {CoverageMapData} from 'istanbul-lib-coverage';
+import {ReportOptions} from 'istanbul-reports';
+import {Arguments} from 'yargs';
+import {SnapshotFormat} from '@jest/schemas';
 
 declare type Argv = Arguments<
   Partial<{
diff --git i/packages/jest-util/build/index.d.ts w/packages/jest-util/build/index.d.ts
index 3d2c98c6d4..817525c2e5 100644
--- i/packages/jest-util/build/index.d.ts
+++ w/packages/jest-util/build/index.d.ts
@@ -4,11 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /// <reference types="node" />
 
-import type {Config} from '@jest/types';
-import type {Global as Global_2} from '@jest/types';
-import type {WriteStream} from 'tty';
+import {WriteStream} from 'tty';
+import {Config, Global as Global_2} from '@jest/types';
 
 declare const ARROW = ' \u203A ';
 
diff --git i/packages/jest-validate/build/index.d.ts w/packages/jest-validate/build/index.d.ts
index 64bd1de03f..ac8f61efe3 100644
--- i/packages/jest-validate/build/index.d.ts
+++ w/packages/jest-validate/build/index.d.ts
@@ -4,8 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Config} from '@jest/types';
-import type {Options} from 'yargs';
+
+import {Options} from 'yargs';
+import {Config} from '@jest/types';
 
 export declare const createDidYouMeanMessage: (
   unrecognized: string,
diff --git i/packages/jest-watcher/build/index.d.ts w/packages/jest-watcher/build/index.d.ts
index 7bb3fa1c6b..f9e816124f 100644
--- i/packages/jest-watcher/build/index.d.ts
+++ w/packages/jest-watcher/build/index.d.ts
@@ -4,13 +4,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /// <reference types="node" />
 
-import type {AggregatedResult} from '@jest/test-result';
-import type {Config} from '@jest/types';
+import {ReadStream, WriteStream} from 'tty';
 import Emittery = require('emittery');
-import type {ReadStream} from 'tty';
-import type {WriteStream} from 'tty';
+import {AggregatedResult} from '@jest/test-result';
+import {Config} from '@jest/types';
 
 export declare type AllowedConfigOptions = Partial<
   Pick<
diff --git i/packages/jest-worker/build/index.d.ts w/packages/jest-worker/build/index.d.ts
index 8f25376839..6f7b623233 100644
--- i/packages/jest-worker/build/index.d.ts
+++ w/packages/jest-worker/build/index.d.ts
@@ -4,10 +4,11 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+
 /// <reference types="node" />
 
-import type {ForkOptions} from 'child_process';
-import type {ResourceLimits} from 'worker_threads';
+import {ForkOptions} from 'child_process';
+import {ResourceLimits} from 'worker_threads';
 
 declare const CHILD_MESSAGE_CALL = 1;
 
diff --git i/packages/jest/build/index.d.ts w/packages/jest/build/index.d.ts
index 05e21ab8ff..e4f2ecaa98 100644
--- i/packages/jest/build/index.d.ts
+++ w/packages/jest/build/index.d.ts
@@ -4,12 +4,15 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Config as Config_2} from '@jest/types';
-import {createTestScheduler} from '@jest/core';
-import {getVersion} from '@jest/core';
+
+import {
+  SearchSource,
+  createTestScheduler,
+  getVersion,
+  runCLI,
+} from '@jest/core';
+import {Config as Config_2} from '@jest/types';
 import {run} from 'jest-cli';
-import {runCLI} from '@jest/core';
-import {SearchSource} from '@jest/core';
 
 export declare type Config = Config_2.InitialOptions;
 
diff --git i/packages/pretty-format/build/index.d.ts w/packages/pretty-format/build/index.d.ts
index 4e99a5e1c1..f33fa7244b 100644
--- i/packages/pretty-format/build/index.d.ts
+++ w/packages/pretty-format/build/index.d.ts
@@ -4,7 +4,8 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {SnapshotFormat} from '@jest/schemas';
+
+import {SnapshotFormat} from '@jest/schemas';
 
 export declare type Colors = {
   comment: {
@@ -61,7 +62,7 @@ export declare const DEFAULT_OPTIONS: {
   maxDepth: number;
   maxWidth: number;
   min: false;
-  plugins: never[];
+  plugins: Array<never>;
   printBasicPrototype: true;
   printFunctionName: true;
   theme: Required<{
diff --git i/packages/test-utils/build/index.d.ts w/packages/test-utils/build/index.d.ts
index f0e42e7334..81ef3aab0a 100644
--- i/packages/test-utils/build/index.d.ts
+++ w/packages/test-utils/build/index.d.ts
@@ -4,8 +4,9 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
-import type {Config} from '@jest/types';
-import type {NewPlugin} from 'pretty-format';
+
+import {Config} from '@jest/types';
+import {NewPlugin} from 'pretty-format';
 
 export declare const alignedAnsiStyleSerializer: NewPlugin;
 
```

</details>

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
