### PR TITLE
chore: migrate type tests of `jest-snapshot` to TSTyche

### DIFF
--- a/jest.config.ts.mjs
+++ b/jest.config.ts.mjs
@@ -35,6 +35,7 @@ export default {
         '!**/packages/jest-cli/__typetests__/*.test.ts',
         '!**/packages/jest-expect/__typetests__/*.test.ts',
         '!**/packages/jest-mock/__typetests__/*.test.ts',
+        '!**/packages/jest-snapshot/__typetests__/*.test.ts',
         '!**/packages/jest-types/__typetests__/config.test.ts',
       ],
     },

--- a/packages/jest-snapshot/__typetests__/SnapshotResolver.test.ts
+++ b/packages/jest-snapshot/__typetests__/SnapshotResolver.test.ts
@@ -5,21 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {expectNotAssignable, expectType} from 'tsd-lite';
+import {expect} from 'tstyche';
 import type {SnapshotResolver} from 'jest-snapshot';
 
 // SnapshotResolver
 
 const snapshotResolver: SnapshotResolver = {
   resolveSnapshotPath: (testPath, snapshotExtension) => {
-    expectType<string>(testPath);
-    expectType<string | undefined>(snapshotExtension);
+    expect(testPath).type.toBeString();
+    expect(snapshotExtension).type.toEqual<string | undefined>();
     return 'snapshot/path';
   },
 
   resolveTestPath: (snapshotPath, snapshotExtension) => {
-    expectType<string>(snapshotPath);
-    expectType<string | undefined>(snapshotExtension);
+    expect(snapshotPath).type.toBeString();
+    expect(snapshotExtension).type.toEqual<string | undefined>();
     return 'test/path';
   },
 
@@ -28,65 +28,65 @@ const snapshotResolver: SnapshotResolver = {
 
 // resolveSnapshotPath
 
-expectNotAssignable<SnapshotResolver>({
+expect<SnapshotResolver>().type.not.toBeAssignable({
   resolveSnapshotPath: (testPath: string, snapshotExtension: boolean) =>
     'snapshot/path',
   resolveTestPath: () => 'test/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
-expectNotAssignable<SnapshotResolver>({
+expect<SnapshotResolver>().type.not.toBeAssignable({
   resolveSnapshotPath: (testPath: boolean) => 'snapshot/path',
   resolveTestPath: () => 'test/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
-expectNotAssignable<SnapshotResolver>({
+expect<SnapshotResolver>().type.not.toBeAssignable({
   resolveSnapshotPath: () => true,
   resolveTestPath: () => 'test/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
-expectNotAssignable<SnapshotResolver>({
+expect<SnapshotResolver>().type.not.toBeAssignable({
   resolveTestPath: () => 'test/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
 // resolveTestPath
 
-expectNotAssignable<SnapshotResolver>({
+expect<SnapshotResolver>().type.not.toBeAssignable({
   resolveSnapshotPath: () => 'snapshot/path',
   resolveTestPath: (snapshotPath: string, snapshotExtension: boolean) =>
     'test/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
-expectNotAssignable<SnapshotResolver>({
+expect<SnapshotResolver>().type.not.toBeAssignable({
   resolveSnapshotPath: () => 'snapshot/path',
   resolveTestPath: (snapshotPath: boolean) => 'test/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
-expectNotAssignable<SnapshotResolver>({
+expect<SnapshotResolver>().type.not.toBeAssignable({
   resolveSnapshotPath: () => 'snapshot/path',
   resolveTestPath: () => true,
   testPathForConsistencyCheck: 'test/path/example',
 });
 
-expectNotAssignable<SnapshotResolver>({
+expect<SnapshotResolver>().type.not.toBeAssignable({
   resolveSnapshotPath: () => 'snapshot/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
 // testPathForConsistencyCheck
 
-expectNotAssignable<SnapshotResolver>({
+expect<SnapshotResolver>().type.not.toBeAssignable({
   resolveSnapshotPath: () => 'snapshot/path',
   resolveTestPath: () => 'test/path',
   testPathForConsistencyCheck: true,
 });
 
-expectNotAssignable<SnapshotResolver>({
+expect<SnapshotResolver>().type.not.toBeAssignable({
   resolveSnapshotPath: () => 'snapshot/path',
   resolveTestPath: () => 'test/path',
 });

--- a/packages/jest-snapshot/__typetests__/matchers.test.ts
+++ b/packages/jest-snapshot/__typetests__/matchers.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {expectError, expectType} from 'tsd-lite';
+import {expect} from 'tstyche';
 import type {ExpectationResult} from 'expect';
 import {
   type Context,
@@ -18,130 +18,132 @@ import {
 
 // Context
 
-expectType<SnapshotState>(({} as Context).snapshotState);
+expect(({} as Context).snapshotState).type.toEqual<SnapshotState>();
 
 // toMatchSnapshot
 
-expectType<ExpectationResult>(
+expect(
   toMatchSnapshot.call({} as Context, {received: 'value'}),
-);
+).type.toEqual<ExpectationResult>();
 
-expectType<ExpectationResult>(
+expect(
   toMatchSnapshot.call({} as Context, {received: 'value'}, 'someHint'),
-);
+).type.toEqual<ExpectationResult>();
 
-expectType<ExpectationResult>(
+expect(
   toMatchSnapshot.call({} as Context, {received: 'value'}, {property: 'match'}),
-);
+).type.toEqual<ExpectationResult>();
 
-expectType<ExpectationResult>(
+expect(
   toMatchSnapshot.call(
     {} as Context,
     {received: 'value'},
     {property: 'match'},
     'someHint',
   ),
-);
+).type.toEqual<ExpectationResult>();
 
-expectError(toMatchSnapshot({received: 'value'}));
+expect(toMatchSnapshot({received: 'value'})).type.toRaiseError();
 
 // toMatchInlineSnapshot
 
-expectType<ExpectationResult>(
+expect(
   toMatchInlineSnapshot.call({} as Context, {received: 'value'}),
-);
+).type.toEqual<ExpectationResult>();
 
-expectType<ExpectationResult>(
+expect(
   toMatchInlineSnapshot.call(
     {} as Context,
     {received: 'value'},
     'inlineSnapshot',
   ),
-);
+).type.toEqual<ExpectationResult>();
 
-expectType<ExpectationResult>(
+expect(
   toMatchInlineSnapshot.call(
     {} as Context,
     {received: 'value'},
     {property: 'match'},
   ),
-);
+).type.toEqual<ExpectationResult>();
 
-expectType<ExpectationResult>(
+expect(
   toMatchInlineSnapshot.call(
     {} as Context,
     {received: 'value'},
     {property: 'match'},
     'inlineSnapshot',
   ),
-);
+).type.toEqual<ExpectationResult>();
 
-expectError(toMatchInlineSnapshot({received: 'value'}));
+expect(toMatchInlineSnapshot({received: 'value'})).type.toRaiseError();
 
 // toThrowErrorMatchingSnapshot
 
-expectType<ExpectationResult>(
+expect(
   toThrowErrorMatchingSnapshot.call({} as Context, new Error('received')),
-);
+).type.toEqual<ExpectationResult>();
 
-expectType<ExpectationResult>(
+expect(
   toThrowErrorMatchingSnapshot.call(
     {} as Context,
     new Error('received'),
     'someHint',
   ),
-);
+).type.toEqual<ExpectationResult>();
 
-expectType<ExpectationResult>(
+expect(
   toThrowErrorMatchingSnapshot.call(
     {} as Context,
     new Error('received'),
     'someHint',
     true, // fromPromise
   ),
-);
+).type.toEqual<ExpectationResult>();
 
-expectType<ExpectationResult>(
+expect(
   toThrowErrorMatchingSnapshot.call(
     {} as Context,
     new Error('received'),
     undefined,
     false, // fromPromise
   ),
-);
+).type.toEqual<ExpectationResult>();
 
-expectError(toThrowErrorMatchingSnapshot({received: 'value'}));
+expect(toThrowErrorMatchingSnapshot({received: 'value'})).type.toRaiseError();
 
 // toThrowErrorMatchingInlineSnapshot
 
-expectType<ExpectationResult>(
+expect(
   toThrowErrorMatchingInlineSnapshot.call({} as Context, new Error('received')),
-);
+).type.toEqual<ExpectationResult>();
 
-expectType<ExpectationResult>(
+expect(
   toThrowErrorMatchingInlineSnapshot.call(
     {} as Context,
     new Error('received'),
     'inlineSnapshot',
   ),
-);
+).type.toEqual<ExpectationResult>();
 
-expectType<ExpectationResult>(
+expect(
   toThrowErrorMatchingInlineSnapshot.call(
     {} as Context,
     new Error('received'),
     'inlineSnapshot',
     true, // fromPromise
   ),
-);
+).type.toEqual<ExpectationResult>();
 
-expectType<ExpectationResult>(
+expect(
   toThrowErrorMatchingInlineSnapshot.call(
     {} as Context,
     new Error('received'),
     undefined,
     false, // fromPromise
   ),
-);
+).type.toEqual<ExpectationResult>();
 
-expectError(toThrowErrorMatchingInlineSnapshot({received: 'value'}));
+expect(
+  toThrowErrorMatchingInlineSnapshot({received: 'value'}),
+).type.toRaiseError();

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -6,6 +6,7 @@
     "**/packages/jest-cli/__typetests__/*.test.ts",
     "**/packages/jest-expect/__typetests__/*.test.ts",
     "**/packages/jest-mock/__typetests__/*.test.ts",
+    "**/packages/jest-snapshot/__typetests__/*.test.ts",
     "**/packages/jest-types/__typetests__/config.test.ts"
   ]
 }


### PR DESCRIPTION
## Summary

This PR migrates type test of `jest-snapshot` to TSTyche. 

Here I migrate only the assertions and leave the `test()` helpers for second PR. Perhaps that’s better strategy? Less noise in the diff would make it easier to review. These are minimal very changes, actually.

## Test plan

Green CI
