### PR TITLE
chore: migrate `jest-mock` type tests to TSTyche

### DIFF
--- a/jest.config.ts.mjs
+++ b/jest.config.ts.mjs
@@ -32,6 +32,7 @@ export default {
         '!**/packages/expect-utils/__typetests__/*.test.ts',
         '!**/packages/jest/__typetests__/*.test.ts',
         '!**/packages/jest-cli/__typetests__/*.test.ts',
+        '!**/packages/jest-mock/__typetests__/*.test.ts',
         '!**/packages/jest-types/__typetests__/config.test.ts',
       ],
     },

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "strip-json-comments": "^3.1.1",
     "tempy": "^1.0.0",
     "ts-node": "^10.5.0",
-    "tstyche": "^1.0.0-rc.1",
+    "tstyche": "^1.0.0-rc.2",
     "typescript": "^5.0.4",
     "webpack": "^5.68.0",
     "webpack-node-externals": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "strip-json-comments": "^3.1.1",
     "tempy": "^1.0.0",
     "ts-node": "^10.5.0",
-    "tstyche": "^1.0.0-beta.9",
+    "tstyche": "^1.0.0-rc.1",
     "typescript": "^5.0.4",
     "webpack": "^5.68.0",
     "webpack-node-externals": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "strip-json-comments": "^3.1.1",
     "tempy": "^1.0.0",
     "ts-node": "^10.5.0",
-    "tstyche": "^1.0.0-rc.2",
+    "tstyche": "^1.0.0",
     "typescript": "^5.0.4",
     "webpack": "^5.68.0",
     "webpack-node-externals": "^3.0.0",

