### PR TITLE
chore: migrate type test of `jest-runner` to TSTyche

### DIFF
--- a/jest.config.ts.mjs
+++ b/jest.config.ts.mjs
@@ -35,6 +35,7 @@ export default {
         '!**/packages/jest-cli/__typetests__/*.test.ts',
         '!**/packages/jest-expect/__typetests__/*.test.ts',
         '!**/packages/jest-mock/__typetests__/*.test.ts',
+        '!**/packages/jest-runner/__typetests__/*.test.ts',
         '!**/packages/jest-snapshot/__typetests__/*.test.ts',
         '!**/packages/jest-types/__typetests__/config.test.ts',
         '!**/packages/jest-worker/__typetests__/*.test.ts',

--- a/packages/jest-runner/__typetests__/jest-runner.test.ts
+++ b/packages/jest-runner/__typetests__/jest-runner.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {expectType} from 'tsd-lite';
+import {expect} from 'tstyche';
 import {
   CallbackTestRunner,
   type CallbackTestRunnerInterface,
@@ -37,8 +37,8 @@ class CallbackRunner extends CallbackTestRunner {
     onFailure: OnTestFailure,
     options: TestRunnerOptions,
   ): Promise<void> {
-    expectType<Config.GlobalConfig>(this._globalConfig);
-    expectType<TestRunnerContext>(this._context);
+    expect(this._globalConfig).type.toEqual<Config.GlobalConfig>();
+    expect(this._context).type.toEqual<TestRunnerContext>();
 
     return;
   }
@@ -46,8 +46,8 @@ class CallbackRunner extends CallbackTestRunner {
 
 const callbackRunner = new CallbackRunner(globalConfig, runnerContext);
 
-expectType<boolean | undefined>(callbackRunner.isSerial);
-expectType<false>(callbackRunner.supportsEventEmitters);
+expect(callbackRunner.isSerial).type.toEqual<boolean | undefined>();
+expect(callbackRunner.supportsEventEmitters).type.toEqual<false>();
 
 // CallbackTestRunnerInterface
 
@@ -68,8 +68,8 @@ class CustomCallbackRunner implements CallbackTestRunnerInterface {
     onFailure: OnTestFailure,
     options: TestRunnerOptions,
   ): Promise<void> {
-    expectType<Config.GlobalConfig>(this.#globalConfig);
-    expectType<number>(this.#maxConcurrency);
+    expect(this.#globalConfig).type.toEqual<Config.GlobalConfig>();
+    expect(this.#maxConcurrency).type.toBeNumber();
 
     return;
   }
@@ -83,8 +83,8 @@ class EmittingRunner extends EmittingTestRunner {
     watcher: TestWatcher,
     options: TestRunnerOptions,
   ): Promise<void> {
-    expectType<Config.GlobalConfig>(this._globalConfig);
-    expectType<TestRunnerContext>(this._context);
+    expect(this._globalConfig).type.toEqual<Config.GlobalConfig>();
+    expect(this._context).type.toEqual<TestRunnerContext>();
 
     return;
   }
@@ -99,8 +99,8 @@ class EmittingRunner extends EmittingTestRunner {
 
 const emittingRunner = new EmittingRunner(globalConfig, runnerContext);
 
-expectType<boolean | undefined>(emittingRunner.isSerial);
-expectType<true>(emittingRunner.supportsEventEmitters);
+expect(emittingRunner.isSerial).type.toEqual<boolean | undefined>();
+expect(emittingRunner.supportsEventEmitters).type.toEqual<true>();
 
 // EmittingTestRunnerInterface
 
@@ -119,8 +119,8 @@ class CustomEmittingRunner implements EmittingTestRunnerInterface {
     watcher: TestWatcher,
     options: TestRunnerOptions,
   ): Promise<void> {
-    expectType<Config.GlobalConfig>(this.#globalConfig);
-    expectType<number>(this.#maxConcurrency);
+    expect(this.#globalConfig).type.toEqual<Config.GlobalConfig>();
+    expect(this.#maxConcurrency).type.toBeNumber();
 
     return;
   }

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -6,8 +6,9 @@
     "**/packages/jest-cli/__typetests__/*.test.ts",
     "**/packages/jest-expect/__typetests__/*.test.ts",
     "**/packages/jest-mock/__typetests__/*.test.ts",
+    "**/packages/jest-runner/__typetests__/*.test.ts",
     "**/packages/jest-snapshot/__typetests__/*.test.ts",
+    "**/packages/jest-types/__typetests__/config.test.ts",
     "**/packages/jest-worker/__typetests__/*.test.ts"
-    "**/packages/jest-types/__typetests__/config.test.ts"
   ]
 }


### PR DESCRIPTION
## Summary

This PR migrates type test of `jest-runner` to TSTyche.

(Includes #14951)

## Test plan

Green CI.