### PR TITLE
fix: comparing different URL objects now return false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,14 @@
 - `[*]` [**BREAKING**] Drop support for `typescript@4.3`, minimum version is now `5.0` ([#14542](https://github.com/facebook/jest/pull/14542))
 - `[*]` Depend on exact versions of monorepo dependencies instead of `^` range ([#14553](https://github.com/facebook/jest/pull/14553))
 - `[*]` [**BREAKING**] Add ESM wrapper for all of Jest's modules ([#14661](https://github.com/jestjs/jest/pull/14661))
+- `[docs]` Fix typos in `CHANGELOG.md` and `packages/jest-validate/README.md` ([#14640](https://github.com/jestjs/jest/pull/14640))
+- `[docs]` Don't use alias matchers in docs ([#14631](https://github.com/facebook/jest/pull/14631))
 - `[babel-jest, babel-preset-jest]` [**BREAKING**] Increase peer dependency of `@babel/core` to `^7.11` ([#14109](https://github.com/jestjs/jest/pull/14109))
 - `[expect]` [**BREAKING**] Remove `.toBeCalled()`, `.toBeCalledTimes()`, `.toBeCalledWith()`, `.lastCalledWith()`, `.nthCalledWith()`, `.toReturn()`, `.toReturnTimes()`, `.toReturnWith()`, `.lastReturnedWith()`, `.nthReturnedWith()` and `.toThrowError()` matcher aliases ([#14632](https://github.com/facebook/jest/pull/14632))
 - `[jest-cli, jest-config, @jest/types]` [**BREAKING**] Remove deprecated `--init` argument ([#14490](https://github.com/jestjs/jest/pull/14490))
 - `[jest-config, @jest/core, jest-util]` Upgrade `ci-info` ([#14655](https://github.com/jestjs/jest/pull/14655))
+- `[jest-mock]` [**BREAKING**] Remove `MockFunctionMetadataType`, `MockFunctionMetadata` and `SpyInstance` types ([#14621](https://github.com/jestjs/jest/pull/14621))
 - `[jest-transform]` Upgrade `write-file-atomic` ([#14274](https://github.com/jestjs/jest/pull/14274))
-- `[docs]` Fix typos in `CHANGELOG.md` and `packages/jest-validate/README.md` ([#14640](https://github.com/jestjs/jest/pull/14640))
-- `[docs]` Don't use alias matchers in docs ([#14631](https://github.com/facebook/jest/pull/14631))
 
 ## 29.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[jest-circus, jest-expect, jest-snapshot]` Pass `test.failing` tests when containing failing snapshot matchers ([#14313](https://github.com/jestjs/jest/pull/14313))
 - `[jest-config]` Make sure to respect `runInBand` option ([#14578](https://github.com/facebook/jest/pull/14578))
 - `[@jest/expect-utils]` Fix comparison of `DataView` ([#14408](https://github.com/jestjs/jest/pull/14408))
+- `[@jest/expect-utils]` Fix comparison of `URL` ([#14672](https://github.com/jestjs/jest/pull/14672))
 - `[jest-leak-detector]` Make leak-detector more aggressive when running GC ([#14526](https://github.com/jestjs/jest/pull/14526))
 - `[jest-runtime]` Properly handle re-exported native modules in ESM via CJS ([#14589](https://github.com/jestjs/jest/pull/14589))
 - `[jest-util]` Make sure `isInteractive` works in a browser ([#14552](https://github.com/jestjs/jest/pull/14552))

--- a/packages/expect-utils/src/__tests__/utils.test.ts
+++ b/packages/expect-utils/src/__tests__/utils.test.ts
@@ -17,6 +17,7 @@ import {
   subsetEquality,
   typeEquality,
 } from '../utils';
+import { equals } from "../jasmineUtils";
 
 describe('getPath()', () => {
   test('property exists', () => {
@@ -578,9 +579,21 @@ describe('arrayBufferEquality', () => {
     expect(arrayBufferEquality(a, b)).toBeTruthy();
   });
 
-  test('returns false when given matching DataView', () => {
+  test('returns false when given non-matching DataView', () => {
     const a = new DataView(Uint8Array.from([1, 2, 3]).buffer);
     const b = new DataView(Uint8Array.from([3, 2, 1]).buffer);
     expect(arrayBufferEquality(a, b)).toBeFalsy();
+  });
+
+  test('returns true when given matching URL', () => {
+    const a = new URL("https://jestjs.io/");
+    const b = new URL("https://jestjs.io/");
+    expect(equals(a, b)).toBeTruthy();
+  });
+
+  test('returns false when given non-matching URL', () => {
+    const a = new URL("https://jestjs.io/docs/getting-started");
+    const b = new URL("https://jestjs.io/docs/getting-started#using-babel");
+    expect(equals(a, b)).toBeFalsy();
   });
 });

--- a/packages/expect-utils/src/__tests__/utils.test.ts
+++ b/packages/expect-utils/src/__tests__/utils.test.ts
@@ -8,6 +8,7 @@
 
 import {List, OrderedMap, OrderedSet, Record} from 'immutable';
 import {stringify} from 'jest-matcher-utils';
+import {equals} from '../jasmineUtils';
 import {
   arrayBufferEquality,
   emptyObject,
@@ -17,7 +18,6 @@ import {
   subsetEquality,
   typeEquality,
 } from '../utils';
-import { equals } from "../jasmineUtils";
 
 describe('getPath()', () => {
   test('property exists', () => {
@@ -586,14 +586,14 @@ describe('arrayBufferEquality', () => {
   });
 
   test('returns true when given matching URL', () => {
-    const a = new URL("https://jestjs.io/");
-    const b = new URL("https://jestjs.io/");
+    const a = new URL('https://jestjs.io/');
+    const b = new URL('https://jestjs.io/');
     expect(equals(a, b)).toBeTruthy();
   });
 
   test('returns false when given non-matching URL', () => {
-    const a = new URL("https://jestjs.io/docs/getting-started");
-    const b = new URL("https://jestjs.io/docs/getting-started#using-babel");
+    const a = new URL('https://jestjs.io/docs/getting-started');
+    const b = new URL('https://jestjs.io/docs/getting-started#using-babel');
     expect(equals(a, b)).toBeFalsy();
   });
 });

--- a/packages/expect-utils/src/jasmineUtils.ts
+++ b/packages/expect-utils/src/jasmineUtils.ts
@@ -125,6 +125,9 @@ function eq(
     // RegExps are compared by their source patterns and flags.
     case '[object RegExp]':
       return a.source === b.source && a.flags === b.flags;
+    // URLs are compared by their href property which contains the entire url string.
+    case '[object URL]':
+      return a.href === b.href;
   }
   if (typeof a !== 'object' || typeof b !== 'object') {
     return false;

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -19,9 +19,6 @@ export type MockMetadataType =
   | 'null'
   | 'undefined';
 
-// TODO remove re-export in Jest 30
-export type MockFunctionMetadataType = MockMetadataType;
-
 export type MockMetadata<T, MetadataType = MockMetadataType> = {
   ref?: number;
   members?: Record<string, MockMetadata<T>>;
@@ -32,12 +29,6 @@ export type MockMetadata<T, MetadataType = MockMetadataType> = {
   value?: T;
   length?: number;
 };
-
-// TODO remove re-export in Jest 30
-export type MockFunctionMetadata<
-  T = unknown,
-  MetadataType = MockMetadataType,
-> = MockMetadata<T, MetadataType>;
 
 export type ClassLike = {new (...args: any): any};
 export type FunctionLike = (...args: any) => any;
@@ -118,11 +109,6 @@ export type Spied<T extends ClassLike | FunctionLike> = T extends ClassLike
   : T extends FunctionLike
   ? SpiedFunction<T>
   : never;
-
-// TODO in Jest 30 remove `SpyInstance` in favour of `Spied`
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface SpyInstance<T extends FunctionLike = UnknownFunction>
-  extends MockInstance<T> {}
 
 /**
  * All what the internal typings need is to be sure that we have any-function.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Previously, jest would report this test as **PASS**.
```ts
test('url test', () => {
    expect(new URL("https://jestjs.io/")).toEqual(new URL("https://jestjs.io/docs/getting-started"));
});
```
In this pull request, this gets fixed and jest properly compares the two URL objects and reports **FAIL**.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
```ts
test('url test', () => {
    expect(new URL("https://jestjs.io/")).toEqual(new URL("https://jestjs.io/"));
});
// Results in PASS.
```
```ts
test('hash test', () => {
    expect(new URL("https://jestjs.io/docs/getting-started")).toEqual(new URL("https://jestjs.io/docs/getting-started#using-babel"));
});
// Results in FAIL.
```