--- a/packages/jest-mock/__typetests__/ModuleMocker.test.ts
+++ b/packages/jest-mock/__typetests__/ModuleMocker.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {expectType} from 'tsd-lite';
+import {expect, test} from 'tstyche';
 import {type MockMetadata, type Mocked, ModuleMocker} from 'jest-mock';
 
 class ExampleClass {
@@ -45,31 +45,37 @@ const exampleModule = {
 
 const moduleMocker = new ModuleMocker(globalThis);
 
-// getMetadata
-
 const exampleMetadata = moduleMocker.getMetadata(exampleModule);
 
-expectType<MockMetadata<typeof exampleModule> | null>(exampleMetadata);
+test('getMetadata', () => {
+  expect(exampleMetadata).type.toEqual<MockMetadata<
+    typeof exampleModule
+  > | null>();
+});
 
-// generateFromMetadata
+test('generateFromMetadata', () => {
+  const exampleMock = moduleMocker.generateFromMetadata(exampleMetadata!);
 
-const exampleMock = moduleMocker.generateFromMetadata(exampleMetadata!);
+  expect(exampleMock).type.toEqual<Mocked<typeof exampleModule>>();
 
-expectType<Mocked<typeof exampleModule>>(exampleMock);
+  expect(exampleMock.methodA.mock.calls).type.toEqual<
+    Array<[a: number, b: number]>
+  >();
+  expect(exampleMock.methodB.mock.calls).type.toEqual<
+    Array<[a: number, b: number]>
+  >();
 
-expectType<Array<[a: number, b: number]>>(exampleMock.methodA.mock.calls);
-expectType<Array<[a: number, b: number]>>(exampleMock.methodB.mock.calls);
+  expect(exampleMock.instance.memberA).type.toEqual<Array<number>>();
+  expect(exampleMock.instance.memberB.mock.calls).type.toEqual<Array<[]>>();
 
-expectType<Array<number>>(exampleMock.instance.memberA);
-expectType<Array<[]>>(exampleMock.instance.memberB.mock.calls);
+  expect(exampleMock.propertyA.one).type.toBeString();
+  expect(exampleMock.propertyA.two.mock.calls).type.toEqual<Array<[]>>();
+  expect(exampleMock.propertyA.three.nine).type.toBeNumber();
+  expect(exampleMock.propertyA.three.ten).type.toEqual<Array<number>>();
 
-expectType<string>(exampleMock.propertyA.one);
-expectType<Array<[]>>(exampleMock.propertyA.two.mock.calls);
-expectType<number>(exampleMock.propertyA.three.nine);
-expectType<Array<number>>(exampleMock.propertyA.three.ten);
-
-expectType<Array<number>>(exampleMock.propertyB);
-expectType<number>(exampleMock.propertyC);
-expectType<string>(exampleMock.propertyD);
-expectType<boolean>(exampleMock.propertyE);
-expectType<symbol>(exampleMock.propertyF);
+  expect(exampleMock.propertyB).type.toEqual<Array<number>>();
+  expect(exampleMock.propertyC).type.toBeNumber();
+  expect(exampleMock.propertyD).type.toBeString();
+  expect(exampleMock.propertyE).type.toBeBoolean();
+  expect(exampleMock.propertyF).type.toBeSymbol();
+});

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -7,12 +7,7 @@
 
 /// <reference lib="dom" />
 
-import {
-  expectAssignable,
-  expectError,
-  expectNotAssignable,
-  expectType,
-} from 'tsd-lite';
+import {describe, expect, test} from 'tstyche';
 import {
   type Mock,
   type Replaced,
@@ -25,545 +20,665 @@ import {
   spyOn,
 } from 'jest-mock';
 
-// jest.fn()
-
-expectType<Mock<() => Promise<string>>>(
-  fn(async () => 'value')
-    .mockClear()
-    .mockReset()
-    .mockImplementation(fn(async () => 'value'))
-    .mockImplementationOnce(fn(async () => 'value'))
-    .mockName('mock')
-    .mockResolvedValue('value')
-    .mockResolvedValueOnce('value')
-    .mockRejectedValue('error')
-    .mockRejectedValueOnce('error')
-    .mockReturnThis()
-    .mockReturnValue(Promise.resolve('value'))
-    .mockReturnValueOnce(Promise.resolve('value')),
-);
-
-expectType<Mock<() => string>>(
-  fn(() => 'value')
-    .mockClear()
-    .mockReset()
-    .mockImplementation(() => 'value')
-    .mockImplementationOnce(() => 'value')
-    .mockName('mock')
-    .mockReturnThis()
-    .mockReturnValue('value')
-    .mockReturnValueOnce('value'),
-);
-
-expectError(fn(() => 'value').mockReturnValue(Promise.resolve('value')));
-expectError(fn(() => 'value').mockReturnValueOnce(Promise.resolve('value')));
-
-expectError(fn(() => 'value').mockResolvedValue('value'));
-expectError(fn(() => 'value').mockResolvedValueOnce('value'));
-
-expectError(fn(() => 'value').mockRejectedValue('error'));
-expectError(fn(() => 'value').mockRejectedValueOnce('error'));
-
-expectAssignable<Function>(fn()); // eslint-disable-line @typescript-eslint/ban-types
-
-expectType<Mock<(...args: Array<unknown>) => unknown>>(fn());
-expectType<Mock<() => void>>(fn(() => {}));
-expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
-  fn((a: string, b?: number) => true),
-);
-expectType<Mock<(e: any) => never>>(
-  fn((e: any) => {
-    throw new Error();
-  }),
-);
-expectError(fn('moduleName'));
-
-declare const mockFnImpl: (this: Date, a: string, b?: number) => boolean;
-const mockFn = fn(mockFnImpl);
-const mockAsyncFn = fn(async (p: boolean) => 'value');
-
-expectType<boolean>(mockFn('one', 2));
-expectType<Promise<string>>(mockAsyncFn(false));
-expectError(mockFn());
-expectError(mockAsyncFn());
-
-const MockObject = fn((credentials: string) => ({
-  connect() {
-    return fn();
-  },
-  disconnect() {
-    return;
-  },
-}));
-
-expectType<{
-  connect(): Mock<(...args: Array<unknown>) => unknown>;
-  disconnect(): void;
-}>(new MockObject('credentials'));
-expectError(new MockObject());
-
-expectType<((a: string, b?: number | undefined) => boolean) | undefined>(
-  mockFn.getMockImplementation(),
-);
-expectError(mockFn.getMockImplementation('some-mock'));
-
-expectType<string>(mockFn.getMockName());
-expectError(mockFn.getMockName('some-mock'));
-
-expectType<number>(mockFn.mock.calls.length);
-
-expectType<string>(mockFn.mock.calls[0][0]);
-expectType<number | undefined>(mockFn.mock.calls[0][1]);
-
-expectType<string>(mockFn.mock.calls[1][0]);
-expectType<number | undefined>(mockFn.mock.calls[1][1]);
-
-expectType<[a: string, b?: number | undefined] | undefined>(
-  mockFn.mock.lastCall,
-);
-
-expectType<Array<number>>(mockFn.mock.invocationCallOrder);
-
-expectType<
-  Array<{
-    connect(): Mock<(...args: Array<unknown>) => unknown>;
-    disconnect(): void;
-  }>
->(MockObject.mock.instances);
-
-const returnValue = mockFn.mock.results[0];
-
-expectType<'incomplete' | 'return' | 'throw'>(returnValue.type);
-expectType<unknown>(returnValue.value);
-
-if (returnValue.type === 'incomplete') {
-  expectType<undefined>(returnValue.value);
-}
-
-if (returnValue.type === 'return') {
-  expectType<boolean>(returnValue.value);
-}
-
-if (returnValue.type === 'throw') {
-  expectType<unknown>(returnValue.value);
-}
-
-expectType<Array<Date>>(mockFn.mock.contexts);
-
-expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
-  mockFn.mockClear(),
-);
-expectError(mockFn.mockClear('some-mock'));
-
-expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
-  mockFn.mockReset(),
-);
-expectError(mockFn.mockClear('some-mock'));
-
-expectType<void>(mockFn.mockRestore());
-expectError(mockFn.mockClear('some-mock'));
-
-expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
-  mockFn.mockImplementation((a, b) => {
-    expectType<string>(a);
-    expectType<number | undefined>(b);
-    return false;
-  }),
-);
-expectError(mockFn.mockImplementation((a: number) => false));
-expectError(mockFn.mockImplementation(a => 'false'));
-expectError(mockFn.mockImplementation());
-
-expectType<Mock<(p: boolean) => Promise<string>>>(
-  mockAsyncFn.mockImplementation(async a => {
-    expectType<boolean>(a);
-    return 'mock value';
-  }),
-);
-expectError(mockAsyncFn.mockImplementation(a => 'mock value'));
-
-expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
-  mockFn.mockImplementationOnce((a, b) => {
-    expectType<string>(a);
-    expectType<number | undefined>(b);
-    return false;
-  }),
-);
-expectError(mockFn.mockImplementationOnce((a: number) => false));
-expectError(mockFn.mockImplementationOnce(a => 'false'));
-expectError(mockFn.mockImplementationOnce());
-
-expectType<Mock<(p: boolean) => Promise<string>>>(
-  mockAsyncFn.mockImplementationOnce(async a => {
-    expectType<boolean>(a);
-    return 'mock value';
-  }),
-);
-expectError(mockAsyncFn.mockImplementationOnce(a => 'mock value'));
-
-expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
-  mockFn.mockName('mockedFunction'),
-);
-expectError(mockFn.mockName(123));
-expectError(mockFn.mockName());
-
-expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
-  mockFn.mockReturnThis(),
-);
-expectError(mockFn.mockReturnThis('this'));
-
-expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
-  mockFn.mockReturnValue(false),
-);
-expectError(mockFn.mockReturnValue('true'));
-expectError(mockFn.mockReturnValue());
-
-expectType<Mock<(p: boolean) => Promise<string>>>(
-  mockAsyncFn.mockReturnValue(Promise.resolve('mock value')),
-);
-expectError(mockAsyncFn.mockReturnValue(Promise.resolve(true)));
-
-expectType<Mock<(a: string, b?: number | undefined) => boolean>>(
-  mockFn.mockReturnValueOnce(false),
-);
-expectError(mockFn.mockReturnValueOnce('true'));
-expectError(mockFn.mockReturnValueOnce());
-
-expectType<Mock<(p: boolean) => Promise<string>>>(
-  mockAsyncFn.mockReturnValueOnce(Promise.resolve('mock value')),
-);
-expectError(mockAsyncFn.mockReturnValueOnce(Promise.resolve(true)));
-
-expectType<Mock<() => Promise<string>>>(
-  fn(() => Promise.resolve('')).mockResolvedValue('Mock value'),
-);
-expectError(fn(() => Promise.resolve('')).mockResolvedValue(123));
-expectError(fn(() => Promise.resolve('')).mockResolvedValue());
-
-expectType<Mock<() => Promise<string>>>(
-  fn(() => Promise.resolve('')).mockResolvedValueOnce('Mock value'),
-);
-expectError(fn(() => Promise.resolve('')).mockResolvedValueOnce(123));
-expectError(fn(() => Promise.resolve('')).mockResolvedValueOnce());
-
-expectType<Mock<() => Promise<string>>>(
-  fn(() => Promise.resolve('')).mockRejectedValue(new Error('Mock error')),
-);
-expectType<Mock<() => Promise<string>>>(
-  fn(() => Promise.resolve('')).mockRejectedValue('Mock error'),
-);
-expectError(fn(() => Promise.resolve('')).mockRejectedValue());
-
-expectType<Mock<() => Promise<string>>>(
-  fn(() => Promise.resolve('')).mockRejectedValueOnce(new Error('Mock error')),
-);
-expectType<Mock<() => Promise<string>>>(
-  fn(() => Promise.resolve('')).mockRejectedValueOnce('Mock error'),
-);
-expectError(fn(() => Promise.resolve('')).mockRejectedValueOnce());
-
-expectType<void>(mockFn.withImplementation(mockFnImpl, () => {}));
-expectType<Promise<void>>(
-  mockFn.withImplementation(mockFnImpl, async () => {}),
-);
-
-expectError(mockFn.withImplementation(mockFnImpl));
-
-// jest.spyOn()
-
-const spiedArray = ['a', 'b'];
-
-const spiedFunction = () => {};
-
-const spiedObject = {
-  _propertyB: false,
-
-  methodA() {
-    return true;
-  },
-  methodB(a: string, b: number) {
-    return;
-  },
-  methodC(e: any) {
-    throw new Error();
-  },
-
-  propertyA: 'abc',
-
-  set propertyB(value) {
-    this._propertyB = value;
-  },
-  get propertyB() {
-    return this._propertyB;
-  },
-};
-
-type IndexSpiedObject = {
-  [key: string]: Record<string, any>;
-
-  methodA(): boolean;
-  methodB(a: string, b: number): void;
-  methodC: (c: number) => boolean;
-  methodE: (e: any) => never;
-
-  propertyA: {a: string};
-};
-
-const indexSpiedObject: IndexSpiedObject = {
-  methodA() {
-    return true;
-  },
-  methodB(a: string, b: number) {
-    return;
-  },
-  methodC(c: number) {
-    return true;
-  },
-  methodE(e: any) {
-    throw new Error();
-  },
-
-  propertyA: {a: 'abc'},
-};
-
-const spy = spyOn(spiedObject, 'methodA');
-
-expectNotAssignable<Function>(spy); // eslint-disable-line @typescript-eslint/ban-types
-expectError(spy());
-expectError(new spy());
-
-expectType<SpiedFunction<typeof spiedObject.methodA>>(
-  spyOn(spiedObject, 'methodA'),
-);
-expectType<SpiedFunction<typeof spiedObject.methodB>>(
-  spyOn(spiedObject, 'methodB'),
-);
-expectType<SpiedFunction<typeof spiedObject.methodC>>(
-  spyOn(spiedObject, 'methodC'),
-);
-
-expectType<SpiedGetter<typeof spiedObject.propertyB>>(
-  spyOn(spiedObject, 'propertyB', 'get'),
-);
-expectType<SpiedSetter<typeof spiedObject.propertyB>>(
-  spyOn(spiedObject, 'propertyB', 'set'),
-);
-expectError(spyOn(spiedObject, 'propertyB'));
-expectError(spyOn(spiedObject, 'methodB', 'get'));
-expectError(spyOn(spiedObject, 'methodB', 'set'));
-
-expectType<SpiedGetter<typeof spiedObject.propertyA>>(
-  spyOn(spiedObject, 'propertyA', 'get'),
-);
-expectType<SpiedSetter<typeof spiedObject.propertyA>>(
-  spyOn(spiedObject, 'propertyA', 'set'),
-);
-expectError(spyOn(spiedObject, 'propertyA'));
-
-expectError(spyOn(spiedObject, 'notThere'));
-expectError(spyOn('abc', 'methodA'));
-expectError(spyOn(123, 'methodA'));
-expectError(spyOn(true, 'methodA'));
-expectError(spyOn(spiedObject));
-expectError(spyOn());
-
-expectType<SpiedFunction<typeof Array.isArray>>(
-  spyOn(spiedArray as unknown as ArrayConstructor, 'isArray'),
-);
-expectError(spyOn(spiedArray, 'isArray'));
-
-expectType<SpiedFunction<typeof spiedFunction.toString>>(
-  spyOn(spiedFunction as unknown as Function, 'toString'), // eslint-disable-line @typescript-eslint/ban-types
-);
-expectError(spyOn(spiedFunction, 'toString'));
-
-expectType<SpiedClass<typeof Date>>(spyOn(globalThis, 'Date'));
-expectType<SpiedFunction<typeof Date.now>>(spyOn(Date, 'now'));
-
-// object with index signatures
-
-expectType<SpiedFunction<typeof indexSpiedObject.methodA>>(
-  spyOn(indexSpiedObject, 'methodA'),
-);
-expectType<SpiedFunction<typeof indexSpiedObject.methodB>>(
-  spyOn(indexSpiedObject, 'methodB'),
-);
-expectType<SpiedFunction<typeof indexSpiedObject.methodC>>(
-  spyOn(indexSpiedObject, 'methodC'),
-);
-expectType<SpiedFunction<typeof indexSpiedObject.methodE>>(
-  spyOn(indexSpiedObject, 'methodE'),
-);
-
-expectType<SpiedGetter<typeof indexSpiedObject.propertyA>>(
-  spyOn(indexSpiedObject, 'propertyA', 'get'),
-);
-expectType<SpiedSetter<typeof indexSpiedObject.propertyA>>(
-  spyOn(indexSpiedObject, 'propertyA', 'set'),
-);
-expectError(spyOn(indexSpiedObject, 'propertyA'));
-
-expectError(spyOn(indexSpiedObject, 'notThere'));
-
-// interface with optional properties
-
-class SomeClass {
-  constructor(one: string, two?: boolean) {}
-
-  methodA() {
-    return true;
+describe('jest.fn()', () => {
+  const mockFnImpl: (this: Date, a: string, b?: number) => boolean = (a, b) =>
+    true;
+
+  const mockFn = fn(mockFnImpl);
+  const mockAsyncFn = fn(async (p: boolean) => 'value');
+
+  const MockObject = fn((credentials: string) => ({
+    connect() {
+      return fn();
+    },
+    disconnect() {
+      return;
+    },
+  }));
+
+  test('when sync function is provided, returned object can be chained', () => {
+    expect(
+      fn(() => 'value')
+        .mockClear()
+        .mockReset()
+        .mockImplementation(() => 'value')
+        .mockImplementationOnce(() => 'value')
+        .mockName('mock')
+        .mockReturnThis()
+        .mockReturnValue('value')
+        .mockReturnValueOnce('value'),
+    ).type.toEqual<Mock<() => string>>();
+
+    expect(
+      fn(() => 'value').mockReturnValue(Promise.resolve('value')),
+    ).type.toRaiseError();
+    expect(
+      fn(() => 'value').mockReturnValueOnce(Promise.resolve('value')),
+    ).type.toRaiseError();
+  });
+
+  test('when async function is provided, returned object can be chained', () => {
+    expect(
+      fn(async () => 'value')
+        .mockClear()
+        .mockReset()
+        .mockImplementation(fn(async () => 'value'))
+        .mockImplementationOnce(fn(async () => 'value'))
+        .mockName('mock')
+        .mockResolvedValue('value')
+        .mockResolvedValueOnce('value')
+        .mockRejectedValue('error')
+        .mockRejectedValueOnce('error')
+        .mockReturnThis()
+        .mockReturnValue(Promise.resolve('value'))
+        .mockReturnValueOnce(Promise.resolve('value')),
+    ).type.toEqual<Mock<() => Promise<string>>>();
+
+    expect(fn(() => 'value').mockResolvedValue('value')).type.toRaiseError();
+    expect(
+      fn(() => 'value').mockResolvedValueOnce('value'),
+    ).type.toRaiseError();
+
+    expect(fn(() => 'value').mockRejectedValue('error')).type.toRaiseError();
+    expect(
+      fn(() => 'value').mockRejectedValueOnce('error'),
+    ).type.toRaiseError();
+  });
+
+  test('models typings of mocked function', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    expect(fn()).type.toMatch<Function>();
+
+    expect(fn()).type.toEqual<Mock<(...args: Array<unknown>) => unknown>>();
+    expect(fn(() => {})).type.toEqual<Mock<() => void>>();
+    expect(fn((a: string, b?: number) => true)).type.toEqual<
+      Mock<(a: string, b?: number | undefined) => boolean>
+    >();
+    expect(
+      fn((e: any) => {
+        throw new Error();
+      }),
+    ).type.toEqual<Mock<(e: any) => never>>();
+
+    expect(fn('moduleName')).type.toRaiseError();
+  });
+
+  test('infers argument and return types of mocked function', () => {
+    expect(mockFn('one', 2)).type.toBeBoolean();
+    expect(mockAsyncFn(false)).type.toEqual<Promise<string>>();
+
+    expect(mockFn()).type.toRaiseError();
+    expect(mockAsyncFn()).type.toRaiseError();
+  });
+
+  test('infers argument and return types of mocked object', () => {
+    expect(new MockObject('credentials')).type.toEqual<{
+      connect(): Mock<(...args: Array<unknown>) => unknown>;
+      disconnect(): void;
+    }>();
+
+    expect(new MockObject()).type.toRaiseError();
+  });
+
+  test('.getMockImplementation()', () => {
+    expect(mockFn.getMockImplementation()).type.toEqual<
+      ((a: string, b?: number | undefined) => boolean) | undefined
+    >();
+
+    expect(mockFn.getMockImplementation('some-mock')).type.toRaiseError();
+  });
+
+  test('.getMockName()', () => {
+    expect(mockFn.getMockName()).type.toBeString();
+
+    expect(mockFn.getMockName('some-mock')).type.toRaiseError();
+  });
+
+  test('.mock', () => {
+    expect(mockFn.mock.calls.length).type.toBeNumber();
+
+    expect(mockFn.mock.calls[0][0]).type.toBeString();
+    expect(mockFn.mock.calls[0][1]).type.toEqual<number | undefined>();
+
+    expect(mockFn.mock.calls[1][0]).type.toBeString();
+    expect(mockFn.mock.calls[1][1]).type.toEqual<number | undefined>();
+
+    expect(mockFn.mock.contexts).type.toEqual<Array<Date>>();
+
+    expect(mockFn.mock.lastCall).type.toEqual<
+      [a: string, b?: number | undefined] | undefined
+    >();
+
+    expect(mockFn.mock.invocationCallOrder).type.toEqual<Array<number>>();
+
+    expect(MockObject.mock.instances).type.toEqual<
+      Array<{
+        connect(): Mock<(...args: Array<unknown>) => unknown>;
+        disconnect(): void;
+      }>
+    >();
+
+    const returnValue = mockFn.mock.results[0];
+
+    expect(returnValue.type).type.toEqual<'incomplete' | 'return' | 'throw'>();
+    expect(returnValue.value).type.toBeUnknown();
+
+    if (returnValue.type === 'incomplete') {
+      expect(returnValue.value).type.toBeUndefined();
+    }
+
+    if (returnValue.type === 'return') {
+      expect(returnValue.value).type.toBeBoolean();
+    }
+
+    if (returnValue.type === 'throw') {
+      expect(returnValue.value).type.toBeUnknown();
+    }
+  });
+
+  test('.mockClear()', () => {
+    expect(mockFn.mockClear()).type.toEqual<
+      Mock<(a: string, b?: number | undefined) => boolean>
+    >();
+
+    expect(mockFn.mockClear('some-mock')).type.toRaiseError();
+  });
+
+  test('.mockReset()', () => {
+    expect(mockFn.mockReset()).type.toEqual<
+      Mock<(a: string, b?: number | undefined) => boolean>
+    >();
+
+    expect(mockFn.mockReset('some-mock')).type.toRaiseError();
+  });
+
+  test('.mockRestore()', () => {
+    expect(mockFn.mockRestore()).type.toBeVoid();
+
+    expect(mockFn.mockRestore('some-mock')).type.toRaiseError();
+  });
+
+  test('.mockImplementation()', () => {
+    expect(
+      mockFn.mockImplementation((a, b) => {
+        expect(a).type.toBeString();
+        expect(b).type.toEqual<number | undefined>();
+        return false;
+      }),
+    ).type.toEqual<Mock<(a: string, b?: number | undefined) => boolean>>();
+
+    expect(mockFn.mockImplementation((a: number) => false)).type.toRaiseError();
+    expect(mockFn.mockImplementation(a => 'false')).type.toRaiseError();
+    expect(mockFn.mockImplementation()).type.toRaiseError();
+
+    expect(
+      mockAsyncFn.mockImplementation(async a => {
+        expect(a).type.toBeBoolean();
+        return 'mock value';
+      }),
+    ).type.toEqual<Mock<(p: boolean) => Promise<string>>>();
+
+    expect(
+      mockAsyncFn.mockImplementation(a => 'mock value'),
+    ).type.toRaiseError();
+  });
+
+  test('.mockImplementationOnce()', () => {
+    expect(
+      mockFn.mockImplementationOnce((a, b) => {
+        expect(a).type.toBeString();
+        expect(b).type.toEqual<number | undefined>();
+        return false;
+      }),
+    ).type.toEqual<Mock<(a: string, b?: number | undefined) => boolean>>();
+
+    expect(
+      mockFn.mockImplementationOnce((a: number) => false),
+    ).type.toRaiseError();
+    expect(mockFn.mockImplementationOnce(a => 'false')).type.toRaiseError();
+    expect(mockFn.mockImplementationOnce()).type.toRaiseError();
+
+    expect(
+      mockAsyncFn.mockImplementationOnce(async a => {
+        expect(a).type.toBeBoolean();
+        return 'mock value';
+      }),
+    ).type.toEqual<Mock<(p: boolean) => Promise<string>>>();
+    expect(
+      mockAsyncFn.mockImplementationOnce(a => 'mock value'),
+    ).type.toRaiseError();
+  });
+
+  test('.mockName()', () => {
+    expect(mockFn.mockName('mockedFunction')).type.toEqual<
+      Mock<(a: string, b?: number | undefined) => boolean>
+    >();
+
+    expect(mockFn.mockName(123)).type.toRaiseError();
+    expect(mockFn.mockName()).type.toRaiseError();
+  });
+
+  test('.mockReturnThis()', () => {
+    expect(mockFn.mockReturnThis()).type.toEqual<
+      Mock<(a: string, b?: number | undefined) => boolean>
+    >();
+
+    expect(mockFn.mockReturnThis('this')).type.toRaiseError();
+  });
+
+  test('.mockReturnValue()', () => {
+    expect(mockFn.mockReturnValue(false)).type.toEqual<
+      Mock<(a: string, b?: number | undefined) => boolean>
+    >();
+
+    expect(mockFn.mockReturnValue('true')).type.toRaiseError();
+    expect(mockFn.mockReturnValue()).type.toRaiseError();
+
+    expect(
+      mockAsyncFn.mockReturnValue(Promise.resolve('mock value')),
+    ).type.toEqual<Mock<(p: boolean) => Promise<string>>>();
+
+    expect(
+      mockAsyncFn.mockReturnValue(Promise.resolve(true)),
+    ).type.toRaiseError();
+  });
+
+  test('.mockReturnValueOnce()', () => {
+    expect(mockFn.mockReturnValueOnce(false)).type.toEqual<
+      Mock<(a: string, b?: number | undefined) => boolean>
+    >();
+    expect(mockFn.mockReturnValueOnce('true')).type.toRaiseError();
+
+    expect(mockFn.mockReturnValueOnce()).type.toRaiseError();
+
+    expect(
+      mockAsyncFn.mockReturnValueOnce(Promise.resolve('mock value')),
+    ).type.toEqual<Mock<(p: boolean) => Promise<string>>>();
+
+    expect(
+      mockAsyncFn.mockReturnValueOnce(Promise.resolve(true)),
+    ).type.toRaiseError();
+  });
+
+  test('.mockResolvedValue()', () => {
+    expect(
+      fn(() => Promise.resolve('')).mockResolvedValue('Mock value'),
+    ).type.toEqual<Mock<() => Promise<string>>>();
+
+    expect(
+      fn(() => Promise.resolve('')).mockResolvedValue(123),
+    ).type.toRaiseError();
+    expect(
+      fn(() => Promise.resolve('')).mockResolvedValue(),
+    ).type.toRaiseError();
+  });
+
+  test('.mockResolvedValueOnce()', () => {
+    expect(
+      fn(() => Promise.resolve('')).mockResolvedValueOnce('Mock value'),
+    ).type.toEqual<Mock<() => Promise<string>>>();
+
+    expect(
+      fn(() => Promise.resolve('')).mockResolvedValueOnce(123),
+    ).type.toRaiseError();
+    expect(
+      fn(() => Promise.resolve('')).mockResolvedValueOnce(),
+    ).type.toRaiseError();
+  });
+
+  test('.mockRejectedValue()', () => {
+    expect(
+      fn(() => Promise.resolve('')).mockRejectedValue(new Error('Mock error')),
+    ).type.toEqual<Mock<() => Promise<string>>>();
+    expect(
+      fn(() => Promise.resolve('')).mockRejectedValue('Mock error'),
+    ).type.toEqual<Mock<() => Promise<string>>>();
+
+    expect(
+      fn(() => Promise.resolve('')).mockRejectedValue(),
+    ).type.toRaiseError();
+  });
+
+  test('.mockRejectedValueOnce()', () => {
+    expect(
+      fn(() => Promise.resolve('')).mockRejectedValueOnce(
+        new Error('Mock error'),
+      ),
+    ).type.toEqual<Mock<() => Promise<string>>>();
+    expect(
+      fn(() => Promise.resolve('')).mockRejectedValueOnce('Mock error'),
+    ).type.toEqual<Mock<() => Promise<string>>>();
+
+    expect(
+      fn(() => Promise.resolve('')).mockRejectedValueOnce(),
+    ).type.toRaiseError();
+  });
+
+  test('.withImplementation()', () => {
+    expect(mockFn.withImplementation(mockFnImpl, () => {})).type.toBeVoid();
+    expect(mockFn.withImplementation(mockFnImpl, async () => {})).type.toEqual<
+      Promise<void>
+    >();
+
+    expect(mockFn.withImplementation(mockFnImpl)).type.toRaiseError();
+  });
+});
+
+describe('jest.spyOn()', () => {
+  const spiedArray = ['a', 'b'];
+
+  const spiedFunction = () => {};
+
+  const spiedObject = {
+    _propertyB: false,
+
+    methodA() {
+      return true;
+    },
+    methodB(a: string, b: number) {
+      return;
+    },
+    methodC(e: any) {
+      throw new Error();
+    },
+
+    propertyA: 'abc',
+
+    set propertyB(value) {
+      this._propertyB = value;
+    },
+    get propertyB() {
+      return this._propertyB;
+    },
+  };
+
+  type IndexSpiedObject = {
+    [key: string]: Record<string, any>;
+
+    methodA(): boolean;
+    methodB(a: string, b: number): void;
+    methodC: (c: number) => boolean;
+    methodE: (e: any) => never;
+
+    propertyA: {a: string};
+  };
+
+  const indexSpiedObject: IndexSpiedObject = {
+    methodA() {
+      return true;
+    },
+    methodB(a: string, b: number) {
+      return;
+    },
+    methodC(c: number) {
+      return true;
+    },
+    methodE(e: any) {
+      throw new Error();
+    },
+
+    propertyA: {a: 'abc'},
+  };
+
+  const spy = spyOn(spiedObject, 'methodA');
+
+  test('models typings of spied object', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-types
+    expect(spy).type.not.toMatch<Function>();
+
+    expect(spy()).type.toRaiseError();
+    expect(new spy()).type.toRaiseError();
+
+    expect(spyOn(spiedObject, 'methodA')).type.toEqual<
+      SpiedFunction<typeof spiedObject.methodA>
+    >();
+    expect(spyOn(spiedObject, 'methodB')).type.toEqual<
+      SpiedFunction<typeof spiedObject.methodB>
+    >();
+    expect(spyOn(spiedObject, 'methodC')).type.toEqual<
+      SpiedFunction<typeof spiedObject.methodC>
+    >();
+
+    expect(spyOn(spiedObject, 'propertyB', 'get')).type.toEqual<
+      SpiedGetter<typeof spiedObject.propertyB>
+    >();
+    expect(spyOn(spiedObject, 'propertyB', 'set')).type.toEqual<
+      SpiedSetter<typeof spiedObject.propertyB>
+    >();
+    expect(spyOn(spiedObject, 'propertyB')).type.toRaiseError();
+    expect(spyOn(spiedObject, 'methodB', 'get')).type.toRaiseError();
+    expect(spyOn(spiedObject, 'methodB', 'set')).type.toRaiseError();
+
+    expect(spyOn(spiedObject, 'propertyA', 'get')).type.toEqual<
+      SpiedGetter<typeof spiedObject.propertyA>
+    >();
+    expect(spyOn(spiedObject, 'propertyA', 'set')).type.toEqual<
+      SpiedSetter<typeof spiedObject.propertyA>
+    >();
+    expect(spyOn(spiedObject, 'propertyA')).type.toRaiseError();
+
+    expect(spyOn(spiedObject, 'notThere')).type.toRaiseError();
+    expect(spyOn('abc', 'methodA')).type.toRaiseError();
+    expect(spyOn(123, 'methodA')).type.toRaiseError();
+    expect(spyOn(true, 'methodA')).type.toRaiseError();
+    expect(spyOn(spiedObject)).type.toRaiseError();
+    expect(spyOn()).type.toRaiseError();
+
+    expect(
+      spyOn(spiedArray as unknown as ArrayConstructor, 'isArray'),
+    ).type.toEqual<SpiedFunction<typeof Array.isArray>>();
+    expect(spyOn(spiedArray, 'isArray')).type.toRaiseError();
+
+    expect(
+      // eslint-disable-next-line @typescript-eslint/ban-types
+      spyOn(spiedFunction as unknown as Function, 'toString'),
+    ).type.toEqual<SpiedFunction<typeof spiedFunction.toString>>();
+    expect(spyOn(spiedFunction, 'toString')).type.toRaiseError();
+
+    expect(spyOn(globalThis, 'Date')).type.toEqual<SpiedClass<typeof Date>>();
+    expect(spyOn(Date, 'now')).type.toEqual<SpiedFunction<typeof Date.now>>();
+  });
+
+  test('handles object with index signature', () => {
+    expect(spyOn(indexSpiedObject, 'methodA')).type.toEqual<
+      SpiedFunction<typeof indexSpiedObject.methodA>
+    >();
+    expect(spyOn(indexSpiedObject, 'methodB')).type.toEqual<
+      SpiedFunction<typeof indexSpiedObject.methodB>
+    >();
+    expect(spyOn(indexSpiedObject, 'methodC')).type.toEqual<
+      SpiedFunction<typeof indexSpiedObject.methodC>
+    >();
+    expect(spyOn(indexSpiedObject, 'methodE')).type.toEqual<
+      SpiedFunction<typeof indexSpiedObject.methodE>
+    >();
+
+    expect(spyOn(indexSpiedObject, 'propertyA', 'get')).type.toEqual<
+      SpiedGetter<typeof indexSpiedObject.propertyA>
+    >();
+    expect(spyOn(indexSpiedObject, 'propertyA', 'set')).type.toEqual<
+      SpiedSetter<typeof indexSpiedObject.propertyA>
+    >();
+    expect(spyOn(indexSpiedObject, 'propertyA')).type.toRaiseError();
+
+    expect(spyOn(indexSpiedObject, 'notThere')).type.toRaiseError();
+  });
+
+  test('handles interface with optional properties', () => {
+    class SomeClass {
+      constructor(one: string, two?: boolean) {}
+
+      methodA() {
+        return true;
+      }
+      methodB(a: string, b?: number) {
+        return;
+      }
+    }
+
+    interface OptionalInterface {
+      constructorA?: (new (one: string) => SomeClass) | undefined;
+      constructorB: new (one: string, two: boolean) => SomeClass;
+
+      propertyA?: number | undefined;
+      propertyB?: number;
+      propertyC: number | undefined;
+      propertyD: string;
+
+      methodA?: ((a: boolean) => void) | undefined;
+      methodB: (b: string) => boolean;
+    }
+
+    const optionalSpiedObject = {} as OptionalInterface;
+
+    expect(spyOn(optionalSpiedObject, 'constructorA')).type.toEqual<
+      SpiedClass<NonNullable<typeof optionalSpiedObject.constructorA>>
+    >();
+    expect(spyOn(optionalSpiedObject, 'constructorB')).type.toEqual<
+      SpiedClass<typeof optionalSpiedObject.constructorB>
+    >();
+
+    expect(
+      spyOn(optionalSpiedObject, 'constructorA', 'get'),
+    ).type.toRaiseError();
+    expect(
+      spyOn(optionalSpiedObject, 'constructorA', 'set'),
+    ).type.toRaiseError();
+
+    expect(spyOn(optionalSpiedObject, 'methodA')).type.toEqual<
+      SpiedFunction<NonNullable<typeof optionalSpiedObject.methodA>>
+    >();
+    expect(spyOn(optionalSpiedObject, 'methodB')).type.toEqual<
+      SpiedFunction<typeof optionalSpiedObject.methodB>
+    >();
+
+    expect(spyOn(optionalSpiedObject, 'methodA', 'get')).type.toRaiseError();
+    expect(spyOn(optionalSpiedObject, 'methodA', 'set')).type.toRaiseError();
+
+    expect(spyOn(optionalSpiedObject, 'propertyA', 'get')).type.toEqual<
+      SpiedGetter<NonNullable<typeof optionalSpiedObject.propertyA>>
+    >();
+    expect(spyOn(optionalSpiedObject, 'propertyA', 'set')).type.toEqual<
+      SpiedSetter<NonNullable<typeof optionalSpiedObject.propertyA>>
+    >();
+    expect(spyOn(optionalSpiedObject, 'propertyB', 'get')).type.toEqual<
+      SpiedGetter<NonNullable<typeof optionalSpiedObject.propertyB>>
+    >();
+    expect(spyOn(optionalSpiedObject, 'propertyB', 'set')).type.toEqual<
+      SpiedSetter<NonNullable<typeof optionalSpiedObject.propertyB>>
+    >();
+    expect(spyOn(optionalSpiedObject, 'propertyC', 'get')).type.toEqual<
+      SpiedGetter<typeof optionalSpiedObject.propertyC>
+    >();
+    expect(spyOn(optionalSpiedObject, 'propertyC', 'set')).type.toEqual<
+      SpiedSetter<typeof optionalSpiedObject.propertyC>
+    >();
+    expect(spyOn(optionalSpiedObject, 'propertyD', 'get')).type.toEqual<
+      SpiedGetter<typeof optionalSpiedObject.propertyD>
+    >();
+    expect(spyOn(optionalSpiedObject, 'propertyD', 'set')).type.toEqual<
+      SpiedSetter<typeof optionalSpiedObject.propertyD>
+    >();
+
+    expect(spyOn(optionalSpiedObject, 'propertyA')).type.toRaiseError();
+    expect(spyOn(optionalSpiedObject, 'propertyB')).type.toRaiseError();
+  });
+
+  test('handles properties of `prototype`', () => {
+    expect(
+      spyOn(Storage.prototype, 'setItem').mockImplementation(
+        (key: string, value: string) => {},
+      ),
+    ).type.toEqual<SpiedFunction<(key: string, value: string) => void>>();
+
+    expect(
+      spyOn(Storage.prototype, 'setItem').mockImplementation(
+        (key: string, value: number) => {},
+      ),
+    ).type.toRaiseError();
+  });
+});
+
+describe('jest.replaceProperty()', () => {
+  const replaceObject = {
+    method: () => {},
+    property: 1,
+  };
+
+  interface ComplexObject {
+    numberOrUndefined: number | undefined;
+    optionalString?: string;
+    multipleTypes: number | string | {foo: number} | null;
   }
-  methodB(a: string, b?: number) {
-    return;
+
+  const complexObject = {} as ComplexObject;
+
+  interface ObjectWithDynamicProperties {
+    [key: string]: boolean;
   }
-}
 
-interface OptionalInterface {
-  constructorA?: (new (one: string) => SomeClass) | undefined;
-  constructorB: new (one: string, two: boolean) => SomeClass;
+  const objectWithDynamicProperties = {} as ObjectWithDynamicProperties;
 
-  propertyA?: number | undefined;
-  propertyB?: number;
-  propertyC: number | undefined;
-  propertyD: string;
+  test('models typings of replaced property', () => {
+    expect(replaceProperty(replaceObject, 'property', 1)).type.toEqual<
+      Replaced<number>
+    >();
+    expect(replaceProperty(replaceObject, 'method', () => {})).type.toEqual<
+      Replaced<() => void>
+    >();
+    expect(
+      replaceProperty(replaceObject, 'property', 1).replaceValue(1).restore(),
+    ).type.toBeVoid();
 
-  methodA?: ((a: boolean) => void) | undefined;
-  methodB: (b: string) => boolean;
-}
+    expect(replaceProperty(replaceObject, 'invalid', 1)).type.toRaiseError();
+    expect(
+      replaceProperty(replaceObject, 'property', 'not a number'),
+    ).type.toRaiseError();
 
-const optionalSpiedObject = {} as OptionalInterface;
+    expect(
+      replaceProperty(replaceObject, 'property', 1).replaceValue(
+        'not a number',
+      ),
+    ).type.toRaiseError();
 
-expectType<SpiedClass<NonNullable<typeof optionalSpiedObject.constructorA>>>(
-  spyOn(optionalSpiedObject, 'constructorA'),
-);
-expectType<SpiedClass<typeof optionalSpiedObject.constructorB>>(
-  spyOn(optionalSpiedObject, 'constructorB'),
-);
+    expect(
+      replaceProperty(complexObject, 'numberOrUndefined', undefined),
+    ).type.toEqual<Replaced<number | undefined>>();
+    expect(replaceProperty(complexObject, 'numberOrUndefined', 1)).type.toEqual<
+      Replaced<number | undefined>
+    >();
 
-expectError(spyOn(optionalSpiedObject, 'constructorA', 'get'));
-expectError(spyOn(optionalSpiedObject, 'constructorA', 'set'));
+    expect(
+      replaceProperty(
+        complexObject,
+        'numberOrUndefined',
+        'string is not valid TypeScript type',
+      ),
+    ).type.toRaiseError();
 
-expectType<SpiedFunction<NonNullable<typeof optionalSpiedObject.methodA>>>(
-  spyOn(optionalSpiedObject, 'methodA'),
-);
-expectType<SpiedFunction<typeof optionalSpiedObject.methodB>>(
-  spyOn(optionalSpiedObject, 'methodB'),
-);
+    expect(
+      replaceProperty(complexObject, 'optionalString', 'foo'),
+    ).type.toEqual<Replaced<string | undefined>>();
+    expect(
+      replaceProperty(complexObject, 'optionalString', undefined),
+    ).type.toEqual<Replaced<string | undefined>>();
 
-expectError(spyOn(optionalSpiedObject, 'methodA', 'get'));
-expectError(spyOn(optionalSpiedObject, 'methodA', 'set'));
+    expect(
+      replaceProperty(objectWithDynamicProperties, 'dynamic prop 1', true),
+    ).type.toEqual<Replaced<boolean>>();
+    expect(
+      replaceProperty(objectWithDynamicProperties, 'dynamic prop 1', undefined),
+    ).type.toRaiseError();
 
-expectType<SpiedGetter<NonNullable<typeof optionalSpiedObject.propertyA>>>(
-  spyOn(optionalSpiedObject, 'propertyA', 'get'),
-);
-expectType<SpiedSetter<NonNullable<typeof optionalSpiedObject.propertyA>>>(
-  spyOn(optionalSpiedObject, 'propertyA', 'set'),
-);
-expectType<SpiedGetter<NonNullable<typeof optionalSpiedObject.propertyB>>>(
-  spyOn(optionalSpiedObject, 'propertyB', 'get'),
-);
-expectType<SpiedSetter<NonNullable<typeof optionalSpiedObject.propertyB>>>(
-  spyOn(optionalSpiedObject, 'propertyB', 'set'),
-);
-expectType<SpiedGetter<typeof optionalSpiedObject.propertyC>>(
-  spyOn(optionalSpiedObject, 'propertyC', 'get'),
-);
-expectType<SpiedSetter<typeof optionalSpiedObject.propertyC>>(
-  spyOn(optionalSpiedObject, 'propertyC', 'set'),
-);
-expectType<SpiedGetter<typeof optionalSpiedObject.propertyD>>(
-  spyOn(optionalSpiedObject, 'propertyD', 'get'),
-);
-expectType<SpiedSetter<typeof optionalSpiedObject.propertyD>>(
-  spyOn(optionalSpiedObject, 'propertyD', 'set'),
-);
+    expect(
+      replaceProperty(complexObject, 'not a property', undefined),
+    ).type.toRaiseError();
 
-expectError(spyOn(optionalSpiedObject, 'propertyA'));
-expectError(spyOn(optionalSpiedObject, 'propertyB'));
-
-// properties of `prototype`
-
-expectType<SpiedFunction<(key: string, value: string) => void>>(
-  spyOn(Storage.prototype, 'setItem').mockImplementation(
-    (key: string, value: string) => {},
-  ),
-);
-
-expectError(
-  spyOn(Storage.prototype, 'setItem').mockImplementation(
-    (key: string, value: number) => {},
-  ),
-);
-
-// replaceProperty + Replaced
-
-const replaceObject = {
-  method: () => {},
-  property: 1,
-};
-
-expectType<Replaced<number>>(replaceProperty(replaceObject, 'property', 1));
-expectType<Replaced<() => void>>(
-  replaceProperty(replaceObject, 'method', () => {}),
-);
-expectType<void>(
-  replaceProperty(replaceObject, 'property', 1).replaceValue(1).restore(),
-);
-
-expectError(replaceProperty(replaceObject, 'invalid', 1));
-expectError(replaceProperty(replaceObject, 'property', 'not a number'));
-
-expectError(
-  replaceProperty(replaceObject, 'property', 1).replaceValue('not a number'),
-);
-
-interface ComplexObject {
-  numberOrUndefined: number | undefined;
-  optionalString?: string;
-  multipleTypes: number | string | {foo: number} | null;
-}
-declare const complexObject: ComplexObject;
-
-interface ObjectWithDynamicProperties {
-  [key: string]: boolean;
-}
-declare const objectWithDynamicProperties: ObjectWithDynamicProperties;
-
-// Resulting type should retain the original property type
-expectType<Replaced<number | undefined>>(
-  replaceProperty(complexObject, 'numberOrUndefined', undefined),
-);
-expectType<Replaced<number | undefined>>(
-  replaceProperty(complexObject, 'numberOrUndefined', 1),
-);
-
-expectError(
-  replaceProperty(
-    complexObject,
-    'numberOrUndefined',
-    'string is not valid TypeScript type',
-  ),
-);
-
-expectType<Replaced<string | undefined>>(
-  replaceProperty(complexObject, 'optionalString', 'foo'),
-);
-expectType<Replaced<string | undefined>>(
-  replaceProperty(complexObject, 'optionalString', undefined),
-);
-
-expectType<Replaced<boolean>>(
-  replaceProperty(objectWithDynamicProperties, 'dynamic prop 1', true),
-);
-expectError(
-  replaceProperty(objectWithDynamicProperties, 'dynamic prop 1', undefined),
-);
-
-expectError(replaceProperty(complexObject, 'not a property', undefined));
-
-expectType<Replaced<ComplexObject['multipleTypes']>>(
-  replaceProperty(complexObject, 'multipleTypes', 1)
-    .replaceValue('foo')
-    .replaceValue({foo: 1})
-    .replaceValue(null),
-);
+    expect(
+      replaceProperty(complexObject, 'multipleTypes', 1)
+        .replaceValue('foo')
+        .replaceValue({foo: 1})
+        .replaceValue(null),
+    ).type.toEqual<Replaced<ComplexObject['multipleTypes']>>();
+  });
+});

