### PR TITLE
Update NodeEnvironment to provide dispose global symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - `[jest-snapshot]` [**BREAKING**] Add support for [Error causes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) in snapshots ([#13965](https://github.com/facebook/jest/pull/13965))
 - `[jest-snapshot]` Support Prettier 3 ([#14566](https://github.com/facebook/jest/pull/14566))
 - `[pretty-format]` [**BREAKING**] Do not render empty string children (`''`) in React plugin ([#14470](https://github.com/facebook/jest/pull/14470))
-- `[jest-environment-node]` Update jest environment with host global `Symbol` ([#14888](https://github.com/jestjs/jest/pull/14888))
+- `[jest-environment-node]` Update jest environment with dispose symbols `Symbol` ([#14888](https://github.com/jestjs/jest/pull/14888))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[@jest/core, @jest/test-sequencer]` [**BREAKING**] Exposes `globalConfig` & `contexts` to `TestSequencer` ([#14535](https://github.com/jestjs/jest/pull/14535), & [#14543](https://github.com/jestjs/jest/pull/14543))
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade JSDOM to v22 ([#13825](https://github.com/jestjs/jest/pull/13825))
 - `[@jest/environment-jsdom-abstract]` Introduce new package which abstracts over the `jsdom` environment, allowing usage of custom versions of JSDOM ([#14717](https://github.com/jestjs/jest/pull/14717))
+- `[jest-environment-node]` Update jest environment with dispose symbols `Symbol` ([#14888](https://github.com/jestjs/jest/pull/14888))
 - `[@jest/fake-timers]` [**BREAKING**] Upgrade `@sinonjs/fake-timers` to v11 ([#14544](https://github.com/jestjs/jest/pull/14544))
 - `[@jest/fake-timers]` Exposing new modern timers function `advanceTimersToFrame()` which advances all timers by the needed milliseconds to execute callbacks currently scheduled with `requestAnimationFrame` ([#14598](https://github.com/jestjs/jest/pull/14598))
 - `[jest-runtime]` Exposing new modern timers function `jest.advanceTimersToFrame()` from `@jest/fake-timers` ([#14598](https://github.com/jestjs/jest/pull/14598))
@@ -24,7 +25,6 @@
 - `[jest-snapshot]` [**BREAKING**] Add support for [Error causes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) in snapshots ([#13965](https://github.com/facebook/jest/pull/13965))
 - `[jest-snapshot]` Support Prettier 3 ([#14566](https://github.com/facebook/jest/pull/14566))
 - `[pretty-format]` [**BREAKING**] Do not render empty string children (`''`) in React plugin ([#14470](https://github.com/facebook/jest/pull/14470))
-- `[jest-environment-node]` Update jest environment with dispose symbols `Symbol` ([#14888](https://github.com/jestjs/jest/pull/14888))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[jest-snapshot]` [**BREAKING**] Add support for [Error causes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) in snapshots ([#13965](https://github.com/facebook/jest/pull/13965))
 - `[jest-snapshot]` Support Prettier 3 ([#14566](https://github.com/facebook/jest/pull/14566))
 - `[pretty-format]` [**BREAKING**] Do not render empty string children (`''`) in React plugin ([#14470](https://github.com/facebook/jest/pull/14470))
+- `[jest-environment-node]` Update jest environment with host global `Symbol` ([#14888](https://github.com/jestjs/jest/pull/14888))
 
 ### Fixes
 

--- a/packages/jest-environment-node/src/__tests__/node_environment.test.ts
+++ b/packages/jest-environment-node/src/__tests__/node_environment.test.ts
@@ -72,6 +72,19 @@ describe('NodeEnvironment', () => {
     }
   });
 
+  it('should configure host global Symbol', () => {
+    const env = new NodeEnvironment(
+      {
+        globalConfig: makeGlobalConfig(),
+        projectConfig: makeProjectConfig(),
+      },
+      context,
+    );
+
+    expect(env.global.Symbol).toBeDefined();
+    expect(env.global.Symbol).toStrictEqual(Symbol);
+  });
+
   it('has modern fake timers implementation', () => {
     const env = new NodeEnvironment(
       {

--- a/packages/jest-environment-node/src/__tests__/node_environment.test.ts
+++ b/packages/jest-environment-node/src/__tests__/node_environment.test.ts
@@ -72,7 +72,7 @@ describe('NodeEnvironment', () => {
     }
   });
 
-  it('should configure host global Symbol', () => {
+  it('should configure dispose symbols', () => {
     const env = new NodeEnvironment(
       {
         globalConfig: makeGlobalConfig(),
@@ -81,8 +81,17 @@ describe('NodeEnvironment', () => {
       context,
     );
 
-    expect(env.global.Symbol).toBeDefined();
-    expect(env.global.Symbol).toStrictEqual(Symbol);
+    if ('asyncDispose' in Symbol) {
+      expect(env.global.Symbol).toHaveProperty('asyncDispose');
+    } else {
+      expect(env.global.Symbol).not.toHaveProperty('asyncDispose');
+    }
+
+    if ('dispose' in Symbol) {
+      expect(env.global.Symbol).toHaveProperty('dispose');
+    } else {
+      expect(env.global.Symbol).not.toHaveProperty('dispose');
+    }
   });
 
   it('has modern fake timers implementation', () => {

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -84,7 +84,7 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
   // while `context` is unused, it should always be passed
   constructor(config: JestEnvironmentConfig, _context: EnvironmentContext) {
     const {projectConfig} = config;
-    this.context = createContext();
+    this.context = createContext({Symbol});
     const global = runInContext(
       'this',
       Object.assign(this.context, projectConfig.testEnvironmentOptions),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This PR aims to solve #14874.

As said in the issue, since typescript 5.2, [Explicit Resource Management](https://github.com/tc39/proposal-explicit-resource-management) is being supported in Typescript. Latest stable NodeJS versions include `Symbol.dispose` and `Symbol.asyncDispose`, essential to pollyfill this feature. Exposing them in the jest node env would allow to properly test modules using this feature.

The vm node API generates by default a global object with standard properties. I think it makes sense the node env provides  dispose Symbols if the host runtime is providing them in order to use NodeJS supported features relying in those symbols.

## Test plan

- Added a unit test to test the host global `Symbol` is set as the vm global `Symbol`.
