### PR TITLE
fix: only check for watchman existence once per process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 ### Performance
 
 - `[*]` [**BREAKING**] Bundle all of Jest's modules into `index.js` ([#12348](https://github.com/jestjs/jest/pull/12348), [#14550](https://github.com/jestjs/jest/pull/14550) & [#14661](https://github.com/jestjs/jest/pull/14661))
+- `[*]` [jest-haste-map] Only spawn one process to check for `watchman` installation ([#14826](https://github.com/jestjs/jest/pull/14826))
 
 ### Chore & Maintenance
 

--- a/packages/jest-core/src/getChangedFilesPromise.ts
+++ b/packages/jest-core/src/getChangedFilesPromise.ts
@@ -18,16 +18,10 @@ export default function getChangedFilesPromise(
   configs: Array<Config.ProjectConfig>,
 ): ChangedFilesPromise | undefined {
   if (globalConfig.onlyChanged) {
-    const allRootsForAllProjects = configs.reduce<Array<string>>(
-      (roots, config) => {
-        if (config.roots) {
-          roots.push(...config.roots);
-        }
-        return roots;
-      },
-      [],
+    const allRootsForAllProjects = new Set(
+      configs.flatMap(config => config.roots || []),
     );
-    return getChangedFilesForRoots(allRootsForAllProjects, {
+    return getChangedFilesForRoots([...allRootsForAllProjects], {
       changedSince: globalConfig.changedSince,
       lastCommit: globalConfig.lastCommit,
       withAncestor: globalConfig.changedFilesWithAncestor,

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -113,7 +113,7 @@ type Watcher = {
 
 type HasteWorker = typeof import('./worker');
 
-const isWatchmanInstalledPromise = isWatchmanInstalled();
+let isWatchmanInstalledPromise: Promise<boolean> | undefined;
 
 export const ModuleMap = HasteModuleMap as {
   create: (rootPath: string) => IModuleMap;
@@ -1108,6 +1108,9 @@ class HasteMap extends EventEmitter implements IHasteMap {
   private async _shouldUseWatchman(): Promise<boolean> {
     if (!this._options.useWatchman) {
       return false;
+    }
+    if (!isWatchmanInstalledPromise) {
+      isWatchmanInstalledPromise = isWatchmanInstalled();
     }
     return isWatchmanInstalledPromise;
   }

--- a/packages/jest-haste-map/src/index.ts
+++ b/packages/jest-haste-map/src/index.ts
@@ -113,6 +113,8 @@ type Watcher = {
 
 type HasteWorker = typeof import('./worker');
 
+const isWatchmanInstalledPromise = isWatchmanInstalled();
+
 export const ModuleMap = HasteModuleMap as {
   create: (rootPath: string) => IModuleMap;
 };
@@ -216,7 +218,6 @@ class HasteMap extends EventEmitter implements IHasteMap {
   private _cachePath = '';
   private _changeInterval?: ReturnType<typeof setInterval>;
   private readonly _console: Console;
-  private _isWatchmanInstalledPromise: Promise<boolean> | null = null;
   private readonly _options: InternalOptions;
   private _watchers: Array<Watcher> = [];
   private _worker: JestWorkerFarm<HasteWorker> | HasteWorker | null = null;
@@ -1108,10 +1109,7 @@ class HasteMap extends EventEmitter implements IHasteMap {
     if (!this._options.useWatchman) {
       return false;
     }
-    if (!this._isWatchmanInstalledPromise) {
-      this._isWatchmanInstalledPromise = isWatchmanInstalled();
-    }
-    return this._isWatchmanInstalledPromise;
+    return isWatchmanInstalledPromise;
   }
 
   private _createEmptyMap(): InternalHasteMap {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

While looking at #14818, I noticed that we spawned a check for `watchman` for every single project as well.

before:
<img width="690" alt="image" src="https://github.com/jestjs/jest/assets/1404810/63cf566c-305d-475d-81c5-595e62b193c0">

After:

<img width="339" alt="image" src="https://github.com/jestjs/jest/assets/1404810/3460ece1-1c55-49e9-9f46-1a2a9b1007d0">

~440ms to ~8ms in this extreme example

The call to `watchman` itself is still about 14ms of course, but it happens outside of the `build` calls. This means that if you install watchman _while_ Jest is running, that won't be picked up. But I think that's perfectly fine.

---

We should try to fix the `createWatcher` call as well

<img width="446" alt="image" src="https://github.com/jestjs/jest/assets/1404810/c2673908-89fa-40d9-b18f-64b820c529fd">

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
