### PR TITLE
fix: allow templating of null and undefined in a jest each key path template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - `[jest-config]` Support `testTimeout` in project config ([#14697](https://github.com/jestjs/jest/pull/14697))
 - `[jest-config]` Support `coverageReporters` in project config ([#14697](https://github.com/jestjs/jest/pull/14830))
 - `[jest-config]` Allow `reporters` in project config ([#14768](https://github.com/jestjs/jest/pull/14768))
+- `[jest-each]` Allow `$keypath` templates with null or undefined values ([]())
 - `[@jest/expect-utils]` Fix comparison of `DataView` ([#14408](https://github.com/jestjs/jest/pull/14408))
 - `[@jest/expect-utils]` [**BREAKING**] exclude non-enumerable in object matching ([#14670](https://github.com/jestjs/jest/pull/14670))
 - `[@jest/expect-utils]` Fix comparison of `URL` ([#14672](https://github.com/jestjs/jest/pull/14672))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - `[jest-config]` Support `testTimeout` in project config ([#14697](https://github.com/jestjs/jest/pull/14697))
 - `[jest-config]` Support `coverageReporters` in project config ([#14697](https://github.com/jestjs/jest/pull/14830))
 - `[jest-config]` Allow `reporters` in project config ([#14768](https://github.com/jestjs/jest/pull/14768))
-- `[jest-each]` Allow `$keypath` templates with null or undefined values ([#14831](https://github.com/jestjs/jest/pull/14831))
+- `[jest-each]` Allow `$keypath` templates with `null` or `undefined` values ([#14831](https://github.com/jestjs/jest/pull/14831))
 - `[@jest/expect-utils]` Fix comparison of `DataView` ([#14408](https://github.com/jestjs/jest/pull/14408))
 - `[@jest/expect-utils]` [**BREAKING**] exclude non-enumerable in object matching ([#14670](https://github.com/jestjs/jest/pull/14670))
 - `[@jest/expect-utils]` Fix comparison of `URL` ([#14672](https://github.com/jestjs/jest/pull/14672))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - `[jest-config]` Support `testTimeout` in project config ([#14697](https://github.com/jestjs/jest/pull/14697))
 - `[jest-config]` Support `coverageReporters` in project config ([#14697](https://github.com/jestjs/jest/pull/14830))
 - `[jest-config]` Allow `reporters` in project config ([#14768](https://github.com/jestjs/jest/pull/14768))
-- `[jest-each]` Allow `$keypath` templates with null or undefined values ([]())
+- `[jest-each]` Allow `$keypath` templates with null or undefined values ([#14831](https://github.com/jestjs/jest/pull/14831))
 - `[@jest/expect-utils]` Fix comparison of `DataView` ([#14408](https://github.com/jestjs/jest/pull/14408))
 - `[@jest/expect-utils]` [**BREAKING**] exclude non-enumerable in object matching ([#14670](https://github.com/jestjs/jest/pull/14670))
 - `[@jest/expect-utils]` Fix comparison of `URL` ([#14672](https://github.com/jestjs/jest/pull/14672))

--- a/e2e/__tests__/__snapshots__/each.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/each.test.ts.snap
@@ -1,5 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`allows nullable or undefined args when templating object each args 1`] = `
+"PASS __tests__/eachTemplate.test.js
+  ✓ allows templating "value"
+  ✓ allows templating "null"
+  ✓ allows templating "undefined"
+  ✓ allows templating "1"
+  ✓ allows templating "null"
+  ✓ allows templating "undefined""
+`;
+
 exports[`formats args with pretty format when given %p 1`] = `
 "PASS __tests__/pretty.test.js
   array

--- a/e2e/__tests__/each.test.ts
+++ b/e2e/__tests__/each.test.ts
@@ -60,3 +60,10 @@ test('formats args with pretty format when given %p', () => {
   expect(rest).toMatchSnapshot();
   expect(result.exitCode).toBe(0);
 });
+
+test('allows nullable or undefined args when templating object each args', () => {
+  const result = runJest(dir, ['eachTemplate.test.js']);
+  const {rest} = extractSummary(result.stderr);
+  expect(rest).toMatchSnapshot();
+  expect(result.exitCode).toBe(0);
+});

--- a/e2e/each/__tests__/eachTemplate.test.js
+++ b/e2e/each/__tests__/eachTemplate.test.js
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 it.each([
   {something: {nested: 'value'}},
   {something: null},

--- a/e2e/each/__tests__/eachTemplate.test.js
+++ b/e2e/each/__tests__/eachTemplate.test.js
@@ -1,0 +1,14 @@
+it.each([
+  {something: {nested: 'value'}},
+  {something: null},
+  {something: undefined},
+])('allows templating "$something.nested"', value => {
+  expect(value).toBe(value);
+});
+
+it.each([{array: ['some value']}, {array: null}, {array: undefined}])(
+  'allows templating "$array.length"',
+  value => {
+    expect(value).toBe(value);
+  },
+);

--- a/packages/jest-each/src/__tests__/template.test.ts
+++ b/packages/jest-each/src/__tests__/template.test.ts
@@ -417,6 +417,30 @@ describe('jest-each', () => {
         );
       });
 
+      test.each([null, undefined])(
+        'calls global with title containing $key.path for %s',
+        value => {
+          const globalTestMocks = getGlobalTestMocks();
+          const eachObject = each.withGlobal(globalTestMocks)`
+          a
+          ${{foo: value}}
+        `;
+          const testFunction = get(eachObject, keyPath);
+          testFunction(
+            'interpolates object keyPath to value: $a.foo.bar',
+            noop,
+          );
+
+          const globalMock = get(globalTestMocks, keyPath);
+          expect(globalMock).toHaveBeenCalledTimes(1);
+          expect(globalMock).toHaveBeenCalledWith(
+            `interpolates object keyPath to value: ${value}`,
+            expectFunction,
+            undefined,
+          );
+        },
+      );
+
       test('calls global with title containing last seen object when $key.path is invalid', () => {
         const globalTestMocks = getGlobalTestMocks();
         const eachObject = each.withGlobal(globalTestMocks)`

--- a/packages/jest-each/src/table/interpolation.ts
+++ b/packages/jest-each/src/table/interpolation.ts
@@ -71,6 +71,8 @@ export function getPath(
   template: Template,
   [head, ...tail]: Array<string>,
 ): unknown {
+  if (template === null) return 'null';
+  if (template === undefined) return 'undefined';
   if (!head || !Object.prototype.hasOwnProperty.call(template, head))
     return template;
   return getPath(template[head] as Template, tail);


### PR DESCRIPTION
## Summary

See newly added e2e tests, currently jest crashed with:

```
 ● allows templating "$array.length"

    Cannot convert undefined or null to object

       7 | });
```

 when adding a nested keypath as a template in a null or undefined object. Instead we just early-exit out of interplation in those cases.

## Test plan

* `yarn test` `yarn constraints` 
