### PR TITLE
fix: not addressing to Sets and Maps as object without keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@
 - `[@jest/expect-utils]` Fix comparison of `URL` ([#14672](https://github.com/jestjs/jest/pull/14672))
 - `[@jest/expect-utils]` Check `Symbol` properties in equality ([#14688](https://github.com/jestjs/jest/pull/14688))
 - `[@jest/expect-utils]` Catch circular references within arrays when matching objects ([#14894](https://github.com/jestjs/jest/pull/14894))
+- `[@jest/expect-utils]` Fix not addressing to Sets and Maps as objects without keys ([#14873](https://github.com/jestjs/jest/pull/14873))
 - `[jest-leak-detector]` Make leak-detector more aggressive when running GC ([#14526](https://github.com/jestjs/jest/pull/14526))
 - `[jest-runtime]` Properly handle re-exported native modules in ESM via CJS ([#14589](https://github.com/jestjs/jest/pull/14589))
 - `[jest-util]` Make sure `isInteractive` works in a browser ([#14552](https://github.com/jestjs/jest/pull/14552))

--- a/packages/expect-utils/src/__tests__/utils.test.ts
+++ b/packages/expect-utils/src/__tests__/utils.test.ts
@@ -401,6 +401,37 @@ describe('subsetEquality()', () => {
       });
     });
   });
+
+  describe('subset is not object with keys', () => {
+    test('returns true if subset has keys', () => {
+      expect(subsetEquality({foo: 'bar'}, {foo: 'bar'})).toBe(true);
+    });
+    test('returns true if subset has Symbols', () => {
+      const symbol = Symbol('foo');
+      expect(subsetEquality({[symbol]: 'bar'}, {[symbol]: 'bar'})).toBe(true);
+    });
+    test('returns undefined if subset has no keys', () => {
+      expect(subsetEquality('foo', 'bar')).toBeUndefined();
+    });
+    test('returns undefined if subset is null', () => {
+      expect(subsetEquality({foo: 'bar'}, null)).toBeUndefined();
+    });
+    test('returns undefined if subset is Error', () => {
+      expect(subsetEquality({foo: 'bar'}, new Error())).toBeUndefined();
+    });
+    test('returns undefined if subset is Array', () => {
+      expect(subsetEquality({foo: 'bar'}, [])).toBeUndefined();
+    });
+    test('returns undefined if subset is Date', () => {
+      expect(subsetEquality({foo: 'bar'}, new Date())).toBeUndefined();
+    });
+    test('returns undefined if subset is Set', () => {
+      expect(subsetEquality({foo: 'bar'}, new Set())).toBeUndefined();
+    });
+    test('returns undefined if subset is Map', () => {
+      expect(subsetEquality({foo: 'bar'}, new Map())).toBeUndefined();
+    });
+  });
 });
 
 describe('iterableEquality', () => {

--- a/packages/expect-utils/src/utils.ts
+++ b/packages/expect-utils/src/utils.ts
@@ -336,7 +336,9 @@ const isObjectWithKeys = (a: any) =>
   isObject(a) &&
   !(a instanceof Error) &&
   !Array.isArray(a) &&
-  !(a instanceof Date);
+  !(a instanceof Date) &&
+  !(a instanceof Set) &&
+  !(a instanceof Map);
 
 export const subsetEquality = (
   object: unknown,


### PR DESCRIPTION
## Summary

Fixes https://github.com/jestjs/jest/issues/14599
The problem is that comparing list of nulls with Set or list of Sets:
```
expect([null]).toMatchObject([new Set()]);
expect([null]).toMatchObject(new Set());
```
In both cases the comparison does not throw an exception.

---
Update: 
Same issue is happening with Map instead of set, I have fixed it too
```
expect([null]).toMatchObject([new Map()]);
expect([null]).toMatchObject(new Map());
```

## Test plan

Unit tests added
Both cases described in the Summery have been tested locally with the fix and reproduced without the fix
