### PR TITLE
feat: add retryImmediately option to jest.retryTimes (#14696)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `[jest-circus, jest-cli, jest-config]` Add `waitNextEventLoopTurnForUnhandledRejectionEvents` flag to minimise performance impact of correct detection of unhandled promise rejections introduced in [#14315](https://github.com/jestjs/jest/pull/14315) ([#14681](https://github.com/jestjs/jest/pull/14681))
 - `[jest-circus]` Add a `waitBeforeRetry` option to `jest.retryTimes` ([#14738](https://github.com/jestjs/jest/pull/14738))
-- `[jest-circus]` Add a `immediately` option to `jest.retryTimes` ([#14696](https://github.com/jestjs/jest/pull/14696))
+- `[jest-circus]` Add a `retryImmediately` option to `jest.retryTimes` ([#14696](https://github.com/jestjs/jest/pull/14696))
 - `[jest-circus, jest-jasmine2]` Allow `setupFilesAfterEnv` to export an async function ([#10962](https://github.com/jestjs/jest/issues/10962))
 - `[jest-config]` [**BREAKING**] Add `mts` and `cts` to default `moduleFileExtensions` config ([#14369](https://github.com/facebook/jest/pull/14369))
 - `[jest-config]` [**BREAKING**] Update `testMatch` and `testRegex` default option for supporting `mjs`, `cjs`, `mts`, and `cts` ([#14584](https://github.com/jestjs/jest/pull/14584))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[jest-circus, jest-cli, jest-config]` Add `waitNextEventLoopTurnForUnhandledRejectionEvents` flag to minimise performance impact of correct detection of unhandled promise rejections introduced in [#14315](https://github.com/jestjs/jest/pull/14315) ([#14681](https://github.com/jestjs/jest/pull/14681))
 - `[jest-circus]` Add a `waitBeforeRetry` option to `jest.retryTimes` ([#14738](https://github.com/jestjs/jest/pull/14738))
+- `[jest-circus]` Add a `immediately` option to `jest.retryTimes` ([#14696](https://github.com/jestjs/jest/pull/14696))
 - `[jest-circus, jest-jasmine2]` Allow `setupFilesAfterEnv` to export an async function ([#10962](https://github.com/jestjs/jest/issues/10962))
 - `[jest-config]` [**BREAKING**] Add `mts` and `cts` to default `moduleFileExtensions` config ([#14369](https://github.com/facebook/jest/pull/14369))
 - `[jest-config]` [**BREAKING**] Update `testMatch` and `testRegex` default option for supporting `mjs`, `cjs`, `mts`, and `cts` ([#14584](https://github.com/jestjs/jest/pull/14584))

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -1139,10 +1139,10 @@ test('will fail', () => {
 });
 ```
 
-`immediately` option is used to retry the failed test immediately after the failure. If this option is not specified, the tests are retried after Jest is finished running all test in a file.
+`retryImmediately` option is used to retry the failed test immediately after the failure. If this option is not specified, the tests are retried after Jest is finished running all test in a file.
 
 ```js
-jest.retryTimes(3, {immediately: true});
+jest.retryTimes(3, {retryImmediately: true});
 
 test('will fail', () => {
   expect(true).toBe(false);

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -1139,6 +1139,16 @@ test('will fail', () => {
 });
 ```
 
+`immediately` option is used to retry the failed test immediately.
+
+```js
+jest.retryTimes(3, {immediately: true});
+
+test('will fail', () => {
+  expect(true).toBe(false);
+});
+```
+
 Returns the `jest` object for chaining.
 
 :::caution

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -1139,7 +1139,7 @@ test('will fail', () => {
 });
 ```
 
-`retryImmediately` option is used to retry the failed test immediately after the failure. If this option is not specified, the tests are retried after Jest is finished running all test in a file.
+`retryImmediately` option is used to retry the failed test immediately after the failure. If this option is not specified, the tests are retried after Jest is finished running all other tests in the file.
 
 ```js
 jest.retryTimes(3, {retryImmediately: true});

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -1139,7 +1139,7 @@ test('will fail', () => {
 });
 ```
 
-`immediately` option is used to retry the failed test immediately.
+`immediately` option is used to retry the failed test immediately after the failure. If this option is not specified, the tests are retried after Jest is finished running all test in a file.
 
 ```js
 jest.retryTimes(3, {immediately: true});

--- a/e2e/__tests__/__snapshots__/testRetries.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testRetries.test.ts.snap
@@ -1,5 +1,44 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Test Retries immediately retry after failed test 1`] = `
+"LOGGING RETRY ERRORS  retryTimes set
+ RETRY 1 
+
+    expect(received).toBeFalsy()
+
+    Received: true
+
+      15 |     expect(true).toBeTruthy();
+      16 |   } else {
+    > 17 |     expect(true).toBeFalsy();
+         |                  ^
+      18 |   }
+      19 | });
+      20 | it('truthy test', () => {
+
+      at Object.toBeFalsy (__tests__/immediatelyRetry.test.js:17:18)
+
+ RETRY 2 
+
+    expect(received).toBeFalsy()
+
+    Received: true
+
+      15 |     expect(true).toBeTruthy();
+      16 |   } else {
+    > 17 |     expect(true).toBeFalsy();
+         |                  ^
+      18 |   }
+      19 | });
+      20 | it('truthy test', () => {
+
+      at Object.toBeFalsy (__tests__/immediatelyRetry.test.js:17:18)
+
+PASS __tests__/immediatelyRetry.test.js
+  ✓ retryTimes set
+  ✓ truthy test"
+`;
+
 exports[`Test Retries logs error(s) before retry 1`] = `
 "LOGGING RETRY ERRORS  retryTimes set
  RETRY 1 

--- a/e2e/__tests__/__snapshots__/testRetries.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testRetries.test.ts.snap
@@ -1,44 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Test Retries immediately retry after failed test 1`] = `
-"LOGGING RETRY ERRORS  retryTimes set
- RETRY 1 
-
-    expect(received).toBeFalsy()
-
-    Received: true
-
-      15 |     expect(true).toBeTruthy();
-      16 |   } else {
-    > 17 |     expect(true).toBeFalsy();
-         |                  ^
-      18 |   }
-      19 | });
-      20 | it('truthy test', () => {
-
-      at Object.toBeFalsy (__tests__/immediatelyRetry.test.js:17:18)
-
- RETRY 2 
-
-    expect(received).toBeFalsy()
-
-    Received: true
-
-      15 |     expect(true).toBeTruthy();
-      16 |   } else {
-    > 17 |     expect(true).toBeFalsy();
-         |                  ^
-      18 |   }
-      19 | });
-      20 | it('truthy test', () => {
-
-      at Object.toBeFalsy (__tests__/immediatelyRetry.test.js:17:18)
-
-PASS __tests__/immediatelyRetry.test.js
-  ✓ retryTimes set
-  ✓ truthy test"
-`;
-
 exports[`Test Retries logs error(s) before retry 1`] = `
 "LOGGING RETRY ERRORS  retryTimes set
  RETRY 1 
@@ -151,4 +112,43 @@ exports[`Test Retries wait before retry with fake timers 1`] = `
 
 PASS __tests__/waitBeforeRetryFakeTimers.test.js
   ✓ retryTimes set with fake timers"
+`;
+
+exports[`Test Retries with flag retryImmediately retry immediately after failed test 1`] = `
+"LOGGING RETRY ERRORS  retryTimes set
+ RETRY 1 
+
+    expect(received).toBeFalsy()
+
+    Received: true
+
+      15 |     expect(true).toBeTruthy();
+      16 |   } else {
+    > 17 |     expect(true).toBeFalsy();
+         |                  ^
+      18 |   }
+      19 | });
+      20 | it('truthy test', () => {
+
+      at Object.toBeFalsy (__tests__/retryImmediately.test.js:17:18)
+
+ RETRY 2 
+
+    expect(received).toBeFalsy()
+
+    Received: true
+
+      15 |     expect(true).toBeTruthy();
+      16 |   } else {
+    > 17 |     expect(true).toBeFalsy();
+         |                  ^
+      18 |   }
+      19 | });
+      20 | it('truthy test', () => {
+
+      at Object.toBeFalsy (__tests__/retryImmediately.test.js:17:18)
+
+PASS __tests__/retryImmediately.test.js
+  ✓ retryTimes set
+  ✓ truthy test"
 `;

--- a/e2e/__tests__/testRetries.test.ts
+++ b/e2e/__tests__/testRetries.test.ts
@@ -60,18 +60,18 @@ describe('Test Retries', () => {
     expect(extractSummary(result.stderr).rest).toMatchSnapshot();
   });
 
-  it('immediately retry after failed test', () => {
+  it('with flag retryImmediately retry immediately after failed test', () => {
     const logMessage = `console.log
     FIRST TRUTHY TEST
 
-      at Object.log (__tests__/immediatelyRetry.test.js:14:13)
+      at Object.log (__tests__/retryImmediately.test.js:14:13)
 
   console.log
     SECOND TRUTHY TEST
 
-      at Object.log (__tests__/immediatelyRetry.test.js:21:11)`;
+      at Object.log (__tests__/retryImmediately.test.js:21:11)`;
 
-    const result = runJest('test-retries', ['immediatelyRetry.test.js']);
+    const result = runJest('test-retries', ['retryImmediately.test.js']);
     const stdout = result.stdout.trim();
     expect(result.exitCode).toBe(0);
     expect(result.failed).toBe(false);

--- a/e2e/__tests__/testRetries.test.ts
+++ b/e2e/__tests__/testRetries.test.ts
@@ -60,6 +60,26 @@ describe('Test Retries', () => {
     expect(extractSummary(result.stderr).rest).toMatchSnapshot();
   });
 
+  it('immediately retry after failed test', () => {
+    const logMessage = `console.log
+    FIRST TRUTHY TEST
+
+      at Object.log (__tests__/immediatelyRetry.test.js:14:13)
+
+  console.log
+    SECOND TRUTHY TEST
+
+      at Object.log (__tests__/immediatelyRetry.test.js:21:11)`;
+
+    const result = runJest('test-retries', ['immediatelyRetry.test.js']);
+    const stdout = result.stdout.trim();
+    expect(result.exitCode).toBe(0);
+    expect(result.failed).toBe(false);
+    expect(result.stderr).toContain(logErrorsBeforeRetryErrorMessage);
+    expect(stdout).toBe(logMessage);
+    expect(extractSummary(result.stderr).rest).toMatchSnapshot();
+  });
+
   it('reporter shows more than 1 invocation if test is retried', () => {
     let jsonResult;
 

--- a/e2e/test-retries/__tests__/immediatelyRetry.test.js
+++ b/e2e/test-retries/__tests__/immediatelyRetry.test.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+jest.retryTimes(3, {immediately: true, logErrorsBeforeRetry: true});
+let i = 0;
+it('retryTimes set', () => {
+  i++;
+  if (i === 3) {
+    console.log('FIRST TRUTHY TEST');
+    expect(true).toBeTruthy();
+  } else {
+    expect(true).toBeFalsy();
+  }
+});
+it('truthy test', () => {
+  console.log('SECOND TRUTHY TEST');
+  expect(true).toBeTruthy();
+});

--- a/e2e/test-retries/__tests__/retryImmediately.test.js
+++ b/e2e/test-retries/__tests__/retryImmediately.test.js
@@ -6,7 +6,7 @@
  */
 'use strict';
 
-jest.retryTimes(3, {immediately: true, logErrorsBeforeRetry: true});
+jest.retryTimes(3, {logErrorsBeforeRetry: true, retryImmediately: true});
 let i = 0;
 it('retryTimes set', () => {
   i++;

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -15,7 +15,7 @@ import shuffleArray, {
   rngBuilder,
 } from './shuffleArray';
 import {dispatch, getState} from './state';
-import {IMMEDIATELY, RETRY_TIMES, WAIT_BEFORE_RETRY} from './types';
+import {RETRY_IMMEDIATELY, RETRY_TIMES, WAIT_BEFORE_RETRY} from './types';
 import {
   callAsyncCircusFn,
   getAllHooksForDescribe,
@@ -81,7 +81,7 @@ const _runTestsForDescribeBlock = async (
 
   const retryImmediately: boolean =
     // eslint-disable-next-line no-restricted-globals
-    ((global as Global.Global)[IMMEDIATELY] as any) || false;
+    ((global as Global.Global)[RETRY_IMMEDIATELY] as any) || false;
 
   const deferredRetryTests = [];
 

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -78,6 +78,7 @@ const _runTestsForDescribeBlock = async (
       (global as Global.Global)[WAIT_BEFORE_RETRY] as string,
       10,
     ) || 0;
+
   const retryImmediately: boolean =
     // eslint-disable-next-line no-restricted-globals
     ((global as Global.Global)[IMMEDIATELY] as any) || false;

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -116,7 +116,7 @@ const _runTestsForDescribeBlock = async (
         const hasRetryTimes = retryTimes > 0;
         await _runTest(child, isSkipped);
 
-        //If immediate retry is set, we retry the test immediately after the first run
+        // If immediate retry is set, we retry the test immediately after the first run
         if (
           retryImmediately &&
           hasErrorsBeforeTestRun === false &&

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -15,7 +15,7 @@ import shuffleArray, {
   rngBuilder,
 } from './shuffleArray';
 import {dispatch, getState} from './state';
-import {RETRY_TIMES, WAIT_BEFORE_RETRY} from './types';
+import {IMMEDIATELY, RETRY_TIMES, WAIT_BEFORE_RETRY} from './types';
 import {
   callAsyncCircusFn,
   getAllHooksForDescribe,
@@ -78,35 +78,17 @@ const _runTestsForDescribeBlock = async (
       (global as Global.Global)[WAIT_BEFORE_RETRY] as string,
       10,
     ) || 0;
+  const retryImmediately: boolean =
+    // eslint-disable-next-line no-restricted-globals
+    ((global as Global.Global)[IMMEDIATELY] as any) || false;
+
   const deferredRetryTests = [];
 
   if (rng) {
     describeBlock.children = shuffleArray(describeBlock.children, rng);
   }
-  for (const child of describeBlock.children) {
-    switch (child.type) {
-      case 'describeBlock': {
-        await _runTestsForDescribeBlock(child, rng);
-        break;
-      }
-      case 'test': {
-        const hasErrorsBeforeTestRun = child.errors.length > 0;
-        await _runTest(child, isSkipped);
 
-        if (
-          hasErrorsBeforeTestRun === false &&
-          retryTimes > 0 &&
-          child.errors.length > 0
-        ) {
-          deferredRetryTests.push(child);
-        }
-        break;
-      }
-    }
-  }
-
-  // Re-run failed tests n-times if configured
-  for (const test of deferredRetryTests) {
+  const rerunTest = async (test: Circus.TestEntry) => {
     let numRetriesAvailable = retryTimes;
 
     while (numRetriesAvailable > 0 && test.errors.length > 0) {
@@ -120,6 +102,43 @@ const _runTestsForDescribeBlock = async (
       await _runTest(test, isSkipped);
       numRetriesAvailable--;
     }
+  };
+
+  for (const child of describeBlock.children) {
+    switch (child.type) {
+      case 'describeBlock': {
+        await _runTestsForDescribeBlock(child, rng);
+        break;
+      }
+      case 'test': {
+        const hasErrorsBeforeTestRun = child.errors.length > 0;
+        const hasRetryTimes = retryTimes > 0;
+        await _runTest(child, isSkipped);
+
+        //If immediate retry is set, we retry the test immediately after the first run
+        if (
+          retryImmediately &&
+          hasErrorsBeforeTestRun === false &&
+          hasRetryTimes
+        ) {
+          await rerunTest(child);
+        }
+
+        if (
+          hasErrorsBeforeTestRun === false &&
+          hasRetryTimes &&
+          !retryImmediately
+        ) {
+          deferredRetryTests.push(child);
+        }
+        break;
+      }
+    }
+  }
+
+  // Re-run failed tests n-times if configured
+  for (const test of deferredRetryTests) {
+    await rerunTest(test);
   }
 
   if (!isSkipped) {

--- a/packages/jest-circus/src/types.ts
+++ b/packages/jest-circus/src/types.ts
@@ -7,7 +7,7 @@
 
 export const STATE_SYM = Symbol('JEST_STATE_SYMBOL');
 export const RETRY_TIMES = Symbol.for('RETRY_TIMES');
-export const IMMEDIATELY = Symbol.for('IMMEDIATELY');
+export const RETRY_IMMEDIATELY = Symbol.for('RETRY_IMMEDIATELY');
 export const WAIT_BEFORE_RETRY = Symbol.for('WAIT_BEFORE_RETRY');
 // To pass this value from Runtime object to state we need to use global[sym]
 export const TEST_TIMEOUT_SYMBOL = Symbol.for('TEST_TIMEOUT_SYMBOL');

--- a/packages/jest-circus/src/types.ts
+++ b/packages/jest-circus/src/types.ts
@@ -7,6 +7,7 @@
 
 export const STATE_SYM = Symbol('JEST_STATE_SYMBOL');
 export const RETRY_TIMES = Symbol.for('RETRY_TIMES');
+export const IMMEDIATELY = Symbol.for('IMMEDIATELY');
 export const WAIT_BEFORE_RETRY = Symbol.for('WAIT_BEFORE_RETRY');
 // To pass this value from Runtime object to state we need to use global[sym]
 export const TEST_TIMEOUT_SYMBOL = Symbol.for('TEST_TIMEOUT_SYMBOL');

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -309,9 +309,9 @@ export interface Jest {
   retryTimes(
     numRetries: number,
     options?: {
+      immediately?: boolean;
       logErrorsBeforeRetry?: boolean;
       waitBeforeRetry?: number;
-      immediately?: boolean;
     },
   ): Jest;
   /**

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -300,7 +300,7 @@ export interface Jest {
    *
    * `waitBeforeRetry` is the number of milliseconds to wait before retrying
    *
-   * `immediately` is the flag to retry the failed tests immediately after
+   * `retryImmediately` is the flag to retry the failed test immediately after
    *  failure
    *
    * @remarks
@@ -309,8 +309,8 @@ export interface Jest {
   retryTimes(
     numRetries: number,
     options?: {
-      immediately?: boolean;
       logErrorsBeforeRetry?: boolean;
+      retryImmediately?: boolean;
       waitBeforeRetry?: number;
     },
   ): Jest;

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -300,12 +300,19 @@ export interface Jest {
    *
    * `waitBeforeRetry` is the number of milliseconds to wait before retrying
    *
+   * `immediately` is the flag to retry the failed tests immediately after
+   *  failure
+   *
    * @remarks
    * Only available with `jest-circus` runner.
    */
   retryTimes(
     numRetries: number,
-    options?: {logErrorsBeforeRetry?: boolean; waitBeforeRetry?: number},
+    options?: {
+      logErrorsBeforeRetry?: boolean;
+      waitBeforeRetry?: number;
+      immediately?: boolean;
+    },
   ): Jest;
   /**
    * Exhausts tasks queued by `setImmediate()`.

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -123,7 +123,7 @@ type ResolveOptions = Parameters<typeof require.resolve>[1] & {
 const testTimeoutSymbol = Symbol.for('TEST_TIMEOUT_SYMBOL');
 const retryTimesSymbol = Symbol.for('RETRY_TIMES');
 const waitBeforeRetrySymbol = Symbol.for('WAIT_BEFORE_RETRY');
-const immediatelySybmbol = Symbol.for('IMMEDIATELY');
+const retryImmediatelySybmbol = Symbol.for('RETRY_IMMEDIATELY');
 const logErrorsBeforeRetrySymbol = Symbol.for('LOG_ERRORS_BEFORE_RETRY');
 
 const NODE_MODULES = `${path.sep}node_modules${path.sep}`;
@@ -2293,7 +2293,8 @@ export default class Runtime {
         options?.logErrorsBeforeRetry;
       this._environment.global[waitBeforeRetrySymbol] =
         options?.waitBeforeRetry;
-      this._environment.global[immediatelySybmbol] = options?.immediately;
+      this._environment.global[retryImmediatelySybmbol] =
+        options?.retryImmediately;
 
       return jestObject;
     };

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -123,6 +123,7 @@ type ResolveOptions = Parameters<typeof require.resolve>[1] & {
 const testTimeoutSymbol = Symbol.for('TEST_TIMEOUT_SYMBOL');
 const retryTimesSymbol = Symbol.for('RETRY_TIMES');
 const waitBeforeRetrySymbol = Symbol.for('WAIT_BEFORE_RETRY');
+const immediatelySybmbol = Symbol.for('IMMEDIATELY');
 const logErrorsBeforeRetrySymbol = Symbol.for('LOG_ERRORS_BEFORE_RETRY');
 
 const NODE_MODULES = `${path.sep}node_modules${path.sep}`;
@@ -2292,6 +2293,7 @@ export default class Runtime {
         options?.logErrorsBeforeRetry;
       this._environment.global[waitBeforeRetrySymbol] =
         options?.waitBeforeRetry;
+      this._environment.global[immediatelySybmbol] = options?.immediately;
 
       return jestObject;
     };

--- a/packages/jest-types/__typetests__/jest.test.ts
+++ b/packages/jest-types/__typetests__/jest.test.ts
@@ -667,9 +667,11 @@ expect(jest.retryTimes(3, {logErrorsBeforeRetry: 'all'})).type.toRaiseError();
 expect(jest.retryTimes({logErrorsBeforeRetry: true})).type.toRaiseError();
 expect(jest.retryTimes(3, {waitBeforeRetry: 1000})).type.toEqual<typeof jest>();
 expect(jest.retryTimes(3, {waitBeforeRetry: true})).type.toRaiseError();
-expect(jest.retryTimes(3, {immediately: true})).type.toEqual<typeof jest>();
-expect(jest.retryTimes(3, {immediately: 'now'})).type.toRaiseError();
-expect(jest.retryTimes(3, {immediately: 1000})).type.toRaiseError();
+expect(jest.retryTimes(3, {retryImmediately: true})).type.toEqual<
+  typeof jest
+>();
+expect(jest.retryTimes(3, {retryImmediately: 'now'})).type.toRaiseError();
+expect(jest.retryTimes(3, {retryImmediately: 1000})).type.toRaiseError();
 expect(jest.retryTimes({logErrorsBeforeRetry: 'all'})).type.toRaiseError();
 expect(jest.retryTimes()).type.toRaiseError();
 

--- a/packages/jest-types/__typetests__/jest.test.ts
+++ b/packages/jest-types/__typetests__/jest.test.ts
@@ -667,6 +667,9 @@ expect(jest.retryTimes(3, {logErrorsBeforeRetry: 'all'})).type.toRaiseError();
 expect(jest.retryTimes({logErrorsBeforeRetry: true})).type.toRaiseError();
 expect(jest.retryTimes(3, {waitBeforeRetry: 1000})).type.toEqual<typeof jest>();
 expect(jest.retryTimes(3, {waitBeforeRetry: true})).type.toRaiseError();
+expect(jest.retryTimes(3, {immediately: true})).type.toEqual<typeof jest>();
+expect(jest.retryTimes(3, {immediately: 'now'})).type.toRaiseError();
+expect(jest.retryTimes(3, {immediately: 1000})).type.toRaiseError();
 expect(jest.retryTimes({logErrorsBeforeRetry: 'all'})).type.toRaiseError();
 expect(jest.retryTimes()).type.toRaiseError();
 


### PR DESCRIPTION
## Summary

Fixes #14696 Added a new property `immediately` to `jest.retryTimes`

## Test plan

I haven't found a smarter way than using console.log to check the order of test runs.