### PR TITLE
Stop issue from #444 causing randomly failing runs

### DIFF
--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -928,14 +928,21 @@ const writeCacheFile = (cachePath: string, fileData: string) => {
  * processes attempt to rename to the same target file at the same time.
  * If the target file exists we can be reasonably sure another process has
  * legitimately won a cache write race and ignore the error.
+ * If the target does not exist we do not know if it is because it is still
+ * being written by another process or is being overwritten by another process.
  */
 const cacheWriteErrorSafeToIgnore = (
   e: Error & {code: string},
   cachePath: string,
-) =>
-  process.platform === 'win32' &&
-  e.code === 'EPERM' &&
-  fs.existsSync(cachePath);
+) => {
+  if (process.platform !== 'win32' || e.code !== 'EPERM') {
+    return false;
+  }
+  if (!fs.existsSync(cachePath)) {
+    console.warn('Possible problem writing cache if this occurs many times', e);
+  }
+  return true;
+};
 
 const readCacheFile = (cachePath: string): string | null => {
   if (!fs.existsSync(cachePath)) {


### PR DESCRIPTION
This is a recreation of my original PR: https://github.com/jestjs/jest/pull/11104

(sorry - it was ignored for a year, then got 2 review comments and then ignored for another year. I've tried mentioning, requesting review and asking for help on the forum). I'm hoping I can get some traction on this now, since our work-around, where we (and many other users) patch jest with every install is getting more difficult in jest v30 with the bundling.

## Summary

We would like to not have jest failing multiple runs a day because of https://github.com/jestjs/jest/issues/4444.

See https://github.com/jestjs/jest/issues/4444#issuecomment-782923561 for an explanation of what is going on.

essentially "reasonably sure" in the comment means 99% of the time, but not 100% of the time, meaning jest fails some of the time, which is not great.

## Test plan

This is really hard to test... If you think this is an approach you could accept I'd be happy to discuss what else you need.

I don't mind removing the console.log if you like or making this opt-in e.g. "makeJestWorkForLargeCodebasesOnWindows" or whatever you want me to do,, please tell me, I just want to stop having to patch jest and be allowed to update to v30.
