### PR TITLE
fix(jest-worker): failed assertion with circular value hangs the test run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
   - [**BREAKING**] Changes `testPathPattern` configuration option to `testPathPatterns`, which now takes a list of patterns instead of the regex.
   - [**BREAKING**] `--testPathPattern` is now `--testPathPatterns`
 - `[jest-reporters, jest-runner]` Unhandled errors without stack get correctly logged to console ([#14619](https://github.com/facebook/jest/pull/14619))
+- [jest-worker] Properly handle a circular reference error when worker tries to send an assertion fails where either the expected or actual value is circular ([#14675](https://github.com/jestjs/jest/pull/14675))
 
 ### Performance
 

--- a/e2e/__tests__/circularInequality.test.ts
+++ b/e2e/__tests__/circularInequality.test.ts
@@ -25,7 +25,7 @@ afterEach(() => {
   cleanup(tempDir);
 });
 
-test.skip('handles circular inequality properly', async () => {
+test('handles circular inequality properly', async () => {
   const testFileContent = `
     it('test', () => {
       const foo = {};

--- a/e2e/__tests__/circularInequality.test.ts
+++ b/e2e/__tests__/circularInequality.test.ts
@@ -44,7 +44,7 @@ test('handles circular inequality properly', async () => {
     tempDir,
     ['--no-watchman', '--watch-all'],
     // timeout in case the `waitUntil` below doesn't fire
-    {stripAnsi: true, timeout: 5000},
+    {stripAnsi: true, timeout: 10_000},
   );
 
   await waitUntil(({stderr}) => stderr.includes('Ran all test suites.'));

--- a/packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.ts
+++ b/packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.ts
@@ -20,7 +20,12 @@ import ThreadsWorker from '../NodeThreadsWorker';
 jest.setTimeout(10_000);
 
 const root = join('../../');
-const filesToBuild = ['workers/processChild', 'workers/threadChild', 'types'];
+const filesToBuild = [
+  'workers/processChild',
+  'workers/threadChild',
+  'workers/withoutCircularRefs',
+  'types',
+];
 const writeDestination = join(__dirname, '__temp__');
 const processChildWorkerPath = join(
   writeDestination,

--- a/packages/jest-worker/src/workers/__tests__/processChild.test.ts
+++ b/packages/jest-worker/src/workers/__tests__/processChild.test.ts
@@ -41,6 +41,12 @@ beforeEach(() => {
       mockCount++;
 
       return {
+        fooCircularResult() {
+          const circular = {self: undefined as unknown};
+          circular.self = circular;
+          return {error: circular};
+        },
+
         fooPromiseThrows() {
           return new Promise((_resolve, reject) => {
             setTimeout(() => reject(mockError), 5);
@@ -336,6 +342,33 @@ it('returns results when it gets resolved if function is asynchronous', async ()
   ]);
 
   expect(spyProcessSend).toHaveBeenCalledTimes(2);
+});
+
+it('returns results with circular references', () => {
+  process.emit(
+    'message',
+    [
+      CHILD_MESSAGE_INITIALIZE,
+      true, // Not really used here, but for type purity.
+      './my-fancy-worker',
+    ],
+    null,
+  );
+
+  process.emit(
+    'message',
+    [
+      CHILD_MESSAGE_CALL,
+      true, // Not really used here, but for type purity.
+      'fooCircularResult',
+      [],
+    ],
+    null,
+  );
+
+  expect(spyProcessSend.mock.calls[0][0][1]).toEqual({
+    error: {self: expect.anything()},
+  });
 });
 
 it('calls the main module if the method call is "default"', () => {

--- a/packages/jest-worker/src/workers/__tests__/withoutCircularRefs.test.ts
+++ b/packages/jest-worker/src/workers/__tests__/withoutCircularRefs.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import {withoutCircularRefs} from '../withoutCircularRefs';
 
 it('test simple values', () => {

--- a/packages/jest-worker/src/workers/__tests__/withoutCircularRefs.test.ts
+++ b/packages/jest-worker/src/workers/__tests__/withoutCircularRefs.test.ts
@@ -1,0 +1,26 @@
+import {withoutCircularRefs} from '../withoutCircularRefs';
+
+it('test simple values', () => {
+  expect(withoutCircularRefs(undefined)).toBeUndefined();
+  expect(withoutCircularRefs(null)).toBeNull();
+  expect(withoutCircularRefs(0)).toBe(0);
+  expect(withoutCircularRefs('12')).toBe('12');
+  expect(withoutCircularRefs(true)).toBe(true);
+  expect(withoutCircularRefs([1])).toEqual([1]);
+  expect(withoutCircularRefs({a: 1, b: {c: 2}})).toEqual({a: 1, b: {c: 2}});
+});
+
+it('test circular values', () => {
+  const circular = {self: undefined as any};
+  circular.self = circular;
+
+  expect(withoutCircularRefs(circular)).toEqual({self: '[Circular]'});
+
+  expect(withoutCircularRefs([{a: circular, b: null}])).toEqual([
+    {a: {self: '[Circular]'}, b: null},
+  ]);
+
+  expect(withoutCircularRefs({a: {b: circular}, c: undefined})).toEqual({
+    a: {b: {self: '[Circular]'}, c: undefined},
+  });
+});

--- a/packages/jest-worker/src/workers/messageParent.ts
+++ b/packages/jest-worker/src/workers/messageParent.ts
@@ -18,8 +18,8 @@ export default function messageParent(
   } else if (typeof parentProcess.send === 'function') {
     try {
       parentProcess.send([PARENT_MESSAGE_CUSTOM, message]);
-    } catch (e: any) {
-      if (/circular structure/.test(e?.message)) {
+    } catch (error) {
+      if (error instanceof Error && /circular structure/.test(e?.message)) {
         // We can safely send a message to the parent process again
         // because previous sending was halted by "TypeError: Converting circular structure to JSON".
         // But this time the message will be cleared from circular references.
@@ -28,7 +28,7 @@ export default function messageParent(
           withoutCircularRefs(message),
         ]);
       } else {
-        throw e;
+        throw error;
       }
     }
   } else {

--- a/packages/jest-worker/src/workers/messageParent.ts
+++ b/packages/jest-worker/src/workers/messageParent.ts
@@ -20,6 +20,9 @@ export default function messageParent(
       parentProcess.send([PARENT_MESSAGE_CUSTOM, message]);
     } catch (e: any) {
       if (/circular structure/.test(e?.message)) {
+        // We can safely send a message to the parent process again
+        // because previous sending was halted by "TypeError: Converting circular structure to JSON".
+        // But this time the message will be cleared from circular references.
         parentProcess.send([
           PARENT_MESSAGE_CUSTOM,
           withoutCircularRefs(message),

--- a/packages/jest-worker/src/workers/messageParent.ts
+++ b/packages/jest-worker/src/workers/messageParent.ts
@@ -19,7 +19,7 @@ export default function messageParent(
     try {
       parentProcess.send([PARENT_MESSAGE_CUSTOM, message]);
     } catch (error) {
-      if (error instanceof Error && /circular structure/.test(e?.message)) {
+      if (error instanceof Error && /circular structure/.test(error?.message)) {
         // We can safely send a message to the parent process again
         // because previous sending was halted by "TypeError: Converting circular structure to JSON".
         // But this time the message will be cleared from circular references.

--- a/packages/jest-worker/src/workers/processChild.ts
+++ b/packages/jest-worker/src/workers/processChild.ts
@@ -104,7 +104,7 @@ function reportSuccess(result: unknown) {
     // We can safely send a message to the parent process again
     // because previous sending was halted by "TypeError: Converting circular structure to JSON".
     // But this time the message will be cleared from circular references.
-    if (error instanceof Error && /circular structure/.test(e?.message)) {
+    if (error instanceof Error && /circular structure/.test(error?.message)) {
       process.send([PARENT_MESSAGE_OK, withoutCircularRefs(result)]);
     } else {
       throw error;

--- a/packages/jest-worker/src/workers/processChild.ts
+++ b/packages/jest-worker/src/workers/processChild.ts
@@ -101,6 +101,9 @@ function reportSuccess(result: unknown) {
   try {
     process.send([PARENT_MESSAGE_OK, result]);
   } catch (e: any) {
+    // We can safely send a message to the parent process again
+    // because previous sending was halted by "TypeError: Converting circular structure to JSON".
+    // But this time the message will be cleared from circular references.
     if (e && /circular structure/.test(e?.message)) {
       process.send([PARENT_MESSAGE_OK, withoutCircularRefs(result)]);
     } else {

--- a/packages/jest-worker/src/workers/processChild.ts
+++ b/packages/jest-worker/src/workers/processChild.ts
@@ -100,14 +100,14 @@ function reportSuccess(result: unknown) {
 
   try {
     process.send([PARENT_MESSAGE_OK, result]);
-  } catch (e: any) {
+  } catch (error) {
     // We can safely send a message to the parent process again
     // because previous sending was halted by "TypeError: Converting circular structure to JSON".
     // But this time the message will be cleared from circular references.
-    if (e && /circular structure/.test(e?.message)) {
+    if (error instanceof Error && /circular structure/.test(e?.message)) {
       process.send([PARENT_MESSAGE_OK, withoutCircularRefs(result)]);
     } else {
-      throw e;
+      throw error;
     }
   }
 }

--- a/packages/jest-worker/src/workers/withoutCircularRefs.ts
+++ b/packages/jest-worker/src/workers/withoutCircularRefs.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 export function withoutCircularRefs(obj: unknown): unknown {
   const cache = new WeakSet();
   function copy(obj: unknown) {

--- a/packages/jest-worker/src/workers/withoutCircularRefs.ts
+++ b/packages/jest-worker/src/workers/withoutCircularRefs.ts
@@ -1,0 +1,20 @@
+export function withoutCircularRefs(obj: unknown): unknown {
+  const cache = new WeakSet();
+  function copy(obj: unknown) {
+    if (typeof obj !== 'object' || obj === null) {
+      return obj;
+    }
+    if (cache.has(obj)) {
+      return '[Circular]';
+    }
+    cache.add(obj);
+    const copyObj: any = Array.isArray(obj) ? [] : {};
+    for (const key in obj) {
+      if (Object.prototype.hasOwnProperty.call(obj, key)) {
+        copyObj[key] = copy((obj as any)[key]);
+      }
+    }
+    return copyObj;
+  }
+  return copy(obj);
+}


### PR DESCRIPTION
Relates #10577

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

When an assertion fails where either the expected or actual value is circular, and both values are objects, jest encounters an error stating it failed to convert a circular structure to JSON, resulting in the test run not completing.

This PR fixes sending `result` with circular references from worker to runner.  

```
       TypeError: Converting circular structure to JSON
        --> starting at object with constructor 'ClientRequest'
        |     property 'socket' -> object with constructor 'TLSSocket'
        --- property '_httpMessage' closes the circle
        at stringify (<anonymous>)

      at messageParent (node_modules/jest-worker/build/workers/messageParent.js:29:19)
```
