### PR TITLE
chore: migrate type tests of `@jest/reporters` to TSTyche

### DIFF
--- a/jest.config.ts.mjs
+++ b/jest.config.ts.mjs
@@ -28,7 +28,6 @@ export default {
       roots: ['<rootDir>/packages'],
       runner: 'jest-runner-tsd',
       testMatch: [
-        '**/packages/jest-reporters/__typetests__/jest-reporters.test.ts',
         '**/packages/jest-resolve/__typetests__/resolver.test.ts',
         '**/packages/jest-types/__typetests__/each.test.ts',
       ],

--- a/packages/jest-reporters/__typetests__/jest-reporters.test.ts
+++ b/packages/jest-reporters/__typetests__/jest-reporters.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {expectError, expectType} from 'tsd-lite';
+import {expect} from 'tstyche';
 import {
   type AggregatedResult,
   type Config,
@@ -25,73 +25,89 @@ declare const testResult: TestResult;
 
 // utils.formatTestPath()
 
-expectType<string>(utils.formatTestPath(globalConfig, 'some/path'));
-expectType<string>(utils.formatTestPath(projectConfig, 'some/path'));
-expectError(utils.formatTestPath());
-expectError(utils.formatTestPath({}, 'some/path'));
-expectError(utils.formatTestPath(globalConfig, 123));
-expectError(utils.formatTestPath(projectConfig, 123));
+expect(utils.formatTestPath(globalConfig, 'some/path')).type.toBeString();
+expect(utils.formatTestPath(projectConfig, 'some/path')).type.toBeString();
+expect(utils.formatTestPath()).type.toRaiseError();
+expect(utils.formatTestPath({}, 'some/path')).type.toRaiseError();
+expect(utils.formatTestPath(globalConfig, 123)).type.toRaiseError();
+expect(utils.formatTestPath(projectConfig, 123)).type.toRaiseError();
 
 // utils.getResultHeader()
 
-expectType<string>(
+expect(
   utils.getResultHeader(testResult, globalConfig, projectConfig),
-);
-expectType<string>(utils.getResultHeader(testResult, globalConfig));
-expectError(utils.getResultHeader());
-expectError(utils.getResultHeader({}, globalConfig));
-expectError(utils.getResultHeader({}, globalConfig, projectConfig));
-expectError(utils.getResultHeader(testResult, {}));
-expectError(utils.getResultHeader(testResult, globalConfig, {}));
+).type.toBeString();
+expect(utils.getResultHeader(testResult, globalConfig)).type.toBeString();
+expect(utils.getResultHeader()).type.toRaiseError();
+expect(utils.getResultHeader({}, globalConfig)).type.toRaiseError();
+expect(
+  utils.getResultHeader({}, globalConfig, projectConfig),
+).type.toRaiseError();
+expect(utils.getResultHeader(testResult, {})).type.toRaiseError();
+expect(utils.getResultHeader(testResult, globalConfig, {})).type.toRaiseError();
 
 // utils.getSnapshotStatus()
 
-expectType<Array<string>>(utils.getSnapshotStatus(snapshot, true));
-expectError(utils.getSnapshotStatus());
-expectError(utils.getSnapshotStatus({}, true));
-expectError(utils.getSnapshotStatus(snapshot, 123));
+expect(utils.getSnapshotStatus(snapshot, true)).type.toEqual<Array<string>>();
+expect(utils.getSnapshotStatus()).type.toRaiseError();
+expect(utils.getSnapshotStatus({}, true)).type.toRaiseError();
+expect(utils.getSnapshotStatus(snapshot, 123)).type.toRaiseError();
 
 // utils.getSnapshotSummary()
 
-expectType<Array<string>>(
+expect(
   utils.getSnapshotSummary(snapshotSummary, globalConfig, 'press `u`'),
-);
-expectError(utils.getSnapshotSummary());
-expectError(utils.getSnapshotSummary({}, globalConfig, 'press `u`'));
-expectError(utils.getSnapshotSummary(snapshotSummary, {}, 'press `u`'));
-expectError(utils.getSnapshotSummary(snapshotSummary, globalConfig, true));
+).type.toEqual<Array<string>>();
+expect(utils.getSnapshotSummary()).type.toRaiseError();
+expect(
+  utils.getSnapshotSummary({}, globalConfig, 'press `u`'),
+).type.toRaiseError();
+expect(
+  utils.getSnapshotSummary(snapshotSummary, {}, 'press `u`'),
+).type.toRaiseError();
+expect(
+  utils.getSnapshotSummary(snapshotSummary, globalConfig, true),
+).type.toRaiseError();
 
 // utils.getSummary()
 
-expectType<string>(utils.getSummary(aggregatedResults, summaryOptions));
-expectType<string>(utils.getSummary(aggregatedResults));
-expectError(utils.getSummary());
-expectError(utils.getSummary({}));
-expectError(utils.getSummary(aggregatedResults, true));
+expect(utils.getSummary(aggregatedResults, summaryOptions)).type.toBeString();
+expect(utils.getSummary(aggregatedResults)).type.toBeString();
+expect(utils.getSummary()).type.toRaiseError();
+expect(utils.getSummary({})).type.toRaiseError();
+expect(utils.getSummary(aggregatedResults, true)).type.toRaiseError();
 
 // utils.printDisplayName()
 
-expectType<string>(utils.printDisplayName(projectConfig));
-expectError(utils.printDisplayName());
-expectError(utils.printDisplayName({}));
+expect(utils.printDisplayName(projectConfig)).type.toBeString();
+expect(utils.printDisplayName()).type.toRaiseError();
+expect(utils.printDisplayName({})).type.toRaiseError();
 
 // utils.relativePath()
 
-expectType<{basename: string; dirname: string}>(
-  utils.relativePath(globalConfig, 'some/path'),
-);
-expectType<{basename: string; dirname: string}>(
-  utils.relativePath(projectConfig, 'some/path'),
-);
-expectError(utils.relativePath());
-expectError(utils.relativePath({}, 'some/path'));
-expectError(utils.relativePath(projectConfig, true));
+expect(utils.relativePath(globalConfig, 'some/path')).type.toEqual<{
+  basename: string;
+  dirname: string;
+}>();
+expect(utils.relativePath(projectConfig, 'some/path')).type.toEqual<{
+  basename: string;
+  dirname: string;
+}>();
+expect(utils.relativePath()).type.toRaiseError();
+expect(utils.relativePath({}, 'some/path')).type.toRaiseError();
+expect(utils.relativePath(projectConfig, true)).type.toRaiseError();
 
 // utils.trimAndFormatPath()
 
-expectType<string>(utils.trimAndFormatPath(2, globalConfig, 'some/path', 4));
-expectError(utils.trimAndFormatPath());
-expectError(utils.trimAndFormatPath(true, globalConfig, 'some/path', 4));
-expectError(utils.trimAndFormatPath(2, {}, 'some/path', 4));
-expectError(utils.trimAndFormatPath(2, globalConfig, true, 4));
-expectError(utils.trimAndFormatPath(2, globalConfig, 'some/path', '4'));
+expect(
+  utils.trimAndFormatPath(2, globalConfig, 'some/path', 4),
+).type.toBeString();
+expect(utils.trimAndFormatPath()).type.toRaiseError();
+expect(
+  utils.trimAndFormatPath(true, globalConfig, 'some/path', 4),
+).type.toRaiseError();
+expect(utils.trimAndFormatPath(2, {}, 'some/path', 4)).type.toRaiseError();
+expect(utils.trimAndFormatPath(2, globalConfig, true, 4)).type.toRaiseError();
+expect(
+  utils.trimAndFormatPath(2, globalConfig, 'some/path', '4'),
+).type.toRaiseError();

--- a/tstyche.config.json
+++ b/tstyche.config.json
@@ -6,6 +6,7 @@
     "packages/jest-cli/__typetests__/*.test.ts",
     "packages/jest-expect/__typetests__/*.test.ts",
     "packages/jest-mock/__typetests__/*.test.ts",
+    "packages/jest-reporters/__typetests__/*.test.ts",
     "packages/jest-runner/__typetests__/*.test.ts",
     "packages/jest-snapshot/__typetests__/*.test.ts",
     "packages/jest-types/__typetests__/config.test.ts",


### PR DESCRIPTION
## Summary

This PR migrates type tests of `@jest/reporters` to TSTyche.

## Test plan

Green CI.