### PR TITLE
fix: allow Node16/NodeNext/Bundler moduleResolution in project's tsconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@
 - `[jest-config]` Support `testTimeout` in project config ([#14697](https://github.com/jestjs/jest/pull/14697))
 - `[jest-config]` Support `coverageReporters` in project config ([#14697](https://github.com/jestjs/jest/pull/14830))
 - `[jest-config]` Allow `reporters` in project config ([#14768](https://github.com/jestjs/jest/pull/14768))
+- `[jest-config]` Allow Node16/NodeNext/Bundler `moduleResolution` in project's tsconfig ([#14739](https://github.com/jestjs/jest/pull/14739))
 - `[jest-each]` Allow `$keypath` templates with `null` or `undefined` values ([#14831](https://github.com/jestjs/jest/pull/14831))
 - `[@jest/expect-utils]` Fix comparison of `DataView` ([#14408](https://github.com/jestjs/jest/pull/14408))
 - `[@jest/expect-utils]` [**BREAKING**] exclude non-enumerable in object matching ([#14670](https://github.com/jestjs/jest/pull/14670))

--- a/e2e/__tests__/typescriptConfigFile.test.ts
+++ b/e2e/__tests__/typescriptConfigFile.test.ts
@@ -8,7 +8,7 @@
 import {tmpdir} from 'os';
 import * as path from 'path';
 import {cleanup, writeFiles} from '../Utils';
-import runJest from '../runJest';
+import runJest, {getConfig} from '../runJest';
 
 const DIR = path.resolve(tmpdir(), 'typescript-config-file');
 
@@ -106,4 +106,20 @@ test('works with multiple typescript configs that import something', () => {
   expect(stderr).toContain('Test Suites: 4 passed, 4 total');
   expect(exitCode).toBe(0);
   expect(stdout).toBe('');
+});
+
+test("works with single typescript config that does not import anything with project's moduleResolution set to Node16", () => {
+  const {configs} = getConfig(
+    'typescript-config/modern-module-resolution',
+    [],
+    {
+      skipPkgJsonCheck: true,
+    },
+  );
+
+  expect(configs).toHaveLength(1);
+  expect(configs[0].displayName).toEqual({
+    color: 'white',
+    name: 'Config from modern ts file',
+  });
 });

--- a/e2e/typescript-config/modern-module-resolution/__tests__/test.js
+++ b/e2e/typescript-config/modern-module-resolution/__tests__/test.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+test('dummy test', () => {
+  expect(1).toBe(1);
+});

--- a/e2e/typescript-config/modern-module-resolution/jest.config.ts
+++ b/e2e/typescript-config/modern-module-resolution/jest.config.ts
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const config = {
+  displayName: 'Config from modern ts file',
+  testEnvironment: 'node',
+};
+export default config;

--- a/e2e/typescript-config/modern-module-resolution/package.json
+++ b/e2e/typescript-config/modern-module-resolution/package.json
@@ -1,0 +1,3 @@
+{
+  "type": "commonjs"
+}

--- a/e2e/typescript-config/modern-module-resolution/tsconfig.json
+++ b/e2e/typescript-config/modern-module-resolution/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "strict": true
+  }
+}

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -119,7 +119,7 @@ async function registerTsNode(): Promise<Service> {
     return tsNode.register({
       compilerOptions: {
         module: 'CommonJS',
-        moduleResolution: 'Node',
+        moduleResolution: 'Node10',
       },
       moduleTypes: {
         '**': 'cjs',

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -119,6 +119,7 @@ async function registerTsNode(): Promise<Service> {
     return tsNode.register({
       compilerOptions: {
         module: 'CommonJS',
+        moduleResolution: 'Node',
       },
       moduleTypes: {
         '**': 'cjs',


### PR DESCRIPTION
This small change fixes an issue that makes using Jest impossible inside a TypeScript project configured with NodeNext, Node16 or Bundler moduleResolution setting **if a Jest configuration file is written in TS**.

The default behaviour of ts-node is to read the default tsconfig.json file from the project.
With a hardcoded option of "module: CommonJs" that is used to read the jest.config.ts file, the TypeScript compiler will throw an error, because the modern moduleResolution options are not compatible with
the hardcoded "CommonJs" module value.

The only way to use Jest in such a repo is to change the jest.config.ts file into a JS one (or pass the options in a different way), so that the code responsible of instantiating ts-node is not invoked.

This commit fixes the issue by providing a missing complementary option, moduleResolution: Node, which will work perfectly with module: CommonJs and will not be overridden by any project-specific value in tsconfig.json.

Closes #14740

EDIT
The PR does **not** close the issue #13350!

This means that the fix works only for `jest.config.ts` files that do not reference other files using `.js` extensions. See https://github.com/jestjs/jest/pull/14739#issuecomment-2113337770
