### PR TITLE
docs: update upgrade to jest28 url to point to archive url

### DIFF
--- a/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
+++ b/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
@@ -417,7 +417,7 @@ exports[`ScriptTransformer throws an error if \`process\` doesn't return an obje
 <red>  should return an object or a Promise resolving to an object. The object </color>
 <red>  must have \`code\` property with a string of processed code.</color>
 <red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
-<red>  https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer</color>
+<red>  https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28#transformer</color>
 <red>  <bold>Code Transformation Documentation:</intensity></color>
 <red>  https://jestjs.io/docs/code-transformation</color>
 <red></color>"
@@ -430,7 +430,7 @@ exports[`ScriptTransformer throws an error if \`process\` doesn't return an obje
 <red>  should return an object or a Promise resolving to an object. The object </color>
 <red>  must have \`code\` property with a string of processed code.</color>
 <red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
-<red>  https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer</color>
+<red>  https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28#transformer</color>
 <red>  <bold>Code Transformation Documentation:</intensity></color>
 <red>  https://jestjs.io/docs/code-transformation</color>
 <red></color>"
@@ -443,7 +443,7 @@ exports[`ScriptTransformer throws an error if \`process\` doesn't return an obje
 <red>  should return an object or a Promise resolving to an object. The object </color>
 <red>  must have \`code\` property with a string of processed code.</color>
 <red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
-<red>  https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer</color>
+<red>  https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28#transformer</color>
 <red>  <bold>Code Transformation Documentation:</intensity></color>
 <red>  https://jestjs.io/docs/code-transformation</color>
 <red></color>"
@@ -456,7 +456,7 @@ exports[`ScriptTransformer throws an error if \`process\` doesn't return an obje
 <red>  should return an object or a Promise resolving to an object. The object </color>
 <red>  must have \`code\` property with a string of processed code.</color>
 <red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
-<red>  https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer</color>
+<red>  https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28#transformer</color>
 <red>  <bold>Code Transformation Documentation:</intensity></color>
 <red>  https://jestjs.io/docs/code-transformation</color>
 <red></color>"
@@ -469,7 +469,7 @@ exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a 
 <red>  should return an object or a Promise resolving to an object. The object </color>
 <red>  must have \`code\` property with a string of processed code.</color>
 <red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
-<red>  https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer</color>
+<red>  https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28#transformer</color>
 <red>  <bold>Code Transformation Documentation:</intensity></color>
 <red>  https://jestjs.io/docs/code-transformation</color>
 <red></color>"
@@ -482,7 +482,7 @@ exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a 
 <red>  should return an object or a Promise resolving to an object. The object </color>
 <red>  must have \`code\` property with a string of processed code.</color>
 <red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
-<red>  https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer</color>
+<red>  https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28#transformer</color>
 <red>  <bold>Code Transformation Documentation:</intensity></color>
 <red>  https://jestjs.io/docs/code-transformation</color>
 <red></color>"
@@ -495,7 +495,7 @@ exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a 
 <red>  should return an object or a Promise resolving to an object. The object </color>
 <red>  must have \`code\` property with a string of processed code.</color>
 <red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
-<red>  https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer</color>
+<red>  https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28#transformer</color>
 <red>  <bold>Code Transformation Documentation:</intensity></color>
 <red>  https://jestjs.io/docs/code-transformation</color>
 <red></color>"
@@ -508,7 +508,7 @@ exports[`ScriptTransformer throws an error if \`processAsync\` doesn't return a 
 <red>  should return an object or a Promise resolving to an object. The object </color>
 <red>  must have \`code\` property with a string of processed code.</color>
 <red>  <bold>This error may be caused by a breaking change in Jest 28:</intensity></color>
-<red>  https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer</color>
+<red>  https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28#transformer</color>
 <red>  <bold>Code Transformation Documentation:</intensity></color>
 <red>  https://jestjs.io/docs/code-transformation</color>
 <red></color>"

--- a/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
+++ b/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
@@ -17,7 +17,7 @@ const DOCUMENTATION_NOTE = `  ${chalk.bold(
 const UPGRADE_NOTE = `  ${chalk.bold(
   'This error may be caused by a breaking change in Jest 28:',
 )}
-  https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer
+  https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28#transformer
 `;
 
 export const makeInvalidReturnValueError = (transformPath: string): string =>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Existing error message relating to breaking changes in Jest 28 contains a link to the "Upgrading to Jest 28" docs page. This link currently points to a 404 page. This updates the link to the archived docs page.

Current link: https://jestjs.io/docs/28.x/upgrading-to-jest28#transformer
New link: https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28#transformer

## Test plan

I have a local test that was reproducing this error message. Attached screen recording shows the current error messaging and link, first. Then, I rerun the failing test using my locally compiled Jest from the PR, showing the corrected URL.

![CleanShot 2024-03-21 at 21 49 13](https://github.com/jestjs/jest/assets/1494297/741670a2-ffd3-45be-86f4-536139e4b38f)
