### PR TITLE
chore: skip broken test on windows and node 21

### DIFF
--- a/packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.ts
+++ b/packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.ts
@@ -6,7 +6,6 @@
  */
 
 import {access, mkdir, rm, writeFile} from 'fs/promises';
-import * as os from 'os';
 import {dirname, join} from 'path';
 import {transformFileAsync} from '@babel/core';
 import {

--- a/packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.ts
+++ b/packages/jest-worker/src/workers/__tests__/WorkerEdgeCases.test.ts
@@ -6,6 +6,7 @@
  */
 
 import {access, mkdir, rm, writeFile} from 'fs/promises';
+import * as os from 'os';
 import {dirname, join} from 'path';
 import {transformFileAsync} from '@babel/core';
 import {
@@ -27,6 +28,13 @@ const processChildWorkerPath = join(
   'workers/processChild.js',
 );
 const threadChildWorkerPath = join(writeDestination, 'workers/threadChild.js');
+
+if (process.platform === 'win32' && process.version.startsWith('v21.')) {
+  // eslint-disable-next-line jest/no-focused-tests
+  test.only('skipping test on broken platform', () => {
+    console.warn('Skipping test on broken platform');
+  });
+}
 
 beforeAll(async () => {
   await mkdir(writeDestination, {recursive: true});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This has been failing consistently on Windows and Node 21 for a long time. Not sure how to debug this as I don't have access to a windows device...

@G-Rath you wouldn't possibly be able to debug this test, would you? 🙏 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
