### PR TITLE
[jest-circus] Omit `expect.hasAssertions()` errors if a test already has errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[expect]` Check error instance type for `toThrow/toThrowError` ([#14576](https://github.com/jestjs/jest/pull/14576))
 - `[jest-circus]` [**BREAKING**] Prevent false test failures caused by promise rejections handled asynchronously ([#14315](https://github.com/jestjs/jest/pull/14315))
 - `[jest-circus]` Replace recursive `makeTestResults` implementation with iterative one ([#14760](https://github.com/jestjs/jest/pull/14760))
+- `[jest-circus]` Omit `expect.hasAssertions()` errors if a test already has errors ([#14866](https://github.com/jestjs/jest/pull/14866))
 - `[jest-circus, jest-expect, jest-snapshot]` Pass `test.failing` tests when containing failing snapshot matchers ([#14313](https://github.com/jestjs/jest/pull/14313))
 - `[jest-cli]` [**BREAKING**] Validate CLI flags that require arguments receives them ([#14783](https://github.com/jestjs/jest/pull/14783))
 - `[jest-config]` Make sure to respect `runInBand` option ([#14578](https://github.com/jestjs/jest/pull/14578))

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/jestAdapterInit.test.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/jestAdapterInit.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {beforeEach, it} from '@jest/globals';
+import type {Circus} from '@jest/types';
+import {eventHandler} from '../jestAdapterInit';
+
+beforeEach(() => expect.hasAssertions());
+
+it("pushes a hasAssertion() error if there's no assertions/errors", () => {
+  const event: Circus.Event = {
+    name: 'test_done',
+    test: {errors: []} as unknown as Circus.TestEntry,
+  };
+  const beforeLength = event.test.errors.length;
+
+  eventHandler(event);
+
+  expect(event.test.errors).toHaveLength(beforeLength + 1);
+  expect(event.test.errors).toEqual([
+    expect.getState().isExpectingAssertionsError,
+  ]);
+});
+
+it("omits hasAssertion() errors if there's already an error", () => {
+  const errors = [new Error('ruh roh'), new Error('not good')];
+  const event: Circus.Event = {
+    name: 'test_done',
+    test: {errors} as unknown as Circus.TestEntry,
+  };
+  const beforeLength = event.test.errors.length;
+
+  eventHandler(event);
+
+  expect(event.test.errors).toHaveLength(beforeLength);
+  expect(event.test.errors).not.toContain(
+    expect.getState().isExpectingAssertionsError,
+  );
+
+  // Ensure test state is not accidentally leaked by e.g. not calling extractExpectedAssertionsErrors() at all.
+  expect(expect.getState().isExpectingAssertions).toBe(false);
+});

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/tsconfig.json
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "extends": "../../../../../tsconfig.test.json",
+  "include": ["./**/*"],
+  "references": [{"path": "../../../"}]
+}

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -254,7 +254,8 @@ const handleSnapshotStateAfterRetry =
     }
   };
 
-const eventHandler = async (event: Circus.Event) => {
+// Exported for direct access from unit tests.
+export const eventHandler = async (event: Circus.Event): Promise<void> => {
   switch (event.name) {
     case 'test_start': {
       jestExpect.setState({
@@ -273,9 +274,13 @@ const eventHandler = async (event: Circus.Event) => {
 };
 
 const _addExpectedAssertionErrors = (test: Circus.TestEntry) => {
+  const {isExpectingAssertions} = jestExpect.getState();
   const failures = jestExpect.extractExpectedAssertionsErrors();
-  const errors = failures.map(failure => failure.error);
-  test.errors = [...test.errors, ...errors];
+  if (isExpectingAssertions && test.errors.length > 0) {
+    // Only show errors from `expect.hasAssertions()` when no other failure has happened.
+    return;
+  }
+  test.errors.push(...failures.map(failure => failure.error));
 };
 
 // Get suppressed errors from ``jest-matchers`` that weren't throw during
@@ -285,6 +290,6 @@ const _addSuppressedErrors = (test: Circus.TestEntry) => {
   const {suppressedErrors} = jestExpect.getState();
   jestExpect.setState({suppressedErrors: []});
   if (suppressedErrors.length > 0) {
-    test.errors = [...test.errors, ...suppressedErrors];
+    test.errors.push(...suppressedErrors);
   }
 };


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Addresses https://github.com/jestjs/jest/issues/14084

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

When using `expect.hasAssertions()`, if an `it()` block throws early, you see both an error for the thrown thing **and** an error about not having called `expect()`.  While this is technically correct, it's a bit spammy, IMO.  The test is already gonna fail.

## Example

Test:
```ts
beforeEach(() => expect.hasAssertions());

it('is correct', () => {
  expect(1).toBe(1);
});

it('is wrong', () => {});

it('is spammy', () => {
  throw new Error('throwing'); // imagine this may vary on whether it throws in reality
  expect(1).toBe(1);
});

```

Before:
```
 FAIL  frontend/example/__tests__/example.test.ts
  ✓ is correct (4 ms)
  ✕ is wrong (1 ms)
  ✕ is spammy (2 ms)

  ● is wrong

    expect.hasAssertions()

    Expected at least one assertion to be called but received none.

    > 1 | beforeEach(() => expect.hasAssertions());
        |                         ^
      2 |
      3 | it('is correct', () => {
      4 |   expect(1).toBe(1);

      at Object.hasAssertions (frontend/example/__tests__/example.test.ts:1:25)

  ● is spammy

    throwing

       8 |
       9 | it('is spammy', () => {
    > 10 |   throw new Error('throwing'); // imagine this may vary on whether it throws in reality
         |         ^
      11 |   expect(1).toBe(1);
      12 | });
      13 |

      at Object.<anonymous> (frontend/example/__tests__/example.test.ts:10:9)

  ● is spammy

    expect.hasAssertions()

    Expected at least one assertion to be called but received none.

    > 1 | beforeEach(() => expect.hasAssertions());
        |                         ^
      2 |
      3 | it('is correct', () => {
      4 |   expect(1).toBe(1);

      at Object.hasAssertions (frontend/example/__tests__/example.test.ts:1:25)

Test Suites: 1 failed, 1 total
Tests:       2 failed, 1 passed, 3 total
Snapshots:   0 total
Time:        1.392 s
Ran all test suites matching /frontend\/example\/__tests__\/example.test.ts/i.
```

After:
```
 FAIL  frontend/example/__tests__/example.test.ts
  ✓ is correct (4 ms)
  ✕ is wrong (2 ms)
  ✕ is spammy (2 ms)

  ● is wrong

    expect.hasAssertions()

    Expected at least one assertion to be called but received none.

    > 1 | beforeEach(() => expect.hasAssertions());
        |                         ^
      2 |
      3 | it('is correct', () => {
      4 |   expect(1).toBe(1);

      at Object.hasAssertions (frontend/example/__tests__/example.test.ts:1:25)

  ● is spammy

    throwing

       8 |
       9 | it('is spammy', () => {
    > 10 |   throw new Error('throwing'); // imagine this may vary on whether it throws in reality
         |         ^
      11 |   expect(1).toBe(1);
      12 | });
      13 |

      at Object.<anonymous> (frontend/example/__tests__/example.test.ts:10:9)

Test Suites: 1 failed, 1 total
Tests:       2 failed, 1 passed, 3 total
Snapshots:   0 total
Time:        1.4 s, estimated 2 s
Ran all test suites matching /frontend\/example\/__tests__\/example.test.ts/i.
```

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I didn't see much that's _directly_ exercising this code at the moment so I created a new test.