### PR TITLE
Link to NestJS docs on testing with Jest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 - `[jest-util]` Upgrade `picomatch` to v4 ([#14653](https://github.com/jestjs/jest/pull/14653) & [#14885](https://github.com/jestjs/jest/pull/14885))
 - `[docs] Append to NODE_OPTIONS, not overwrite ([#14730](https://github.com/jestjs/jest/pull/14730))`
 - `[docs]` Updated `.toHaveBeenCalled()` documentation to correctly reflect its functionality ([#14842](https://github.com/jestjs/jest/pull/14842))
+- `[docs]` Link NestJS documentation on testing with Jest ([#14940](https://github.com/jestjs/jest/pull/14940))
 
 ## 29.7.0
 

--- a/docs/TestingFrameworks.md
+++ b/docs/TestingFrameworks.md
@@ -47,3 +47,7 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 ## Next.js
 
 - [Jest and React Testing Library](https://nextjs.org/docs/pages/building-your-application/testing/jest) by Next.js docs
+
+## NestJS
+
+- [Jest and NestJS dependencies](https://docs.nestjs.com/fundamentals/testing#unit-testing) by NestJS docs

--- a/website/versioned_docs/version-29.4/TestingFrameworks.md
+++ b/website/versioned_docs/version-29.4/TestingFrameworks.md
@@ -47,3 +47,7 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 ## Next.js
 
 - [Jest and React Testing Library](https://nextjs.org/docs/pages/building-your-application/testing/jest) by Next.js docs
+
+## NestJS
+
+- [Jest and NestJS dependencies](https://docs.nestjs.com/fundamentals/testing#unit-testing) by NestJS docs

--- a/website/versioned_docs/version-29.5/TestingFrameworks.md
+++ b/website/versioned_docs/version-29.5/TestingFrameworks.md
@@ -47,3 +47,7 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 ## Next.js
 
 - [Jest and React Testing Library](https://nextjs.org/docs/pages/building-your-application/testing/jest) by Next.js docs
+
+## NestJS
+
+- [Jest and NestJS dependencies](https://docs.nestjs.com/fundamentals/testing#unit-testing) by NestJS docs

--- a/website/versioned_docs/version-29.6/TestingFrameworks.md
+++ b/website/versioned_docs/version-29.6/TestingFrameworks.md
@@ -47,3 +47,7 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 ## Next.js
 
 - [Jest and React Testing Library](https://nextjs.org/docs/pages/building-your-application/testing/jest) by Next.js docs
+
+## NestJS
+
+- [Jest and NestJS dependencies](https://docs.nestjs.com/fundamentals/testing#unit-testing) by NestJS docs

--- a/website/versioned_docs/version-29.7/TestingFrameworks.md
+++ b/website/versioned_docs/version-29.7/TestingFrameworks.md
@@ -47,3 +47,7 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 ## Next.js
 
 - [Jest and React Testing Library](https://nextjs.org/docs/pages/building-your-application/testing/jest) by Next.js docs
+
+## NestJS
+
+- [Jest and NestJS dependencies](https://docs.nestjs.com/fundamentals/testing#unit-testing) by NestJS docs


### PR DESCRIPTION
## Summary

https://jestjs.io/docs/testing-frameworks is linking different guides on testing other web frameworks like Express.js.

This change is now linking the popular NestJS backend framework as well as it integrates with Jest out of the box and it has good tooling, docs and examples on testing.

## Screenshot 

[<img width="444" alt="Screenshot 2024-03-05 at 23 32 25" src="https://github.com/jestjs/jest/assets/506129/fec7e9c1-361b-4462-a0da-942a9e807f60">](https://deploy-preview-14940--jestjs.netlify.app/docs/testing-frameworks)
