### PR TITLE
chore: user `Object.fromEntries` over `reduce`

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -698,7 +698,6 @@ module.exports = {
     // TODO: turn on at some point
     'unicorn/error-message': 'off',
     'unicorn/no-object-as-default-parameter': 'off',
-    'unicorn/prefer-object-from-entries': 'off',
     'unicorn/prefer-string-replace-all': 'off',
 
     // enabling this is blocked by https://github.com/microsoft/rushstack/issues/2780

--- a/packages/jest-each/src/table/template.ts
+++ b/packages/jest-each/src/table/template.ts
@@ -10,7 +10,6 @@ import type {Global} from '@jest/types';
 import type {EachTests} from '../bind';
 import {
   type Headings,
-  type Template,
   type Templates,
   interpolateVariables,
 } from './interpolation';
@@ -41,8 +40,5 @@ const convertTableToTemplates = (
   headings: Headings,
 ): Templates =>
   table.map(row =>
-    row.reduce<Template>(
-      (acc, value, index) => Object.assign(acc, {[headings[index]]: value}),
-      {},
-    ),
+    Object.fromEntries(row.map((value, index) => [headings[index], value])),
   );

--- a/scripts/buildUtils.mjs
+++ b/scripts/buildUtils.mjs
@@ -79,10 +79,11 @@ function getPackages() {
                 },
         /* eslint-enable */
         './package.json': './package.json',
-        ...Object.values(pkg.bin || {}).reduce(
-          (mem, curr) =>
-            Object.assign(mem, {[curr.replace(/\.js$/, '')]: curr}),
-          {},
+        ...Object.fromEntries(
+          Object.values(pkg.bin || {}).map(curr => [
+            curr.replace(/\.js$/, ''),
+            curr,
+          ]),
         ),
         ...(pkg.name === 'jest-circus'
           ? {'./runner': './build/runner.js'}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-object-from-entries.md

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
