### PR TITLE
chore: migrate few more type tests to TSTyche

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -365,7 +365,7 @@ module.exports = {
         'website/**',
         '**/__benchmarks__/**',
         '**/__tests__/**',
-        'packages/jest-types/**/*',
+        '**/__typetests__/**',
         '.eslintplugin/**',
       ],
       rules: {

--- a/jest.config.ts.mjs
+++ b/jest.config.ts.mjs
@@ -29,6 +29,9 @@ export default {
       runner: 'jest-runner-tsd',
       testMatch: [
         '**/__typetests__/**/*.test.ts',
+        '!**/packages/expect-utils/__typetests__/*.test.ts',
+        '!**/packages/jest/__typetests__/*.test.ts',
+        '!**/packages/jest-cli/__typetests__/*.test.ts',
         '!**/packages/jest-types/__typetests__/config.test.ts',
       ],
     },

--- a/packages/expect-utils/__typetests__/utils.test.ts
+++ b/packages/expect-utils/__typetests__/utils.test.ts
@@ -5,34 +5,32 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {expectType} from 'tsd-lite';
+import {expect, test} from 'tstyche';
 import {isA} from '@jest/expect-utils';
 
-// isA
+test('isA', () => {
+  expect(isA('String', 'default')).type.toBeBoolean();
+  expect(isA<number>('Number', 123)).type.toBeBoolean();
 
-expectType<boolean>(isA('String', 'default'));
-expectType<boolean>(isA<number>('Number', 123));
+  const sample = {} as unknown;
 
-const sample = {} as unknown;
+  if (isA('String', sample)) {
+    expect(sample).type.toBeUnknown();
+  }
 
-expectType<unknown>(sample);
+  if (isA<string>('String', sample)) {
+    expect(sample).type.toBeString();
+  }
 
-if (isA('String', sample)) {
-  expectType<unknown>(sample);
-}
+  if (isA<number>('Number', sample)) {
+    expect(sample).type.toBeNumber();
+  }
 
-if (isA<string>('String', sample)) {
-  expectType<string>(sample);
-}
+  if (isA<Map<unknown, unknown>>('Map', sample)) {
+    expect(sample).type.toEqual<Map<unknown, unknown>>();
+  }
 
-if (isA<number>('Number', sample)) {
-  expectType<number>(sample);
-}
-
-if (isA<Map<unknown, unknown>>('Map', sample)) {
-  expectType<Map<unknown, unknown>>(sample);
-}
-
-if (isA<Set<unknown>>('Set', sample)) {
-  expectType<Set<unknown>>(sample);
-}
+  if (isA<Set<unknown>>('Set', sample)) {
+    expect(sample).type.toEqual<Set<unknown>>();
+  }
+});

--- a/packages/expect-utils/package.json
+++ b/packages/expect-utils/package.json
@@ -22,10 +22,8 @@
     "jest-get-type": "workspace:*"
   },
   "devDependencies": {
-    "@tsd/typescript": "^5.0.4",
     "immutable": "^4.0.0",
-    "jest-matcher-utils": "workspace:*",
-    "tsd-lite": "^0.8.0"
+    "jest-matcher-utils": "workspace:*"
   },
   "engines": {
     "node": "^16.10.0 || ^18.12.0 || >=20.0.0"

--- a/packages/jest-cli/__typetests__/jest-cli.test.ts
+++ b/packages/jest-cli/__typetests__/jest-cli.test.ts
@@ -3,11 +3,12 @@
  *
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
- *
  */
 
-import {expectType} from 'tsd-lite';
+import {expect, test} from 'tstyche';
 import type {Options} from 'yargs';
 import {yargsOptions} from 'jest-cli';
 
-expectType<{[key: string]: Options}>(yargsOptions);
+test('yargsOptions', () => {
+  expect(yargsOptions).type.toEqual<{[key: string]: Options}>();
+});

--- a/packages/jest-cli/package.json
+++ b/packages/jest-cli/package.json
@@ -27,10 +27,8 @@
     "yargs": "^17.3.1"
   },
   "devDependencies": {
-    "@tsd/typescript": "^5.0.4",
     "@types/exit": "^0.1.30",
-    "@types/yargs": "^17.0.8",
-    "tsd-lite": "^0.8.0"
+    "@types/yargs": "^17.0.8"
   },
   "peerDependencies": {
     "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"

--- a/packages/jest/__typetests__/jest.test.ts
+++ b/packages/jest/__typetests__/jest.test.ts
@@ -5,10 +5,13 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {expectType} from 'tsd-lite';
-import type {Config as ConfigTypes} from '@jest/types';
+import {describe, expect, test} from 'tstyche';
 import type {Config} from 'jest';
 
-declare const config: Config;
+describe('Config', () => {
+  test('is a reexport of the `InitialOptions`', () => {
+    type InitialOptions = import('@jest/types').Config.InitialOptions;
 
-expectType<ConfigTypes.InitialOptions>(config);
+    expect<Config>().type.toEqual<InitialOptions>();
+  });
+});

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -20,10 +20,6 @@
     "import-local": "^3.0.2",
     "jest-cli": "workspace:*"
   },
-  "devDependencies": {
-    "@tsd/typescript": "^5.0.4",
-    "tsd-lite": "^0.8.0"
-  },
   "peerDependencies": {
     "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
   },

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -1,3 +1,8 @@
 {
-  "testFileMatch": ["**/packages/jest-types/__typetests__/config.test.ts"]
+  "testFileMatch": [
+    "**/packages/expect-utils/__typetests__/*.test.ts",
+    "**/packages/jest/__typetests__/*.test.ts",
+    "**/packages/jest-cli/__typetests__/*.test.ts",
+    "**/packages/jest-types/__typetests__/config.test.ts"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2955,11 +2955,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jest/expect-utils@workspace:packages/expect-utils"
   dependencies:
-    "@tsd/typescript": ^5.0.4
     immutable: ^4.0.0
     jest-get-type: "workspace:*"
     jest-matcher-utils: "workspace:*"
-    tsd-lite: ^0.8.0
   languageName: unknown
   linkType: soft
 
@@ -12869,7 +12867,6 @@ __metadata:
     "@jest/core": "workspace:*"
     "@jest/test-result": "workspace:*"
     "@jest/types": "workspace:*"
-    "@tsd/typescript": ^5.0.4
     "@types/exit": ^0.1.30
     "@types/yargs": ^17.0.8
     chalk: ^4.0.0
@@ -12878,7 +12875,6 @@ __metadata:
     jest-config: "workspace:*"
     jest-util: "workspace:*"
     jest-validate: "workspace:*"
-    tsd-lite: ^0.8.0
     yargs: ^17.3.1
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -13595,10 +13591,8 @@ __metadata:
   dependencies:
     "@jest/core": "workspace:*"
     "@jest/types": "workspace:*"
-    "@tsd/typescript": ^5.0.4
     import-local: ^3.0.2
     jest-cli: "workspace:*"
-    tsd-lite: ^0.8.0
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:


### PR DESCRIPTION
Following up #14687

## Summary

Migrating few smaller type test files to TSTyche.

## Test plan

Type tests should pass in CI.
