### PR TITLE
fix: validate CLI flags that require arguments receives them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,9 +28,9 @@
 - `[expect]` Check error instance type for `toThrow/toThrowError` ([#14576](https://github.com/jestjs/jest/pull/14576))
 - `[jest-circus]` [**BREAKING**] Prevent false test failures caused by promise rejections handled asynchronously ([#14315](https://github.com/jestjs/jest/pull/14315))
 - `[jest-circus, jest-expect, jest-snapshot]` Pass `test.failing` tests when containing failing snapshot matchers ([#14313](https://github.com/jestjs/jest/pull/14313))
-- `[jest-cli]` [**BREAKING**] Validate CLI flags that require arguments receives them ([#14783](https://github.com/facebook/jest/pull/14783))
-- `[jest-config]` Make sure to respect `runInBand` option ([#14578](https://github.com/facebook/jest/pull/14578))
-- `[jest-config]` Support `testTimeout` in project config ([#14697](https://github.com/facebook/jest/pull/14697))
+- `[jest-cli]` [**BREAKING**] Validate CLI flags that require arguments receives them ([#14783](https://github.com/jestjs/jest/pull/14783))
+- `[jest-config]` Make sure to respect `runInBand` option ([#14578](https://github.com/jestjs/jest/pull/14578))
+- `[jest-config]` Support `testTimeout` in project config ([#14697](https://github.com/jestjs/jest/pull/14697))
 - `[jest-config]` Allow `reporters` in project config ([#14768](https://github.com/jestjs/jest/pull/14768))
 - `[@jest/expect-utils]` Fix comparison of `DataView` ([#14408](https://github.com/jestjs/jest/pull/14408))
 - `[@jest/expect-utils]` [**BREAKING**] exclude non-enumerable in object matching ([#14670](https://github.com/jestjs/jest/pull/14670))
@@ -39,11 +39,11 @@
 - `[jest-leak-detector]` Make leak-detector more aggressive when running GC ([#14526](https://github.com/jestjs/jest/pull/14526))
 - `[jest-runtime]` Properly handle re-exported native modules in ESM via CJS ([#14589](https://github.com/jestjs/jest/pull/14589))
 - `[jest-util]` Make sure `isInteractive` works in a browser ([#14552](https://github.com/jestjs/jest/pull/14552))
-- `[pretty-format]` [**BREAKING**] Print `ArrayBuffer` and `DataView` correctly ([#14290](https://github.com/facebook/jest/pull/14290))
-- `[jest-cli]` When specifying paths on the command line, only match against the relative paths of the test files ([#12519](https://github.com/facebook/jest/pull/12519))
+- `[pretty-format]` [**BREAKING**] Print `ArrayBuffer` and `DataView` correctly ([#14290](https://github.com/jestjs/jest/pull/14290))
+- `[jest-cli]` When specifying paths on the command line, only match against the relative paths of the test files ([#12519](https://github.com/jestjs/jest/pull/12519))
   - [**BREAKING**] Changes `testPathPattern` configuration option to `testPathPatterns`, which now takes a list of patterns instead of the regex.
   - [**BREAKING**] `--testPathPattern` is now `--testPathPatterns`
-- `[jest-reporters, jest-runner]` Unhandled errors without stack get correctly logged to console ([#14619](https://github.com/facebook/jest/pull/14619))
+- `[jest-reporters, jest-runner]` Unhandled errors without stack get correctly logged to console ([#14619](https://github.com/jestjs/jest/pull/14619))
 
 ### Performance
 
@@ -52,14 +52,14 @@
 ### Chore & Maintenance
 
 - `[*]` [**BREAKING**] Drop support for Node.js versions 14 and 19 ([#14460](https://github.com/jestjs/jest/pull/14460))
-- `[*]` [**BREAKING**] Drop support for `typescript@4.3`, minimum version is now `5.0` ([#14542](https://github.com/facebook/jest/pull/14542))
-- `[*]` Depend on exact versions of monorepo dependencies instead of `^` range ([#14553](https://github.com/facebook/jest/pull/14553))
+- `[*]` [**BREAKING**] Drop support for `typescript@4.3`, minimum version is now `5.0` ([#14542](https://github.com/jestjs/jest/pull/14542))
+- `[*]` Depend on exact versions of monorepo dependencies instead of `^` range ([#14553](https://github.com/jestjs/jest/pull/14553))
 - `[*]` [**BREAKING**] Add ESM wrapper for all of Jest's modules ([#14661](https://github.com/jestjs/jest/pull/14661))
 - `[*]` [**BREAKING**] Upgrade to `glob@10` ([#14509](https://github.com/jestjs/jest/pull/14509))
 - `[docs]` Fix typos in `CHANGELOG.md` and `packages/jest-validate/README.md` ([#14640](https://github.com/jestjs/jest/pull/14640))
-- `[docs]` Don't use alias matchers in docs ([#14631](https://github.com/facebook/jest/pull/14631))
+- `[docs]` Don't use alias matchers in docs ([#14631](https://github.com/jestjs/jest/pull/14631))
 - `[babel-jest, babel-preset-jest]` [**BREAKING**] Increase peer dependency of `@babel/core` to `^7.11` ([#14109](https://github.com/jestjs/jest/pull/14109))
-- `[expect]` [**BREAKING**] Remove `.toBeCalled()`, `.toBeCalledTimes()`, `.toBeCalledWith()`, `.lastCalledWith()`, `.nthCalledWith()`, `.toReturn()`, `.toReturnTimes()`, `.toReturnWith()`, `.lastReturnedWith()`, `.nthReturnedWith()` and `.toThrowError()` matcher aliases ([#14632](https://github.com/facebook/jest/pull/14632))
+- `[expect]` [**BREAKING**] Remove `.toBeCalled()`, `.toBeCalledTimes()`, `.toBeCalledWith()`, `.lastCalledWith()`, `.nthCalledWith()`, `.toReturn()`, `.toReturnTimes()`, `.toReturnWith()`, `.lastReturnedWith()`, `.nthReturnedWith()` and `.toThrowError()` matcher aliases ([#14632](https://github.com/jestjs/jest/pull/14632))
 - `[jest-cli, jest-config, @jest/types]` [**BREAKING**] Remove deprecated `--init` argument ([#14490](https://github.com/jestjs/jest/pull/14490))
 - `[jest-config, @jest/core, jest-util]` Upgrade `ci-info` ([#14655](https://github.com/jestjs/jest/pull/14655))
 - `[jest-mock]` [**BREAKING**] Remove `MockFunctionMetadataType`, `MockFunctionMetadata` and `SpyInstance` types ([#14621](https://github.com/jestjs/jest/pull/14621))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 - `[expect]` Check error instance type for `toThrow/toThrowError` ([#14576](https://github.com/jestjs/jest/pull/14576))
 - `[jest-circus]` [**BREAKING**] Prevent false test failures caused by promise rejections handled asynchronously ([#14315](https://github.com/jestjs/jest/pull/14315))
 - `[jest-circus, jest-expect, jest-snapshot]` Pass `test.failing` tests when containing failing snapshot matchers ([#14313](https://github.com/jestjs/jest/pull/14313))
+- `[jest-cli]` [**BREAKING**] Validate CLI flags that require arguments receives them ([#14783](https://github.com/facebook/jest/pull/14783))
 - `[jest-config]` Make sure to respect `runInBand` option ([#14578](https://github.com/facebook/jest/pull/14578))
 - `[jest-config]` Support `testTimeout` in project config ([#14697](https://github.com/facebook/jest/pull/14697))
 - `[jest-config]` Allow `reporters` in project config ([#14768](https://github.com/jestjs/jest/pull/14768))

--- a/packages/jest-cli/src/args.ts
+++ b/packages/jest-cli/src/args.ts
@@ -253,15 +253,6 @@ export const options: {[key: string]: Options} = {
       'end of a test run. Implies `runInBand`.',
     type: 'boolean',
   },
-  env: {
-    alias: 'testEnvironment',
-    description:
-      'The test environment used for all tests. This can point to ' +
-      'any file or node module. Examples: `jsdom`, `node` or ' +
-      '`path/to/my-environment.js`',
-    requiresArg: true,
-    type: 'string',
-  },
   errorOnDeprecated: {
     description: 'Make calling deprecated APIs throw helpful error messages.',
     type: 'boolean',
@@ -619,6 +610,15 @@ export const options: {[key: string]: Options} = {
     requiresArg: true,
     string: true,
     type: 'array',
+  },
+  testEnvironment: {
+    alias: 'env',
+    description:
+      'The test environment used for all tests. This can point to ' +
+      'any file or node module. Examples: `jsdom`, `node` or ' +
+      '`path/to/my-environment.js`',
+    requiresArg: true,
+    type: 'string',
   },
   testEnvironmentOptions: {
     description:

--- a/packages/jest-cli/src/args.ts
+++ b/packages/jest-cli/src/args.ts
@@ -98,7 +98,7 @@ export function check(argv: Config.Argv): true {
 
 export const usage =
   'Usage: $0 [--config=<pathToConfigFile>] [TestPathPatterns]';
-export const docs = 'Documentation: https://jestjs.io/';
+export const docs = 'Documentation: https://jestjs.io/docs/cli';
 
 // The default values are all set in jest-config
 export const options: {[key: string]: Options} = {
@@ -129,6 +129,7 @@ export const options: {[key: string]: Options} = {
     description:
       'The directory where Jest should store its cached ' +
       ' dependency information.',
+    requiresArg: true,
     type: 'string',
   },
   changedFilesWithAncestor: {
@@ -142,7 +143,7 @@ export const options: {[key: string]: Options} = {
       'Runs tests related to the changes since the provided branch. If the ' +
       'current branch has diverged from the given branch, then only changes ' +
       'made locally will be tested. Behaves similarly to `--onlyChanged`.',
-    nargs: 1,
+    requiresArg: true,
     type: 'string',
   },
   ci: {
@@ -172,6 +173,7 @@ export const options: {[key: string]: Options} = {
     description:
       'A glob pattern relative to <rootDir> matching the files that coverage ' +
       'info needs to be collected from.',
+    requiresArg: true,
     type: 'string',
   },
   color: {
@@ -191,6 +193,7 @@ export const options: {[key: string]: Options} = {
       'and execute tests. If no rootDir is set in the config, the directory ' +
       'containing the config file is assumed to be the rootDir for the project. ' +
       'This can also be a JSON encoded value which Jest will use as configuration.',
+    requiresArg: true,
     type: 'string',
   },
   coverage: {
@@ -201,6 +204,7 @@ export const options: {[key: string]: Options} = {
   },
   coverageDirectory: {
     description: 'The directory where Jest should output its coverage files.',
+    requiresArg: true,
     type: 'string',
   },
   coveragePathIgnorePatterns: {
@@ -208,17 +212,20 @@ export const options: {[key: string]: Options} = {
       'An array of regexp pattern strings that are matched ' +
       'against all file paths before executing the test. If the file path ' +
       'matches any of the patterns, coverage information will be skipped.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
   coverageProvider: {
     choices: ['babel', 'v8'],
     description: 'Select between Babel and V8 to collect coverage',
+    requiresArg: true,
   },
   coverageReporters: {
     description:
       'A list of reporter names that Jest uses when writing ' +
       'coverage reports. Any istanbul reporter can be used.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -226,6 +233,7 @@ export const options: {[key: string]: Options} = {
     description:
       'A JSON string with which will be used to configure ' +
       'minimum threshold enforcement for coverage results',
+    requiresArg: true,
     type: 'string',
   },
   debug: {
@@ -246,10 +254,12 @@ export const options: {[key: string]: Options} = {
     type: 'boolean',
   },
   env: {
+    alias: 'testEnvironment',
     description:
       'The test environment used for all tests. This can point to ' +
       'any file or node module. Examples: `jsdom`, `node` or ' +
       '`path/to/my-environment.js`',
+    requiresArg: true,
     type: 'string',
   },
   errorOnDeprecated: {
@@ -267,6 +277,7 @@ export const options: {[key: string]: Options} = {
       'a list of tests which can be manipulated to exclude tests from ' +
       'running. Especially useful when used in conjunction with a testing ' +
       'infrastructure to filter known broken tests.',
+    requiresArg: true,
     type: 'string',
   },
   findRelatedTests: {
@@ -285,27 +296,32 @@ export const options: {[key: string]: Options} = {
   },
   globalSetup: {
     description: 'The path to a module that runs before All Tests.',
+    requiresArg: true,
     type: 'string',
   },
   globalTeardown: {
     description: 'The path to a module that runs after All Tests.',
+    requiresArg: true,
     type: 'string',
   },
   globals: {
     description:
       'A JSON string with map of global variables that need ' +
       'to be available in all test environments.',
+    requiresArg: true,
     type: 'string',
   },
   haste: {
     description:
       'A JSON string with map of variables for the haste module system',
+    requiresArg: true,
     type: 'string',
   },
   ignoreProjects: {
     description:
       'Ignore the tests of the specified projects. ' +
       'Jest uses the attribute `displayName` in the configuration to identify each project.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -343,6 +359,7 @@ export const options: {[key: string]: Options} = {
     description:
       'Specifies the maximum number of tests that are allowed to run ' +
       'concurrently. This only affects tests using `test.concurrent`.',
+    requiresArg: true,
     type: 'number',
   },
   maxWorkers: {
@@ -352,12 +369,14 @@ export const options: {[key: string]: Options} = {
       'will spawn for running tests. This defaults to the number of the ' +
       'cores available on your machine. (its usually best not to override ' +
       'this default)',
+    requiresArg: true,
     type: 'string',
   },
   moduleDirectories: {
     description:
       'An array of directory names to be searched recursively ' +
       "up from the requiring module's location.",
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -366,6 +385,7 @@ export const options: {[key: string]: Options} = {
       'An array of file extensions your modules use. If you ' +
       'require modules without specifying a file extension, these are the ' +
       'extensions Jest will look for.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -374,6 +394,7 @@ export const options: {[key: string]: Options} = {
       'A JSON string with a map from regular expressions to ' +
       'module names or to arrays of module names that allow to stub ' +
       'out resources, like images or styles with a single module',
+    requiresArg: true,
     type: 'string',
   },
   modulePathIgnorePatterns: {
@@ -381,6 +402,7 @@ export const options: {[key: string]: Options} = {
       'An array of regexp pattern strings that are matched ' +
       'against all module paths before those paths are to be considered ' +
       '"visible" to the module loader.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -389,6 +411,7 @@ export const options: {[key: string]: Options} = {
       'An alternative API to setting the NODE_PATH env variable, ' +
       'modulePaths is an array of absolute paths to additional locations to ' +
       'search when resolving modules.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -401,8 +424,16 @@ export const options: {[key: string]: Options} = {
     type: 'boolean',
   },
   notifyMode: {
+    choices: [
+      'always',
+      'failure',
+      'success',
+      'change',
+      'success-change',
+      'failure-change',
+    ],
     description: 'Specifies when notifications will appear for test results.',
-    type: 'string',
+    requiresArg: true,
   },
   onlyChanged: {
     alias: 'o',
@@ -421,12 +452,14 @@ export const options: {[key: string]: Options} = {
     description:
       'Print a warning about probable open handles if Jest does not exit ' +
       'cleanly after this number of milliseconds. `0` to disable.',
+    requiresArg: true,
     type: 'number',
   },
   outputFile: {
     description:
       'Write test results to a file when the --json option is ' +
       'also specified.',
+    requiresArg: true,
     type: 'string',
   },
   passWithNoTests: {
@@ -436,16 +469,19 @@ export const options: {[key: string]: Options} = {
   },
   preset: {
     description: "A preset that is used as a base for Jest's configuration.",
+    requiresArg: true,
     type: 'string',
   },
   prettierPath: {
     description: 'The path to the "prettier" module used for inline snapshots.',
+    requiresArg: true,
     type: 'string',
   },
   projects: {
     description:
       'A list of projects that use Jest to run all tests of all ' +
       'projects in a single instance of Jest.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -456,6 +492,7 @@ export const options: {[key: string]: Options} = {
   },
   reporters: {
     description: 'A list of custom reporters for the test suite.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -473,6 +510,7 @@ export const options: {[key: string]: Options} = {
   },
   resolver: {
     description: 'A JSON string which allows the use of a custom resolver.',
+    requiresArg: true,
     type: 'string',
   },
   restoreMocks: {
@@ -485,12 +523,14 @@ export const options: {[key: string]: Options} = {
     description:
       'The root directory that Jest should scan for tests and ' +
       'modules within.',
+    requiresArg: true,
     type: 'string',
   },
   roots: {
     description:
       'A list of paths to directories that Jest should use to ' +
       'search for files in.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -513,17 +553,20 @@ export const options: {[key: string]: Options} = {
   runner: {
     description:
       "Allows to use a custom runner instead of Jest's default test runner.",
+    requiresArg: true,
     type: 'string',
   },
   seed: {
     description:
       'Sets a seed value that can be retrieved in a tests file via `jest.getSeed()`. If this option is not specified Jest will randomly generate the value. The seed value must be between `-0x80000000` and `0x7fffffff` inclusive.',
+    requiresArg: true,
     type: 'number',
   },
   selectProjects: {
     description:
       'Run the tests of the specified projects. ' +
       'Jest uses the attribute `displayName` in the configuration to identify each project.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -531,6 +574,7 @@ export const options: {[key: string]: Options} = {
     description:
       'A list of paths to modules that run some code to configure or ' +
       'set up the testing environment before each test.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -538,6 +582,7 @@ export const options: {[key: string]: Options} = {
     description:
       'A list of paths to modules that run some code to configure or ' +
       'set up the testing framework before each test',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -545,6 +590,7 @@ export const options: {[key: string]: Options} = {
     description:
       'Shard tests and execute only the selected shard, specify in ' +
       'the form "current/all". 1-based, for example "3/5".',
+    requiresArg: true,
     type: 'string',
   },
   showConfig: {
@@ -570,21 +616,20 @@ export const options: {[key: string]: Options} = {
     description:
       'A list of paths to snapshot serializer modules Jest should ' +
       'use for snapshot testing.',
+    requiresArg: true,
     string: true,
     type: 'array',
-  },
-  testEnvironment: {
-    description: 'Alias for --env',
-    type: 'string',
   },
   testEnvironmentOptions: {
     description:
       'A JSON string with options that will be passed to the `testEnvironment`. ' +
       'The relevant options depend on the environment.',
+    requiresArg: true,
     type: 'string',
   },
   testFailureExitCode: {
     description: 'Exit code of `jest` command if the test run failed',
+    requiresArg: true,
     type: 'string', // number
   },
   testLocationInResults: {
@@ -593,12 +638,14 @@ export const options: {[key: string]: Options} = {
   },
   testMatch: {
     description: 'The glob patterns Jest uses to detect test files.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
   testNamePattern: {
     alias: 't',
     description: 'Run only tests with a name that matches the regex pattern.',
+    requiresArg: true,
     type: 'string',
   },
   testPathIgnorePatterns: {
@@ -606,6 +653,7 @@ export const options: {[key: string]: Options} = {
       'An array of regexp pattern strings that are matched ' +
       'against all test paths before executing the test. If the test path ' +
       'matches any of the patterns, it will be skipped.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -613,12 +661,14 @@ export const options: {[key: string]: Options} = {
     description:
       'A regexp pattern string that is matched against all tests ' +
       'paths before executing the test.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
   testRegex: {
     description:
       'A string or array of string regexp patterns that Jest uses to detect test files.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -627,6 +677,7 @@ export const options: {[key: string]: Options} = {
       'Allows the use of a custom results processor. ' +
       'This processor must be a node module that exports ' +
       'a function expecting as the first argument the result object.',
+    requiresArg: true,
     type: 'string',
   },
   testRunner: {
@@ -634,6 +685,7 @@ export const options: {[key: string]: Options} = {
       'Allows to specify a custom test runner. The default is' +
       ' `jest-circus/runner`. A path to a custom test runner can be provided:' +
       ' `<rootDir>/path/to/testRunner.js`.',
+    requiresArg: true,
     type: 'string',
   },
   testSequencer: {
@@ -641,22 +693,26 @@ export const options: {[key: string]: Options} = {
       'Allows to specify a custom test sequencer. The default is ' +
       '`@jest/test-sequencer`. A path to a custom test sequencer can be ' +
       'provided: `<rootDir>/path/to/testSequencer.js`',
+    requiresArg: true,
     type: 'string',
   },
   testTimeout: {
     description: 'This option sets the default timeouts of test cases.',
+    requiresArg: true,
     type: 'number',
   },
   transform: {
     description:
       'A JSON string which maps from regular expressions to paths ' +
       'to transformers.',
+    requiresArg: true,
     type: 'string',
   },
   transformIgnorePatterns: {
     description:
       'An array of regexp pattern strings that are matched ' +
       'against all source file paths before transformation.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -665,6 +721,7 @@ export const options: {[key: string]: Options} = {
       'An array of regexp pattern strings that are matched ' +
       'against all modules before the module loader will automatically ' +
       'return a mock for them.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },
@@ -711,6 +768,7 @@ export const options: {[key: string]: Options} = {
       'An array of regexp pattern strings that are matched ' +
       'against all paths before trigger test re-run in watch mode. ' +
       'If the test path matches any of the patterns, it will be skipped.',
+    requiresArg: true,
     string: true,
     type: 'array',
   },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I noticed `jest --shard` without an argument didn't fail, so added that.

Also removed the explicit `env` flag and added it as an alias to `testEnvironment` instead.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
