### PR TITLE
fix(jest-environment-jsdom): Add `structuredClone` to globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `[jest-config]` Support `testTimeout` in project config ([#14697](https://github.com/jestjs/jest/pull/14697))
 - `[jest-config]` Support `coverageReporters` in project config ([#14697](https://github.com/jestjs/jest/pull/14830))
 - `[jest-config]` Allow `reporters` in project config ([#14768](https://github.com/jestjs/jest/pull/14768))
+- `[jest-environment-jsdom]` Add `structuredClone` to globals ([#14765](https://github.com/facebook/jest/pull/14765))
 - `[@jest/expect-utils]` Fix comparison of `DataView` ([#14408](https://github.com/jestjs/jest/pull/14408))
 - `[@jest/expect-utils]` [**BREAKING**] exclude non-enumerable in object matching ([#14670](https://github.com/jestjs/jest/pull/14670))
 - `[@jest/expect-utils]` Fix comparison of `URL` ([#14672](https://github.com/jestjs/jest/pull/14672))

--- a/e2e/env-test/__tests__/env.test.js
+++ b/e2e/env-test/__tests__/env.test.js
@@ -9,3 +9,9 @@
 console.log(globalThis.window ? 'WINDOW' : 'NO WINDOW');
 
 test('stub', () => expect(1).toBe(1));
+
+test('structuredClone works in env', () => {
+  expect(typeof structuredClone).toBe('function');
+  const x = {a: 'b'};
+  expect(structuredClone(x)).not.toBe(x);
+});

--- a/packages/jest-environment-jsdom-abstract/src/index.ts
+++ b/packages/jest-environment-jsdom-abstract/src/index.ts
@@ -136,6 +136,12 @@ export default abstract class BaseJSDOMEnvironment
       }
     }
 
+    // Workaround for jsdom missing structuredClone
+    // https://github.com/jsdom/jsdom/issues/3363
+    if (typeof structuredClone === 'function') {
+      global.structuredClone = structuredClone;
+    }
+
     this.moduleMocker = new ModuleMocker(global);
 
     this.fakeTimers = new LegacyFakeTimers({


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

When using `jest-environment-jsdom` using `structuredClone` is `undefined`. This is a workaround till https://github.com/jsdom/jsdom/issues/3363 is resolved. For `jest-environment-node` a similar fix was made in #12631

## Test plan

I have added a test to `e2e/env-test/__tests__/env.test.js`.
