### PR TITLE
chore: bump Node.js `nightly` version

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: 21-nightly
+          node-version: 22-nightly
           cache: yarn
       - name: install
         run: yarn --immutable
@@ -55,7 +55,7 @@ jobs:
       - name: Use Node.js LTS
         uses: actions/setup-node@v4
         with:
-          node-version: 21-nightly
+          node-version: 22-nightly
           cache: yarn
       - name: install
         run: yarn --immutable


### PR DESCRIPTION
## Summary

I was setting up my first nightly workflow today and was looking with one eye at the setup here in Jest's repo.

Just wondering: can it be that the last nightly release in 21 series was `v21.0.0-nightly20231024...` and the following ones are in 22 series already? See the list: https://nodejs.org/download/nightly

## Test plan

~~Green CI.~~ Hm.. It does not run in CI.
