### PR TITLE
Add `waitNextEventLoopTurnForUnhandledRejectionEvents` flag

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -517,6 +517,12 @@ Display individual test results with the test suite hierarchy.
 
 Alias: `-v`. Print the version and exit.
 
+### `--waitNextEventLoopTurnForUnhandledRejectionEvents`
+
+Gives one event loop turn to handle `rejectionHandled`, `uncaughtException` or `unhandledRejection`.
+
+Without this flag Jest may report false-positive errors (e.g. actually handled rejection reported) or not report actually unhandled rejection (or report it for different test case).
+
 ### `--watch`
 
 Watch files for changes and rerun tests related to changed files. If you want to re-run all tests when a file has changed, use the `--watchAll` option instead.

--- a/e2e/promise-async-handling/package.json
+++ b/e2e/promise-async-handling/package.json
@@ -1,5 +1,6 @@
 {
   "jest": {
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "waitNextEventLoopTurnForUnhandledRejectionEvents": true
   }
 }

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -132,7 +132,7 @@ export const initialize = async ({
     addEventHandler(testCaseReportHandler(testPath, sendMessageToJest));
   }
 
-  addEventHandler(unhandledRejectionHandler(runtime));
+  addEventHandler(unhandledRejectionHandler(runtime, globalConfig.waitNextEventLoopTurnForUnhandledRejectionEvents));
 
   // Return it back to the outer scope (test runner outside the VM).
   return {globals: globalsObject, snapshotState};

--- a/packages/jest-circus/src/unhandledRejectionHandler.ts
+++ b/packages/jest-circus/src/unhandledRejectionHandler.ts
@@ -22,6 +22,7 @@ const untilNextEventLoopTurn = async () => {
 
 export const unhandledRejectionHandler = (
   runtime: Runtime,
+  waitNextEventLoopTurnForUnhandledRejectionEvents: boolean,
 ): Circus.EventHandler => {
   return async (event, state) => {
     if (event.name === 'hook_start') {
@@ -29,8 +30,10 @@ export const unhandledRejectionHandler = (
     } else if (event.name === 'hook_success' || event.name === 'hook_failure') {
       runtime.leaveTestCode();
 
-      // We need to give event loop the time to actually execute `rejectionHandled`, `uncaughtException` or `unhandledRejection` events
-      await untilNextEventLoopTurn();
+      if (waitNextEventLoopTurnForUnhandledRejectionEvents) {
+        // We need to give event loop the time to actually execute `rejectionHandled`, `uncaughtException` or `unhandledRejection` events
+        await untilNextEventLoopTurn();
+      }
 
       const {test, describeBlock, hook} = event;
       const {asyncError, type} = hook;
@@ -60,8 +63,10 @@ export const unhandledRejectionHandler = (
     ) {
       runtime.leaveTestCode();
 
-      // We need to give event loop the time to actually execute `rejectionHandled`, `uncaughtException` or `unhandledRejection` events
-      await untilNextEventLoopTurn();
+      if (waitNextEventLoopTurnForUnhandledRejectionEvents) {
+        // We need to give event loop the time to actually execute `rejectionHandled`, `uncaughtException` or `unhandledRejection` events
+        await untilNextEventLoopTurn();
+      }
 
       const {test} = event;
       invariant(test, 'always present for `*Each` hooks');
@@ -70,8 +75,10 @@ export const unhandledRejectionHandler = (
         test.errors.push([error, event.test.asyncError]);
       }
     } else if (event.name === 'teardown') {
-      // We need to give event loop the time to actually execute `rejectionHandled`, `uncaughtException` or `unhandledRejection` events
-      await untilNextEventLoopTurn();
+      if (waitNextEventLoopTurnForUnhandledRejectionEvents) {
+        // We need to give event loop the time to actually execute `rejectionHandled`, `uncaughtException` or `unhandledRejection` events
+        await untilNextEventLoopTurn();
+      }
 
       state.unhandledErrors.push(
         ...state.unhandledRejectionErrorByPromise.values(),

--- a/packages/jest-cli/src/args.ts
+++ b/packages/jest-cli/src/args.ts
@@ -686,6 +686,12 @@ export const options: {[key: string]: Options} = {
       'Display individual test results with the test suite hierarchy.',
     type: 'boolean',
   },
+  waitNextEventLoopTurnForUnhandledRejectionEvents: {
+    description:
+      'Gives one event loop turn to handle `rejectionHandled`, ' +
+      '`uncaughtException` or `unhandledRejection`.',
+    type: 'boolean',
+  },
   watch: {
     description:
       'Watch files for changes and rerun tests related to ' +

--- a/packages/jest-config/src/Defaults.ts
+++ b/packages/jest-config/src/Defaults.ts
@@ -91,6 +91,7 @@ const defaultOptions: Config.DefaultOptions = {
   testSequencer: '@jest/test-sequencer',
   transformIgnorePatterns: [NODE_MODULES_REGEXP, `\\.pnp\\.[^\\${sep}]+$`],
   useStderr: false,
+  waitNextEventLoopTurnForUnhandledRejectionEvents: false,
   watch: false,
   watchPathIgnorePatterns: [],
   watchman: true,

--- a/packages/jest-config/src/ValidConfig.ts
+++ b/packages/jest-config/src/ValidConfig.ts
@@ -181,6 +181,7 @@ export const initialOptions: Config.InitialOptions = {
   updateSnapshot: true,
   useStderr: false,
   verbose: false,
+  waitNextEventLoopTurnForUnhandledRejectionEvents: false,
   watch: false,
   watchAll: false,
   watchPathIgnorePatterns: ['<rootDir>/e2e/'],
@@ -320,6 +321,7 @@ export const initialProjectOptions: Config.InitialProjectOptions = {
   },
   transformIgnorePatterns: [NODE_MODULES_REGEXP],
   unmockedModulePathPatterns: ['mock'],
+  waitNextEventLoopTurnForUnhandledRejectionEvents: false,
   watchPathIgnorePatterns: ['<rootDir>/e2e/'],
   workerIdleMemoryLimit: multipleValidOptions(0.2, '50%'),
 };

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -138,6 +138,7 @@ const groupOptions = (
     updateSnapshot: options.updateSnapshot,
     useStderr: options.useStderr,
     verbose: options.verbose,
+    waitNextEventLoopTurnForUnhandledRejectionEvents: options.waitNextEventLoopTurnForUnhandledRejectionEvents,
     watch: options.watch,
     watchAll: options.watchAll,
     watchPlugins: options.watchPlugins,
@@ -203,6 +204,7 @@ const groupOptions = (
     transform: options.transform,
     transformIgnorePatterns: options.transformIgnorePatterns,
     unmockedModulePathPatterns: options.unmockedModulePathPatterns,
+    waitNextEventLoopTurnForUnhandledRejectionEvents: options.waitNextEventLoopTurnForUnhandledRejectionEvents,
     watchPathIgnorePatterns: options.watchPathIgnorePatterns,
   }),
 });

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -933,6 +933,7 @@ export default async function normalize(
       case 'testNamePattern':
       case 'useStderr':
       case 'verbose':
+      case 'waitNextEventLoopTurnForUnhandledRejectionEvents':
       case 'watch':
       case 'watchAll':
       case 'watchman':

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -204,6 +204,7 @@ export type DefaultOptions = {
   testSequencer: string;
   transformIgnorePatterns: Array<string>;
   useStderr: boolean;
+  waitNextEventLoopTurnForUnhandledRejectionEvents: boolean;
   watch: boolean;
   watchPathIgnorePatterns: Array<string>;
   watchman: boolean;
@@ -325,6 +326,7 @@ export type InitialOptions = Partial<{
   updateSnapshot: boolean;
   useStderr: boolean;
   verbose?: boolean;
+  waitNextEventLoopTurnForUnhandledRejectionEvents: boolean;
   watch: boolean;
   watchAll: boolean;
   watchman: boolean;
@@ -419,6 +421,7 @@ export type GlobalConfig = {
   updateSnapshot: SnapshotUpdateState;
   useStderr: boolean;
   verbose?: boolean;
+  waitNextEventLoopTurnForUnhandledRejectionEvents: boolean;
   watch: boolean;
   watchAll: boolean;
   watchman: boolean;
@@ -491,6 +494,7 @@ export type ProjectConfig = {
   transformIgnorePatterns: Array<string>;
   watchPathIgnorePatterns: Array<string>;
   unmockedModulePathPatterns?: Array<string>;
+  waitNextEventLoopTurnForUnhandledRejectionEvents: boolean;
   workerIdleMemoryLimit?: number;
 };
 

--- a/packages/test-utils/src/config.ts
+++ b/packages/test-utils/src/config.ts
@@ -62,6 +62,7 @@ const DEFAULT_GLOBAL_CONFIG: Config.GlobalConfig = {
   updateSnapshot: 'none',
   useStderr: false,
   verbose: false,
+  waitNextEventLoopTurnForUnhandledRejectionEvents: false,
   watch: false,
   watchAll: false,
   watchPlugins: [],
@@ -126,6 +127,7 @@ const DEFAULT_PROJECT_CONFIG: Config.ProjectConfig = {
   transformIgnorePatterns: [],
   unmockedModulePathPatterns: undefined,
   watchPathIgnorePatterns: [],
+  waitNextEventLoopTurnForUnhandledRejectionEvents: false,
 };
 
 export const makeGlobalConfig = (


### PR DESCRIPTION
Followup on #14315

## Summary

Adds `waitNextEventLoopTurnForUnhandledRejectionEvents` flag to await for the next even loop turn to correctly detect unhandled promise rejections in tests. See https://github.com/jestjs/jest/pull/14315#issuecomment-1785225984 for more details

The feature of correct detection of unhandled promise rejections adds one event loop turn to every hook and test. It may have negative performance impact on test suites with many tests and hooks.