### PR TITLE
Docs: Update .toHaveBeenCalled() documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 - `[jest-transform]` Upgrade `write-file-atomic` ([#14274](https://github.com/jestjs/jest/pull/14274))
 - `[jest-util]` Upgrade `picomatch` to v3 ([#14653](https://github.com/jestjs/jest/pull/14653))
 - `[docs] Append to NODE_OPTIONS, not overwrite ([#14730](https://github.com/jestjs/jest/pull/14730))`
-- `[docs]` Corrected `.toHaveBeenCalled()` description ([#14842](https://github.com/jestjs/jest/pull/14842))`
+- `[docs]` Corrected `.toHaveBeenCalled()` naming and description([#14842](https://github.com/jestjs/jest/pull/14842))
 
 ## 29.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,7 @@
 - `[jest-transform]` Upgrade `write-file-atomic` ([#14274](https://github.com/jestjs/jest/pull/14274))
 - `[jest-util]` Upgrade `picomatch` to v3 ([#14653](https://github.com/jestjs/jest/pull/14653))
 - `[docs] Append to NODE_OPTIONS, not overwrite ([#14730](https://github.com/jestjs/jest/pull/14730))`
-- `[docs]` Corrected `.toHaveBeenCalled()` naming and description([#14842](https://github.com/jestjs/jest/pull/14842))
+- `[docs]` Updated `.toHaveBeenCalled()` documentation to correctly reflect its functionality ([#14842](https://github.com/jestjs/jest/pull/14842))
 
 ## 29.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@
 - `[jest-transform]` Upgrade `write-file-atomic` ([#14274](https://github.com/jestjs/jest/pull/14274))
 - `[jest-util]` Upgrade `picomatch` to v3 ([#14653](https://github.com/jestjs/jest/pull/14653))
 - `[docs] Append to NODE_OPTIONS, not overwrite ([#14730](https://github.com/jestjs/jest/pull/14730))`
+- `[docs]` Corrected `.toHaveBeenCalled()` description ([#14842](https://github.com/jestjs/jest/pull/14842))`
 
 ## 29.7.0
 

--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -144,7 +144,7 @@ Although the `.toBe` matcher **checks** referential identity, it **reports** a d
 
 ### `.toHaveBeenCalled()`
 
-Use `.toHaveBeenCalledWith` to ensure that a mock function was called with specific arguments. The arguments are checked with the same algorithm that `.toEqual` uses.
+Use `.toHaveBeenCalled` to ensure that a mock function was called.
 
 For example, let's say you have a `drinkAll(drink, flavour)` function that takes a `drink` function and applies it to all available beverages. You might want to check that `drink` gets called for `'lemon'`, but not for `'octopus'`, because `'octopus'` flavour is really weird and why would anything be octopus-flavoured? You can do that with this test suite:
 

--- a/website/versioned_docs/version-29.4/ExpectAPI.md
+++ b/website/versioned_docs/version-29.4/ExpectAPI.md
@@ -146,7 +146,7 @@ Although the `.toBe` matcher **checks** referential identity, it **reports** a d
 
 Also under the alias: `.toBeCalled()`
 
-Use `.toHaveBeenCalledWith` to ensure that a mock function was called with specific arguments. The arguments are checked with the same algorithm that `.toEqual` uses.
+Use `.toHaveBeenCalled` to ensure that a mock function was called.
 
 For example, let's say you have a `drinkAll(drink, flavour)` function that takes a `drink` function and applies it to all available beverages. You might want to check that `drink` gets called for `'lemon'`, but not for `'octopus'`, because `'octopus'` flavour is really weird and why would anything be octopus-flavoured? You can do that with this test suite:
 

--- a/website/versioned_docs/version-29.5/ExpectAPI.md
+++ b/website/versioned_docs/version-29.5/ExpectAPI.md
@@ -146,7 +146,7 @@ Although the `.toBe` matcher **checks** referential identity, it **reports** a d
 
 Also under the alias: `.toBeCalled()`
 
-Use `.toHaveBeenCalledWith` to ensure that a mock function was called with specific arguments. The arguments are checked with the same algorithm that `.toEqual` uses.
+Use `.toHaveBeenCalled` to ensure that a mock function was called.
 
 For example, let's say you have a `drinkAll(drink, flavour)` function that takes a `drink` function and applies it to all available beverages. You might want to check that `drink` gets called for `'lemon'`, but not for `'octopus'`, because `'octopus'` flavour is really weird and why would anything be octopus-flavoured? You can do that with this test suite:
 

--- a/website/versioned_docs/version-29.6/ExpectAPI.md
+++ b/website/versioned_docs/version-29.6/ExpectAPI.md
@@ -146,7 +146,7 @@ Although the `.toBe` matcher **checks** referential identity, it **reports** a d
 
 Also under the alias: `.toBeCalled()`
 
-Use `.toHaveBeenCalledWith` to ensure that a mock function was called with specific arguments. The arguments are checked with the same algorithm that `.toEqual` uses.
+Use `.toHaveBeenCalled` to ensure that a mock function was called.
 
 For example, let's say you have a `drinkAll(drink, flavour)` function that takes a `drink` function and applies it to all available beverages. You might want to check that `drink` gets called for `'lemon'`, but not for `'octopus'`, because `'octopus'` flavour is really weird and why would anything be octopus-flavoured? You can do that with this test suite:
 

--- a/website/versioned_docs/version-29.7/ExpectAPI.md
+++ b/website/versioned_docs/version-29.7/ExpectAPI.md
@@ -146,7 +146,7 @@ Although the `.toBe` matcher **checks** referential identity, it **reports** a d
 
 Also under the alias: `.toBeCalled()`
 
-Use `.toHaveBeenCalledWith` to ensure that a mock function was called with specific arguments. The arguments are checked with the same algorithm that `.toEqual` uses.
+Use `.toHaveBeenCalled` to ensure that a mock function was called.
 
 For example, let's say you have a `drinkAll(drink, flavour)` function that takes a `drink` function and applies it to all available beverages. You might want to check that `drink` gets called for `'lemon'`, but not for `'octopus'`, because `'octopus'` flavour is really weird and why would anything be octopus-flavoured? You can do that with this test suite:
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This change concerns issue #14842, where [.toHaveBeenCalled()](https://jestjs.io/docs/expect#tohavebeencalled) and [.toHaveBeenCalledWith()](https://jestjs.io/docs/expect#tohavebeencalledwitharg1-arg2-) have duplicate descriptions despite serving two different functionalities. I made this change because [.toHaveBeenCalled()](https://jestjs.io/docs/expect#tohavebeencalled) refers to an example where there are no function parameters, and therefore should be updated accordingly because it was not called with specific arguments. Therefore, I took out the argument explanations and simply revised the description to correctly reflect `.toHaveBeenCalled`'s functionality. 

I additionally updated the descriptions for all versioned docs which concern this documentation issue. 

Fixes #14842

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

By updating the documentation, I then ran it on the documentation website node server to make sure changes were updated accordingly. Jest documentation versions 29.7, 29.6, 29.5, and 29.4 were changed. 

Documentation on the server now showing corrected values. 

![image](https://github.com/jestjs/jest/assets/66581240/854b97ab-d238-4f3b-a263-8f974d7fa159)
![image](https://github.com/jestjs/jest/assets/66581240/f715562d-1652-463e-bc28-26986486a34b)
![image](https://github.com/jestjs/jest/assets/66581240/a96a012b-afce-4fc6-a7cb-697ecdd6d49c)
![image](https://github.com/jestjs/jest/assets/66581240/4902b648-e39c-4eaa-9dbf-a20bcdc318dd)





