### PR TITLE
feat(snapshot): support snapshotResolver and snapshotSerializers written in ESM (#12014 rebase)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[jest-snapshot]` [**BREAKING**] Add support for [Error causes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) in snapshots ([#13965](https://github.com/facebook/jest/pull/13965))
 - `[jest-snapshot]` Support Prettier 3 ([#14566](https://github.com/facebook/jest/pull/14566))
 - `[pretty-format]` [**BREAKING**] Do not render empty string children (`''`) in React plugin ([#14470](https://github.com/facebook/jest/pull/14470))
+- `[jest-circus, jest-jasmine2, jest-runtime, jest-snapshot]` Add support for `snapshotResolver` and `snapshotSerializers` written in ESM ([#12014](https://github.com/facebook/jest/pull/12014))
 
 ### Fixes
 

--- a/e2e/__tests__/transform.test.ts
+++ b/e2e/__tests__/transform.test.ts
@@ -344,4 +344,42 @@ describe('transform-esm-testrunner', () => {
     expect(json.success).toBe(true);
     expect(json.numPassedTests).toBe(1);
   });
+
+  describe('transform-esm-snapshotResolver', () => {
+    const dir = path.resolve(
+      __dirname,
+      '..',
+      'transform/transform-esm-snapshotResolver',
+    );
+    const snapshotDir = path.resolve(dir, '__snapshots__');
+    const snapshotFile = path.resolve(snapshotDir, 'snapshot.test.js.snap');
+
+    const cleanupTest = () => {
+      if (fs.existsSync(snapshotFile)) {
+        fs.unlinkSync(snapshotFile);
+      }
+      if (fs.existsSync(snapshotDir)) {
+        fs.rmdirSync(snapshotDir);
+      }
+    };
+
+    beforeAll(() => {
+      runYarnInstall(dir);
+    });
+    beforeEach(cleanupTest);
+    afterAll(cleanupTest);
+
+    it('should transform the snapshotResolver', () => {
+      const result = runJest(dir, ['-w=1', '--no-cache', '--ci=false'], {
+        nodeOptions: '--experimental-vm-modules --no-warnings',
+      });
+
+      expect(result.stderr).toMatch('1 snapshot written from 1 test suite');
+
+      const contents = require(snapshotFile);
+      expect(contents).toHaveProperty(
+        'snapshots are written to custom location 1',
+      );
+    });
+  });
 });

--- a/e2e/snapshot-resolver-esm/__tests__/snapshot.test.js
+++ b/e2e/snapshot-resolver-esm/__tests__/snapshot.test.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+test('snapshots are written to custom location', () => {
+  expect('foobar').toMatchSnapshot();
+});

--- a/e2e/snapshot-resolver-esm/customSnapshotResolver.mjs
+++ b/e2e/snapshot-resolver-esm/customSnapshotResolver.mjs
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default {
+  resolveSnapshotPath: (testPath, snapshotExtension) =>
+    testPath.replace('__tests__', '__snapshots__') + snapshotExtension,
+
+  resolveTestPath: (snapshotFilePath, snapshotExtension) =>
+    snapshotFilePath
+      .replace('__snapshots__', '__tests__')
+      .slice(0, -snapshotExtension.length),
+
+  testPathForConsistencyCheck: 'foo/__tests__/bar.test.js',
+};

--- a/e2e/snapshot-resolver-esm/package.json
+++ b/e2e/snapshot-resolver-esm/package.json
@@ -1,0 +1,6 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "snapshotResolver": "<rootDir>/customSnapshotResolver.mjs"
+  }
+}

--- a/e2e/snapshot-serializers-esm/__tests__/snapshot.test.js
+++ b/e2e/snapshot-serializers-esm/__tests__/snapshot.test.js
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+'use strict';
+
+describe('snapshot serializers', () => {
+  it('works with first plugin', () => {
+    const test = {
+      foo: 1,
+    };
+    expect(test).toMatchSnapshot();
+  });
+
+  it('works with second plugin', () => {
+    const test = {
+      bar: 2,
+    };
+    expect(test).toMatchSnapshot();
+  });
+
+  it('works with nested serializable objects', () => {
+    const test = {
+      foo: {
+        bar: 2,
+      },
+    };
+    expect(test).toMatchSnapshot();
+  });
+
+  it('works with default serializers', () => {
+    const test = {
+      $$typeof: Symbol.for('react.test.json'),
+      children: null,
+      props: {
+        id: 'foo',
+      },
+      type: 'div',
+    };
+    expect(test).toMatchSnapshot();
+  });
+
+  it('works with prepended plugins and default serializers', () => {
+    const test = {
+      $$typeof: Symbol.for('react.test.json'),
+      children: null,
+      props: {
+        aProp: {a: 6},
+        bProp: {foo: 8},
+      },
+      type: 'div',
+    };
+    expect(test).toMatchSnapshot();
+  });
+
+  it('works with prepended plugins from expect method called once', () => {
+    const test = {
+      $$typeof: Symbol.for('react.test.json'),
+      children: null,
+      props: {
+        aProp: {a: 6},
+        bProp: {foo: 8},
+      },
+      type: 'div',
+    };
+    // Add plugin that overrides foo specified by Jest config in package.json
+    expect.addSnapshotSerializer({
+      print: (val, serialize) => `Foo: ${serialize(val.foo)}`,
+      test: val => val && val.hasOwnProperty('foo'),
+    });
+    expect(test).toMatchSnapshot();
+  });
+
+  it('works with prepended plugins from expect method called twice', () => {
+    const test = {
+      $$typeof: Symbol.for('react.test.json'),
+      children: null,
+      props: {
+        aProp: {a: 6},
+        bProp: {foo: 8},
+      },
+      type: 'div',
+    };
+    // Add plugin that overrides preceding added plugin
+    expect.addSnapshotSerializer({
+      print: (val, serialize) => `FOO: ${serialize(val.foo)}`,
+      test: val => val && val.hasOwnProperty('foo'),
+    });
+    expect(test).toMatchSnapshot();
+  });
+
+  it('works with array of strings in property matcher', () => {
+    expect({
+      arrayOfStrings: ['stream'],
+    }).toMatchSnapshot({
+      arrayOfStrings: ['stream'],
+    });
+  });
+
+  it('works with expect.XXX within array in property matcher', () => {
+    expect({
+      arrayOfStrings: ['stream'],
+    }).toMatchSnapshot({
+      arrayOfStrings: [expect.any(String)],
+    });
+  });
+});

--- a/e2e/snapshot-serializers-esm/package.json
+++ b/e2e/snapshot-serializers-esm/package.json
@@ -1,0 +1,12 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "transform": {
+      "\\.js$": "<rootDir>/transformer.js"
+    },
+    "snapshotSerializers": [
+      "./plugins/foo",
+      "<rootDir>/plugins/bar"
+    ]
+  }
+}

--- a/e2e/snapshot-serializers-esm/plugins/bar.mjs
+++ b/e2e/snapshot-serializers-esm/plugins/bar.mjs
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {createPlugin} from '../utils';
+
+// We inject the call to "createPlugin('bar') through the transformer"

--- a/e2e/snapshot-serializers-esm/plugins/foo/index.mjs
+++ b/e2e/snapshot-serializers-esm/plugins/foo/index.mjs
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {createPlugin} from '../../utils';
+export default createPlugin('foo');

--- a/e2e/snapshot-serializers-esm/transformer.js
+++ b/e2e/snapshot-serializers-esm/transformer.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+module.exports = {
+  process(src, filename) {
+    if (/bar.mjs$/.test(filename)) {
+      return `${src};\nexport default createPlugin('bar');`;
+    }
+    return src;
+  },
+};

--- a/e2e/snapshot-serializers-esm/utils.mjs
+++ b/e2e/snapshot-serializers-esm/utils.mjs
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+export const createPlugin = prop => ({
+  print: (val, serialize) => `${prop} - ${serialize(val[prop])}`,
+  test: val => val && val.hasOwnProperty(prop),
+});

--- a/e2e/transform/transform-esm-snapshotResolver/__tests__/snapshot.test.js
+++ b/e2e/transform/transform-esm-snapshotResolver/__tests__/snapshot.test.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+test('snapshots are written to custom location', () => {
+  expect('foobar').toMatchSnapshot();
+});

--- a/e2e/transform/transform-esm-snapshotResolver/customSnapshotResolver.mjs
+++ b/e2e/transform/transform-esm-snapshotResolver/customSnapshotResolver.mjs
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default {
+  resolveSnapshotPath: (testPath, snapshotExtension) =>
+    testPath.replace('__tests__', '__snapshots__') + snapshotExtension,
+
+  resolveTestPath: (snapshotFilePath, snapshotExtension) =>
+    snapshotFilePath
+      .replace('__snapshots__', '__tests__')
+      .slice(0, -(snapshotExtension || '').length),
+
+  testPathForConsistencyCheck: 'foo/__tests__/bar.test.js',
+};

--- a/e2e/transform/transform-esm-snapshotResolver/package.json
+++ b/e2e/transform/transform-esm-snapshotResolver/package.json
@@ -1,0 +1,6 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "snapshotResolver": "<rootDir>/customSnapshotResolver.mjs"
+  }
+}

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -54,7 +54,10 @@ export const initialize = async ({
   environment: JestEnvironment;
   runtime: Runtime;
   globalConfig: Config.GlobalConfig;
-  localRequire: <T = unknown>(path: string) => T;
+  localRequire: <T = unknown>(
+    path: string,
+    applyInteropRequireDefault?: boolean,
+  ) => Promise<T>;
   testPath: string;
   parentProcess: typeof Process;
   sendMessageToJest?: TestFileEvent;
@@ -113,7 +116,7 @@ export const initialize = async ({
   // Jest tests snapshotSerializers in order preceding built-in serializers.
   // Therefore, add in reverse because the last added is the first tested.
   for (const path of config.snapshotSerializers.concat().reverse())
-    addSerializer(localRequire(path));
+    addSerializer(await localRequire(path));
 
   const snapshotResolver = await buildSnapshotResolver(config, localRequire);
   const snapshotPath = snapshotResolver.resolveSnapshotPath(testPath);

--- a/packages/jest-jasmine2/src/setup_jest_globals.ts
+++ b/packages/jest-jasmine2/src/setup_jest_globals.ts
@@ -12,7 +12,6 @@ import {
   addSerializer,
   buildSnapshotResolver,
 } from 'jest-snapshot';
-import type {Plugin} from 'pretty-format';
 import type {
   Attributes,
   default as JasmineSpec,
@@ -22,7 +21,10 @@ import type {
 export type SetupOptions = {
   config: Config.ProjectConfig;
   globalConfig: Config.GlobalConfig;
-  localRequire: (moduleName: string) => Plugin;
+  localRequire: <T = unknown>(
+    path: string,
+    applyInteropRequireDefault?: boolean,
+  ) => Promise<T>;
   testPath: string;
 };
 
@@ -96,7 +98,7 @@ export default async function setupJestGlobals({
   // Jest tests snapshotSerializers in order preceding built-in serializers.
   // Therefore, add in reverse because the last added is the first tested.
   for (let i = config.snapshotSerializers.length - 1; i >= 0; i--) {
-    addSerializer(localRequire(config.snapshotSerializers[i]));
+    addSerializer(await localRequire(config.snapshotSerializers[i]));
   }
 
   patchJasmine();

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -769,7 +769,11 @@ export default class Runtime {
 
     const module = await this.loadEsmModule(modulePath, query);
 
-    return this.linkAndEvaluateModule(module);
+    const evaluatedModule = await this.linkAndEvaluateModule(module);
+
+    return evaluatedModule instanceof SourceTextModule
+      ? evaluatedModule.namespace.default
+      : evaluatedModule;
   }
 
   private loadCjsAsEsm(from: string, modulePath: string, context: VMContext) {

--- a/packages/jest-snapshot/src/__tests__/SnapshotResolver.test.ts
+++ b/packages/jest-snapshot/src/__tests__/SnapshotResolver.test.ts
@@ -81,6 +81,45 @@ describe('custom resolver in project config', () => {
   });
 });
 
+describe('custom resolver written in ESM in project config', () => {
+  let snapshotResolver: SnapshotResolver;
+  const customSnapshotResolverFile = path.join(
+    __dirname,
+    'fixtures',
+    'customSnapshotResolver.mjs',
+  );
+  const projectConfig = makeProjectConfig({
+    rootDir: 'custom1',
+    snapshotResolver: customSnapshotResolverFile,
+  });
+
+  beforeEach(async () => {
+    snapshotResolver = await buildSnapshotResolver(projectConfig);
+  });
+
+  it('returns cached object if called multiple times', async () => {
+    await expect(buildSnapshotResolver(projectConfig)).resolves.toBe(
+      snapshotResolver,
+    );
+  });
+
+  it('resolveSnapshotPath()', () => {
+    expect(
+      snapshotResolver.resolveSnapshotPath(
+        path.resolve('/abc/cde/__tests__/a.test.js'),
+      ),
+    ).toBe(path.resolve('/abc/cde/__snapshots__/a.test.js.snap'));
+  });
+
+  it('resolveTestPath()', () => {
+    expect(
+      snapshotResolver.resolveTestPath(
+        path.resolve('/abc', 'cde', '__snapshots__', 'a.test.js.snap'),
+      ),
+    ).toBe(path.resolve('/abc/cde/__tests__/a.test.js'));
+  });
+});
+
 describe('malformed custom resolver in project config', () => {
   const newProjectConfig = (filename: string) => {
     const customSnapshotResolverFile = path.join(

--- a/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver.mjs
+++ b/packages/jest-snapshot/src/__tests__/fixtures/customSnapshotResolver.mjs
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default {
+  resolveSnapshotPath: (testPath, snapshotExtension) =>
+    testPath.replace('__tests__', '__snapshots__') + snapshotExtension,
+
+  resolveTestPath: (snapshotFilePath, snapshotExtension) =>
+    snapshotFilePath
+      .replace('__snapshots__', '__tests__')
+      .slice(0, -snapshotExtension.length),
+
+  testPathForConsistencyCheck: 'foo/__tests__/bar.test.js',
+};


### PR DESCRIPTION
Just a rebase of https://github.com/jestjs/jest/pull/12014

Tests to not run locally for me because of watchman issues:
```
    expect(received).toHaveLength(expected)

    Expected length: 1
    Received length: 7
    Received array:  ["jest-haste-map: Watchman crawl failed. Retrying once with node crawler.", "  Usually this happens when watchman isn't running. Create an empty `.watchmanconfig` file in your project's root folder or initialize a git or hg repository in your project.", "  Error: Watchman error: watchman::RootResolveError: failed to resolve root: unable to resolve root /tmp/multi-project-runner-test: failed to parse json from /tmp/multi-project-runner-test/.watchmanconfig: '[' or '{' expected near end of file. Make sure watchman is running for this project. See https://facebook.github.io/watchman/docs/troubleshooting.", "jest-haste-map: Watchman crawl failed. Retrying once with node crawler.", "  Usually this happens when watchman isn't running. Create an empty `.watchmanconfig` file in your project's root folder or initialize a git or hg repository in your project.", "  Error: Watchman error: watchman::RootResolveError: failed to resolve root: unable to resolve root /tmp/multi-project-runner-test: failed to parse json from /tmp/multi-project-runner-test/.watchmanconfig: '[' or '{' expected near end of file. Make sure watchman is running for this project. See https://facebook.github.io/watchman/docs/troubleshooting.", "/tmp/multi-project-runner-test/__tests__/inBothProjectsTest.js"]
```

So let's see what the CI has to say about it.