### PR TITLE
docs: fetch is not a type and a default import

### DIFF
--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -620,7 +620,7 @@ The `jest.Mocked<Source>` utility type returns the `Source` type wrapped with ty
 
 ```ts
 import {expect, jest, test} from '@jest/globals';
-import type {fetch} from 'node-fetch';
+import {fetch} from 'node-fetch';
 
 jest.mock('node-fetch');
 

--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -620,7 +620,7 @@ The `jest.Mocked<Source>` utility type returns the `Source` type wrapped with ty
 
 ```ts
 import {expect, jest, test} from '@jest/globals';
-import {fetch} from 'node-fetch';
+import fetch from 'node-fetch';
 
 jest.mock('node-fetch');
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

`fetch` is not a type and a default import. (see https://www.npmjs.com/package/node-fetch)

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