--- a/packages/jest-mock/__typetests__/utility-types.test.ts
+++ b/packages/jest-mock/__typetests__/utility-types.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {expectAssignable, expectNotAssignable, expectType} from 'tsd-lite';
+import {expect, test} from 'tstyche';
 import type {
   ClassLike,
   ConstructorLikeKeys,
@@ -105,64 +105,63 @@ type IndexObject = {
   propertyB: {b: string};
 };
 
-// ClassLike
+test('ClassLike', () => {
+  expect<ClassLike>().type.toBeAssignable(SomeClass);
 
-expectAssignable<ClassLike>(SomeClass);
-expectNotAssignable<ClassLike>(() => {});
-expectNotAssignable<ClassLike>(function abc() {
-  return;
+  expect<ClassLike>().type.not.toBeAssignable(() => {});
+  expect<ClassLike>().type.not.toBeAssignable(function abc() {
+    return;
+  });
+  expect<ClassLike>().type.not.toBeAssignable('abc');
+  expect<ClassLike>().type.not.toBeAssignable(123);
+  expect<ClassLike>().type.not.toBeAssignable(false);
+  expect<ClassLike>().type.not.toBeAssignable(someObject);
 });
-expectNotAssignable<ClassLike>('abc');
-expectNotAssignable<ClassLike>(123);
-expectNotAssignable<ClassLike>(false);
-expectNotAssignable<ClassLike>(someObject);
 
-// FunctionLike
+test('FunctionLike', () => {
+  expect<FunctionLike>().type.toBeAssignable(() => {});
+  expect<FunctionLike>().type.toBeAssignable(function abc() {
+    return;
+  });
 
-expectAssignable<FunctionLike>(() => {});
-expectAssignable<FunctionLike>(function abc() {
-  return;
+  expect<FunctionLike>().type.not.toBeAssignable('abc');
+  expect<FunctionLike>().type.not.toBeAssignable(123);
+  expect<FunctionLike>().type.not.toBeAssignable(false);
+  expect<FunctionLike>().type.not.toBeAssignable(SomeClass);
+  expect<FunctionLike>().type.not.toBeAssignable(someObject);
 });
-expectNotAssignable<FunctionLike>('abc');
-expectNotAssignable<FunctionLike>(123);
-expectNotAssignable<FunctionLike>(false);
-expectNotAssignable<FunctionLike>(SomeClass);
-expectNotAssignable<FunctionLike>(someObject);
 
-// ConstructorKeys
+test('ConstructorKeys', () => {
+  expect<ConstructorLikeKeys<OptionalInterface>>().type.toEqual<
+    'constructorA' | 'constructorB'
+  >();
+  expect<ConstructorLikeKeys<SomeObject>>().type.toEqual<'SomeClass'>();
+});
 
-declare const interfaceConstructorKeys: ConstructorLikeKeys<OptionalInterface>;
-declare const objectConstructorKeys: ConstructorLikeKeys<SomeObject>;
+test('MethodKeys', () => {
+  expect<MethodLikeKeys<SomeClass>>().type.toEqual<'methodA' | 'methodB'>();
+  expect<MethodLikeKeys<IndexClass>>().type.toEqual<'methodA' | 'methodB'>();
+  expect<MethodLikeKeys<OptionalInterface>>().type.toEqual<
+    'methodA' | 'methodB'
+  >();
+  expect<MethodLikeKeys<SomeObject>>().type.toEqual<
+    'methodA' | 'methodB' | 'methodC'
+  >();
+  expect<MethodLikeKeys<IndexObject>>().type.toEqual<
+    'methodA' | 'methodB' | 'methodC'
+  >();
+});
 
-expectType<'constructorA' | 'constructorB'>(interfaceConstructorKeys);
-expectType<'SomeClass'>(objectConstructorKeys);
-
-// MethodKeys
-
-declare const classMethods: MethodLikeKeys<SomeClass>;
-declare const indexClassMethods: MethodLikeKeys<IndexClass>;
-declare const interfaceMethods: MethodLikeKeys<OptionalInterface>;
-declare const objectMethods: MethodLikeKeys<SomeObject>;
-declare const indexObjectMethods: MethodLikeKeys<IndexObject>;
-
-expectType<'methodA' | 'methodB'>(classMethods);
-expectType<'methodA' | 'methodB'>(indexClassMethods);
-expectType<'methodA' | 'methodB'>(interfaceMethods);
-expectType<'methodA' | 'methodB' | 'methodC'>(objectMethods);
-expectType<'methodA' | 'methodB' | 'methodC'>(indexObjectMethods);
-
-// PropertyKeys
-
-declare const classProperties: PropertyLikeKeys<SomeClass>;
-declare const indexClassProperties: PropertyLikeKeys<IndexClass>;
-declare const interfaceProperties: PropertyLikeKeys<OptionalInterface>;
-declare const objectProperties: PropertyLikeKeys<SomeObject>;
-declare const indexObjectProperties: PropertyLikeKeys<IndexObject>;
-
-expectType<'propertyA' | 'propertyB' | 'propertyC'>(classProperties);
-expectType<string | number>(indexClassProperties);
-expectType<'propertyA' | 'propertyB' | 'propertyC' | 'propertyD'>(
-  interfaceProperties,
-);
-expectType<'propertyA' | 'propertyB' | 'someClassInstance'>(objectProperties);
-expectType<string | number>(indexObjectProperties);
+test('PropertyKeys', () => {
+  expect<PropertyLikeKeys<SomeClass>>().type.toEqual<
+    'propertyA' | 'propertyB' | 'propertyC'
+  >();
+  expect<PropertyLikeKeys<IndexClass>>().type.toEqual<string | number>();
+  expect<PropertyLikeKeys<OptionalInterface>>().type.toEqual<
+    'propertyA' | 'propertyB' | 'propertyC' | 'propertyD'
+  >();
+  expect<PropertyLikeKeys<SomeObject>>().type.toEqual<
+    'propertyA' | 'propertyB' | 'someClassInstance'
+  >();
+  expect<PropertyLikeKeys<IndexObject>>().type.toEqual<string | number>();
+});

--- a/packages/jest-mock/package.json
+++ b/packages/jest-mock/package.json
@@ -23,10 +23,6 @@
     "@types/node": "*",
     "jest-util": "workspace:*"
   },
-  "devDependencies": {
-    "@tsd/typescript": "^5.0.4",
-    "tsd-lite": "^0.8.0"
-  },
   "engines": {
     "node": "^16.10.0 || ^18.12.0 || >=20.0.0"
   },

--- a/scripts/verifyOldTs.mjs
+++ b/scripts/verifyOldTs.mjs
@@ -144,7 +144,10 @@ function typeTests() {
 
     verifyInstalledTypescript();
 
-    execa.sync('yarn', ['test-types'], {cwd, stdio: 'inherit'});
+    execa.sync('yarn', ['test-ts', '--selectProjects', 'type-tests'], {
+      cwd,
+      stdio: 'inherit',
+    });
   } finally {
     execa.sync('git', ['checkout', 'package.json', 'yarn.lock'], {cwd});
     execa.sync('yarn', ['install'], {cwd});

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -3,6 +3,7 @@
     "**/packages/expect-utils/__typetests__/*.test.ts",
     "**/packages/jest/__typetests__/*.test.ts",
     "**/packages/jest-cli/__typetests__/*.test.ts",
+    "**/packages/jest-mock/__typetests__/*.test.ts",
     "**/packages/jest-types/__typetests__/config.test.ts"
   ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12961,10 +12961,8 @@ __metadata:
   resolution: "jest-mock@workspace:packages/jest-mock"
   dependencies:
     "@jest/types": "workspace:*"
-    "@tsd/typescript": ^5.0.4
     "@types/node": "*"
     jest-util: "workspace:*"
-    tsd-lite: ^0.8.0
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3076,7 +3076,7 @@ __metadata:
     strip-json-comments: ^3.1.1
     tempy: ^1.0.0
     ts-node: ^10.5.0
-    tstyche: ^1.0.0-rc.1
+    tstyche: ^1.0.0-rc.2
     typescript: ^5.0.4
     webpack: ^5.68.0
     webpack-node-externals: ^3.0.0
@@ -20151,9 +20151,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tstyche@npm:^1.0.0-rc.1":
-  version: 1.0.0-rc.1
-  resolution: "tstyche@npm:1.0.0-rc.1"
+"tstyche@npm:^1.0.0-rc.2":
+  version: 1.0.0-rc.2
+  resolution: "tstyche@npm:1.0.0-rc.2"
   peerDependencies:
     typescript: 4.x || 5.x
   peerDependenciesMeta:
@@ -20161,7 +20161,7 @@ __metadata:
       optional: true
   bin:
     tstyche: ./build/bin.js
-  checksum: 611ce37a868bd944ab4412941cfb8949553e978b3d754c99dff2ebfdab6762660dfaf0a0b62634812ace5126b548d4ac1a38b2a2c9653421e0ea4090169d0d6b
+  checksum: a118cde0744a4074f4abeb9f2392919aa6d2a3cf0b73a05ed41a6cd2c95ee5b6ff63fa495342fa8596d679c4370b8ffa822e0ad49ba7910edeb993fb620537bf
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3076,7 +3076,7 @@ __metadata:
     strip-json-comments: ^3.1.1
     tempy: ^1.0.0
     ts-node: ^10.5.0
-    tstyche: ^1.0.0-beta.9
+    tstyche: ^1.0.0-rc.1
     typescript: ^5.0.4
     webpack: ^5.68.0
     webpack-node-externals: ^3.0.0
@@ -20151,9 +20151,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tstyche@npm:^1.0.0-beta.9":
-  version: 1.0.0-beta.9
-  resolution: "tstyche@npm:1.0.0-beta.9"
+"tstyche@npm:^1.0.0-rc.1":
+  version: 1.0.0-rc.1
+  resolution: "tstyche@npm:1.0.0-rc.1"
   peerDependencies:
     typescript: 4.x || 5.x
   peerDependenciesMeta:
@@ -20161,7 +20161,7 @@ __metadata:
       optional: true
   bin:
     tstyche: ./build/bin.js
-  checksum: 448171bd7d747e4463c8d4bde67a05b16300fba098e07cb576c64fe1524dedcb02f087e5291be35d883d06fa70a61d7c313ca07cc33e43fd104fcf6246cc97e6
+  checksum: 611ce37a868bd944ab4412941cfb8949553e978b3d754c99dff2ebfdab6762660dfaf0a0b62634812ace5126b548d4ac1a38b2a2c9653421e0ea4090169d0d6b
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3076,7 +3076,7 @@ __metadata:
     strip-json-comments: ^3.1.1
     tempy: ^1.0.0
     ts-node: ^10.5.0
-    tstyche: ^1.0.0-rc.2
+    tstyche: ^1.0.0
     typescript: ^5.0.4
     webpack: ^5.68.0
     webpack-node-externals: ^3.0.0
@@ -20151,9 +20151,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tstyche@npm:^1.0.0-rc.2":
-  version: 1.0.0-rc.2
-  resolution: "tstyche@npm:1.0.0-rc.2"
+"tstyche@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "tstyche@npm:1.0.0"
   peerDependencies:
     typescript: 4.x || 5.x
   peerDependenciesMeta:
@@ -20161,7 +20161,7 @@ __metadata:
       optional: true
   bin:
     tstyche: ./build/bin.js
-  checksum: a118cde0744a4074f4abeb9f2392919aa6d2a3cf0b73a05ed41a6cd2c95ee5b6ff63fa495342fa8596d679c4370b8ffa822e0ad49ba7910edeb993fb620537bf
+  checksum: 83725c3651707d1d6afe46833a1ef43a650e839116a5f10193f6059f5f52923968dd0f05aaef827d96dcad8438330a9b53ffa4f69ebccee1fb25e8b77f0e81e0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR migrates `jest-mock` type tests to TSTyche. The diff is hm.. There is no diff actually, these look like newly added files. Not sure if this is good for review. Or is that fine?

## Test plan

The type tests should pass.