### PR TITLE
feat(jest-environment-node) add crypto to test environment node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[jest-snapshot]` [**BREAKING**] Add support for [Error causes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) in snapshots ([#13965](https://github.com/facebook/jest/pull/13965))
 - `[jest-snapshot]` Support Prettier 3 ([#14566](https://github.com/facebook/jest/pull/14566))
 - `[pretty-format]` [**BREAKING**] Do not render empty string children (`''`) in React plugin ([#14470](https://github.com/facebook/jest/pull/14470))
+- `[jest-environment-node]` Add `global.crypto` ([#14680](https://github.com/jestjs/jest/pull/14680))
 
 ### Fixes
 

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {webcrypto} from 'node:crypto';
 import {type Context, createContext, runInContext} from 'vm';
 import type {
   EnvironmentContext,
@@ -130,6 +131,8 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
     }
 
     global.global = global;
+    // global Crypto type is consuming lib.dom.d.ts but this is for node environment.
+    global.crypto = webcrypto as Crypto;
     global.Buffer = Buffer;
     global.ArrayBuffer = ArrayBuffer;
     // TextEncoder (global or via 'util') references a Uint8Array constructor


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Add `crypto` to jest environment node, for context, see: https://github.com/jestjs/jest/issues/14679

## Test plan

Not sure whether we need test here? `webCrypto` is introduced to node since v16, which is the lowest version jest@29 supports I think?