### PR TITLE
fix(@jest/expect-utils): exclude non-enumerable symbol in object matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[jest-circus, jest-expect, jest-snapshot]` Pass `test.failing` tests when containing failing snapshot matchers ([#14313](https://github.com/jestjs/jest/pull/14313))
 - `[jest-config]` Make sure to respect `runInBand` option ([#14578](https://github.com/facebook/jest/pull/14578))
 - `[@jest/expect-utils]` Fix comparison of `DataView` ([#14408](https://github.com/jestjs/jest/pull/14408))
+- `[@jest/expect-utils]` [**BREAKING**] exclude non-enumerable in object matching ([#14670](https://github.com/jestjs/jest/pull/14670))
 - `[jest-leak-detector]` Make leak-detector more aggressive when running GC ([#14526](https://github.com/jestjs/jest/pull/14526))
 - `[jest-runtime]` Properly handle re-exported native modules in ESM via CJS ([#14589](https://github.com/jestjs/jest/pull/14589))
 - `[jest-util]` Make sure `isInteractive` works in a browser ([#14552](https://github.com/jestjs/jest/pull/14552))
@@ -32,7 +33,6 @@
   - [**BREAKING**] Changes `testPathPattern` configuration option to `testPathPatterns`, which now takes a list of patterns instead of the regex.
   - [**BREAKING**] `--testPathPattern` is now `--testPathPatterns`
 - `[jest-reporters, jest-runner]` Unhandled errors without stack get correctly logged to console ([#14619](https://github.com/facebook/jest/pull/14619))
-- `[@jest/expect-utils]` [**BREAKING**] exclude non-enumerable in object matching ([#14670](https://github.com/jestjs/jest/pull/14670))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@
   - [**BREAKING**] Changes `testPathPattern` configuration option to `testPathPatterns`, which now takes a list of patterns instead of the regex.
   - [**BREAKING**] `--testPathPattern` is now `--testPathPatterns`
 - `[jest-reporters, jest-runner]` Unhandled errors without stack get correctly logged to console ([#14619](https://github.com/facebook/jest/pull/14619))
+- `[@jest/expect-utils]` [**BREAKING**] exclude non-enumerable in object matching ([#14670](https://github.com/jestjs/jest/pull/14670))
 
 ### Performance
 

--- a/packages/expect-utils/src/__tests__/utils.test.ts
+++ b/packages/expect-utils/src/__tests__/utils.test.ts
@@ -355,6 +355,51 @@ describe('subsetEquality()', () => {
       ).toBe(false);
     });
   });
+
+  describe('matching subsets with symbols', () => {
+    describe('same symbol', () => {
+      test('objects to not match with value diff', () => {
+        const symbol = Symbol('foo');
+        expect(subsetEquality({[symbol]: 1}, {[symbol]: 2})).toBe(false);
+      });
+
+      test('objects to match with non-enumerable symbols', () => {
+        const symbol = Symbol('foo');
+        const foo = {};
+        Object.defineProperty(foo, symbol, {
+          enumerable: false,
+          value: 1,
+        });
+        const bar = {};
+        Object.defineProperty(bar, symbol, {
+          enumerable: false,
+          value: 2,
+        });
+        expect(subsetEquality(foo, bar)).toBe(true);
+      });
+    });
+
+    describe('different symbol', () => {
+      test('objects to not match with same value', () => {
+        expect(subsetEquality({[Symbol('foo')]: 1}, {[Symbol('foo')]: 2})).toBe(
+          false,
+        );
+      });
+      test('objects to match with non-enumerable symbols', () => {
+        const foo = {};
+        Object.defineProperty(foo, Symbol('foo'), {
+          enumerable: false,
+          value: 1,
+        });
+        const bar = {};
+        Object.defineProperty(bar, Symbol('foo'), {
+          enumerable: false,
+          value: 2,
+        });
+        expect(subsetEquality(foo, bar)).toBe(true);
+      });
+    });
+  });
 });
 
 describe('iterableEquality', () => {

--- a/packages/expect-utils/src/utils.ts
+++ b/packages/expect-utils/src/utils.ts
@@ -44,13 +44,23 @@ const hasPropertyInObject = (object: object, key: string | symbol): boolean => {
 };
 
 // Retrieves an object's keys for evaluation by getObjectSubset.  This evaluates
-// the prototype chain for string keys but not for symbols.  (Otherwise, it
-// could find values such as a Set or Map's Symbol.toStringTag, with unexpected
-// results.)
-export const getObjectKeys = (object: object): Array<string | symbol> => [
-  ...Object.keys(object),
-  ...Object.getOwnPropertySymbols(object),
-];
+// the prototype chain for string keys but not for non-enumerable symbols.
+// (Otherwise, it could find values such as a Set or Map's Symbol.toStringTag,
+// with unexpected results.)
+// export const getObjectKeys = (object: object): Array<string | symbol> => [
+//   ...Object.keys(object),
+//   ...Object.getOwnPropertySymbols(object).filter(
+//     s => Object.getOwnPropertyDescriptor(object, s)?.enumerable,
+//   ),
+// ];
+export const getObjectKeys = (object: object): Array<string | symbol> => {
+  return [
+    ...Object.keys(object),
+    ...Object.getOwnPropertySymbols(object).filter(
+      s => Object.getOwnPropertyDescriptor(object, s)?.enumerable,
+    ),
+  ];
+};
 
 export const getPath = (
   object: Record<string, any>,


### PR DESCRIPTION
# Summary

Aim to solve https://github.com/jestjs/jest/issues/14669. Context is detailed in the issue.

I think it makes more sense to ignore non-enumerable fields in the object when doing the match, otherwise it may have some unexpected behavior mobx is involved.

# Test plan

Unit tests has been added