### PR TITLE
feat: Add DEC mode 2026 support (Synchronized Output) to Jest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[@jest/fake-timers]` Exposing new modern timers function `advanceTimersToFrame()` which advances all timers by the needed milliseconds to execute callbacks currently scheduled with `requestAnimationFrame` ([#14598](https://github.com/jestjs/jest/pull/14598))
 - `[jest-matcher-utils]` Add `SERIALIZABLE_PROPERTIES` to allow custom serialization of objects ([#14893](https://github.com/jestjs/jest/pull/14893))
 - `[jest-mock]` Add support for the Explicit Resource Management proposal to use the `using` keyword with `jest.spyOn(object, methodName)` ([#14895](https://github.com/jestjs/jest/pull/14895))
+- `[jest-reporters]` Add support for [DEC mode 2026](https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036)
 - `[jest-runtime]` Exposing new modern timers function `jest.advanceTimersToFrame()` from `@jest/fake-timers` ([#14598](https://github.com/jestjs/jest/pull/14598))
 - `[jest-runtime]` Support `import.meta.filename` and `import.meta.dirname` (available from [Node 20.11](https://nodejs.org/en/blog/release/v20.11.0)) ([#14854](https://github.com/jestjs/jest/pull/14854))
 - `[jest-runtime]` Support `import.meta.resolve` ([#14930](https://github.com/jestjs/jest/pull/14930))
@@ -31,7 +32,6 @@
 - `[jest-snapshot]` [**BREAKING**] Add support for [Error causes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) in snapshots ([#13965](https://github.com/facebook/jest/pull/13965))
 - `[jest-snapshot]` Support Prettier 3 ([#14566](https://github.com/facebook/jest/pull/14566))
 - `[pretty-format]` [**BREAKING**] Do not render empty string children (`''`) in React plugin ([#14470](https://github.com/facebook/jest/pull/14470))
-- `[jest-reporters]` Add support for [DEC mode 2026](https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[jest-snapshot]` [**BREAKING**] Add support for [Error causes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/cause) in snapshots ([#13965](https://github.com/facebook/jest/pull/13965))
 - `[jest-snapshot]` Support Prettier 3 ([#14566](https://github.com/facebook/jest/pull/14566))
 - `[pretty-format]` [**BREAKING**] Do not render empty string children (`''`) in React plugin ([#14470](https://github.com/facebook/jest/pull/14470))
+- `[jest-reporters]` Add support for [DEC mode 2026](https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036)
 
 ### Fixes
 

--- a/packages/jest-reporters/src/BaseReporter.ts
+++ b/packages/jest-reporters/src/BaseReporter.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {WriteStream} from 'tty';
 import type {
   AggregatedResult,
   Test,
@@ -12,7 +13,7 @@ import type {
   TestContext,
   TestResult,
 } from '@jest/test-result';
-import {preRunMessage} from 'jest-util';
+import {isInteractive, preRunMessage} from 'jest-util';
 import type {Reporter, ReporterOnStartOptions} from './types';
 
 const {remove: preRunMessageRemove} = preRunMessage;
@@ -56,5 +57,17 @@ export default class BaseReporter implements Reporter {
   // define whether the test run was successful or failed.
   getLastError(): Error | undefined {
     return this._error;
+  }
+
+  protected __beginSynchronizedUpdate(write: WriteStream['write']): void {
+    if (isInteractive) {
+      write('\u001B[?2026h');
+    }
+  }
+
+  protected __endSynchronizedUpdate(write: WriteStream['write']): void {
+    if (isInteractive) {
+      write('\u001B[?2026l');
+    }
   }
 }

--- a/packages/jest-reporters/src/DefaultReporter.ts
+++ b/packages/jest-reporters/src/DefaultReporter.ts
@@ -5,263 +5,195 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {WriteStream} from 'tty';
-import chalk = require('chalk');
-import {getConsoleOutput} from '@jest/console';
-import type {
-  AggregatedResult,
-  Test,
-  TestCaseResult,
-  TestResult,
-} from '@jest/test-result';
-import type {Config} from '@jest/types';
-import {
-  formatStackTrace,
-  indentAllLines,
-  separateMessageFromStack,
-} from 'jest-message-util';
-import {clearLine, isInteractive} from 'jest-util';
-import BaseReporter from './BaseReporter';
-import Status from './Status';
-import getResultHeader from './getResultHeader';
-import getSnapshotStatus from './getSnapshotStatus';
-import type {ReporterOnStartOptions} from './types';
+import type { WriteStream } from "tty";
+import chalk = require("chalk");
+import { getConsoleOutput } from "@jest/console";
+import type { AggregatedResult, Test, TestCaseResult, TestResult } from "@jest/test-result";
+import type { Config } from "@jest/types";
+import { formatStackTrace, indentAllLines, separateMessageFromStack } from "jest-message-util";
+import { clearLine, isInteractive } from "jest-util";
+import BaseReporter from "./BaseReporter";
+import Status from "./Status";
+import getResultHeader from "./getResultHeader";
+import getSnapshotStatus from "./getSnapshotStatus";
+import type { ReporterOnStartOptions } from "./types";
 
-type write = WriteStream['write'];
+type write = WriteStream["write"];
 type FlushBufferedOutput = () => void;
 
-const TITLE_BULLET = chalk.bold('\u25CF ');
+const TITLE_BULLET = chalk.bold("\u25CF ");
 
 export default class DefaultReporter extends BaseReporter {
-  private _clear: string; // ANSI clear sequence for the last printed status
-  private readonly _err: write;
-  protected _globalConfig: Config.GlobalConfig;
-  private readonly _out: write;
-  private readonly _status: Status;
-  private readonly _bufferedOutput: Set<FlushBufferedOutput>;
+    private _clear: string; // ANSI clear sequence for the last printed status
+    private readonly _err: write;
+    protected _globalConfig: Config.GlobalConfig;
+    private readonly _out: write;
+    private readonly _status: Status;
+    private readonly _bufferedOutput: Set<FlushBufferedOutput>;
 
-  static readonly filename = __filename;
+    static readonly filename = __filename;
 
-  constructor(globalConfig: Config.GlobalConfig) {
-    super();
-    this._globalConfig = globalConfig;
-    this._clear = '';
-    this._out = process.stdout.write.bind(process.stdout);
-    this._err = process.stderr.write.bind(process.stderr);
-    this._status = new Status(globalConfig);
-    this._bufferedOutput = new Set();
-    this.__wrapStdio(process.stdout);
-    this.__wrapStdio(process.stderr);
-    this._status.onChange(() => {
-      this.__beginSynchronizedUpdate();
-      this.__clearStatus();
-      this.__printStatus();
-      this.__endSynchronizedUpdate();
-    });
-  }
+    constructor(globalConfig: Config.GlobalConfig) {
+        super();
+        this._globalConfig = globalConfig;
+        this._clear = "";
+        this._out = process.stdout.write.bind(process.stdout);
+        this._err = process.stderr.write.bind(process.stderr);
+        this._status = new Status(globalConfig);
+        this._bufferedOutput = new Set();
+        this.__wrapStdio(process.stdout);
+        this.__wrapStdio(process.stderr);
+        this._status.onChange(() => {
+            this.__beginSynchronizedUpdate(this._globalConfig.useStderr ? this._err : this._out);
+            this.__clearStatus();
+            this.__printStatus();
+            this.__endSynchronizedUpdate(this._globalConfig.useStderr ? this._err : this._out);
+        });
+    }
 
-  protected __wrapStdio(stream: NodeJS.WritableStream | WriteStream): void {
-    const write = stream.write.bind(stream);
+    protected __wrapStdio(stream: NodeJS.WritableStream | WriteStream): void {
+        const write = stream.write.bind(stream);
 
-    let buffer: Array<string> = [];
-    let timeout: NodeJS.Timeout | null = null;
+        let buffer: Array<string> = [];
+        let timeout: NodeJS.Timeout | null = null;
 
-    const flushBufferedOutput = () => {
-      const string = buffer.join('');
-      buffer = [];
+        const flushBufferedOutput = () => {
+            const string = buffer.join("");
+            buffer = [];
 
-      // This is to avoid conflicts between random output and status text
-      this.__beginSynchronizedUpdate();
-      this.__clearStatus();
-      if (string) {
-        write(string);
-      }
-      this.__printStatus();
-      this.__endSynchronizedUpdate();
+            // This is to avoid conflicts between random output and status text
+            this.__beginSynchronizedUpdate(this._globalConfig.useStderr ? this._err : this._out);
+            this.__clearStatus();
+            if (string) {
+                write(string);
+            }
+            this.__printStatus();
+            this.__endSynchronizedUpdate(this._globalConfig.useStderr ? this._err : this._out);
 
-      this._bufferedOutput.delete(flushBufferedOutput);
-    };
+            this._bufferedOutput.delete(flushBufferedOutput);
+        };
 
-    this._bufferedOutput.add(flushBufferedOutput);
+        this._bufferedOutput.add(flushBufferedOutput);
 
-    const debouncedFlush = () => {
-      // If the process blows up no errors would be printed.
-      // There should be a smart way to buffer stderr, but for now
-      // we just won't buffer it.
-      if (stream === process.stderr) {
-        flushBufferedOutput();
-      } else {
-        if (!timeout) {
-          timeout = setTimeout(() => {
+        const debouncedFlush = () => {
+            // If the process blows up no errors would be printed.
+            // There should be a smart way to buffer stderr, but for now
+            // we just won't buffer it.
+            if (stream === process.stderr) {
+                flushBufferedOutput();
+            } else {
+                if (!timeout) {
+                    timeout = setTimeout(() => {
+                        flushBufferedOutput();
+                        timeout = null;
+                    }, 100);
+                }
+            }
+        };
+
+        stream.write = (chunk: string) => {
+            buffer.push(chunk);
+            debouncedFlush();
+            return true;
+        };
+    }
+
+    // Don't wait for the debounced call and flush all output immediately.
+    forceFlushBufferedOutput(): void {
+        for (const flushBufferedOutput of this._bufferedOutput) {
             flushBufferedOutput();
-            timeout = null;
-          }, 100);
         }
-      }
-    };
-
-    stream.write = (chunk: string) => {
-      buffer.push(chunk);
-      debouncedFlush();
-      return true;
-    };
-  }
-
-  // Don't wait for the debounced call and flush all output immediately.
-  forceFlushBufferedOutput(): void {
-    for (const flushBufferedOutput of this._bufferedOutput) {
-      flushBufferedOutput();
     }
-  }
 
-  protected __clearStatus(): void {
-    if (isInteractive) {
-      if (this._globalConfig.useStderr) {
-        this._err(this._clear);
-      } else {
-        this._out(this._clear);
-      }
-    }
-  }
-
-  protected __beginSynchronizedUpdate(): void {
-    if (isInteractive) {
-      if (this._globalConfig.useStderr) {
-        this._err('\x1b[?2026h');
-      } else {
-        this._out('\x1b[?2026h');
-      }
-    }
-  }
-
-  protected __endSynchronizedUpdate(): void {
-    if (isInteractive) {
-      if (this._globalConfig.useStderr) {
-        this._err('\x1b[?2026l');
-      } else {
-        this._out('\x1b[?2026l');
-      }
-    }
-  }
-
-  protected __printStatus(): void {
-    const {content, clear} = this._status.get();
-    this._clear = clear;
-    if (isInteractive) {
-      if (this._globalConfig.useStderr) {
-        this._err(content);
-      } else {
-        this._out(content);
-      }
-    }
-  }
-
-  override onRunStart(
-    aggregatedResults: AggregatedResult,
-    options: ReporterOnStartOptions,
-  ): void {
-    this._status.runStarted(aggregatedResults, options);
-  }
-
-  override onTestStart(test: Test): void {
-    this._status.testStarted(test.path, test.context.config);
-  }
-
-  override onTestCaseResult(test: Test, testCaseResult: TestCaseResult): void {
-    this._status.addTestCaseResult(test, testCaseResult);
-  }
-
-  override onRunComplete(): void {
-    this.forceFlushBufferedOutput();
-    this._status.runFinished();
-    process.stdout.write = this._out;
-    process.stderr.write = this._err;
-    clearLine(process.stderr);
-  }
-
-  override onTestResult(
-    test: Test,
-    testResult: TestResult,
-    aggregatedResults: AggregatedResult,
-  ): void {
-    this.testFinished(test.context.config, testResult, aggregatedResults);
-    if (!testResult.skipped) {
-      this.printTestFileHeader(
-        testResult.testFilePath,
-        test.context.config,
-        testResult,
-      );
-      this.printTestFileFailureMessage(
-        testResult.testFilePath,
-        test.context.config,
-        testResult,
-      );
-    }
-    this.forceFlushBufferedOutput();
-  }
-
-  testFinished(
-    config: Config.ProjectConfig,
-    testResult: TestResult,
-    aggregatedResults: AggregatedResult,
-  ): void {
-    this._status.testFinished(config, testResult, aggregatedResults);
-  }
-
-  printTestFileHeader(
-    testPath: string,
-    config: Config.ProjectConfig,
-    result: TestResult,
-  ): void {
-    // log retry errors if any exist
-    for (const testResult of result.testResults) {
-      const testRetryReasons = testResult.retryReasons;
-      if (testRetryReasons && testRetryReasons.length > 0) {
-        this.log(
-          `${chalk.reset.inverse.bold.yellow(
-            ' LOGGING RETRY ERRORS ',
-          )} ${chalk.bold(testResult.fullName)}`,
-        );
-        for (const [index, retryReasons] of testRetryReasons.entries()) {
-          let {message, stack} = separateMessageFromStack(retryReasons);
-          stack = this._globalConfig.noStackTrace
-            ? ''
-            : chalk.dim(
-                formatStackTrace(stack, config, this._globalConfig, testPath),
-              );
-
-          message = indentAllLines(message);
-
-          this.log(
-            `${chalk.reset.inverse.bold.blueBright(` RETRY ${index + 1} `)}\n`,
-          );
-          this.log(`${message}\n${stack}\n`);
+    protected __clearStatus(): void {
+        if (isInteractive) {
+            if (this._globalConfig.useStderr) {
+                this._err(this._clear);
+            } else {
+                this._out(this._clear);
+            }
         }
-      }
     }
 
-    this.log(getResultHeader(result, this._globalConfig, config));
-    if (result.console) {
-      this.log(
-        `  ${TITLE_BULLET}Console\n\n${getConsoleOutput(
-          result.console,
-          config,
-          this._globalConfig,
-        )}`,
-      );
+    protected __printStatus(): void {
+        const { content, clear } = this._status.get();
+        this._clear = clear;
+        if (isInteractive) {
+            if (this._globalConfig.useStderr) {
+                this._err(content);
+            } else {
+                this._out(content);
+            }
+        }
     }
-  }
 
-  printTestFileFailureMessage(
-    _testPath: string,
-    _config: Config.ProjectConfig,
-    result: TestResult,
-  ): void {
-    if (result.failureMessage) {
-      this.log(result.failureMessage);
+    override onRunStart(aggregatedResults: AggregatedResult, options: ReporterOnStartOptions): void {
+        this._status.runStarted(aggregatedResults, options);
     }
-    const didUpdate = this._globalConfig.updateSnapshot === 'all';
-    const snapshotStatuses = getSnapshotStatus(result.snapshot, didUpdate);
-    for (const status of snapshotStatuses) this.log(status);
-  }
+
+    override onTestStart(test: Test): void {
+        this._status.testStarted(test.path, test.context.config);
+    }
+
+    override onTestCaseResult(test: Test, testCaseResult: TestCaseResult): void {
+        this._status.addTestCaseResult(test, testCaseResult);
+    }
+
+    override onRunComplete(): void {
+        this.forceFlushBufferedOutput();
+        this._status.runFinished();
+        process.stdout.write = this._out;
+        process.stderr.write = this._err;
+        clearLine(process.stderr);
+    }
+
+    override onTestResult(test: Test, testResult: TestResult, aggregatedResults: AggregatedResult): void {
+        this.testFinished(test.context.config, testResult, aggregatedResults);
+        if (!testResult.skipped) {
+            this.printTestFileHeader(testResult.testFilePath, test.context.config, testResult);
+            this.printTestFileFailureMessage(testResult.testFilePath, test.context.config, testResult);
+        }
+        this.forceFlushBufferedOutput();
+    }
+
+    testFinished(config: Config.ProjectConfig, testResult: TestResult, aggregatedResults: AggregatedResult): void {
+        this._status.testFinished(config, testResult, aggregatedResults);
+    }
+
+    printTestFileHeader(testPath: string, config: Config.ProjectConfig, result: TestResult): void {
+        // log retry errors if any exist
+        for (const testResult of result.testResults) {
+            const testRetryReasons = testResult.retryReasons;
+            if (testRetryReasons && testRetryReasons.length > 0) {
+                this.log(
+                    `${chalk.reset.inverse.bold.yellow(" LOGGING RETRY ERRORS ")} ${chalk.bold(testResult.fullName)}`,
+                );
+                for (const [index, retryReasons] of testRetryReasons.entries()) {
+                    let { message, stack } = separateMessageFromStack(retryReasons);
+                    stack = this._globalConfig.noStackTrace
+                        ? ""
+                        : chalk.dim(formatStackTrace(stack, config, this._globalConfig, testPath));
+
+                    message = indentAllLines(message);
+
+                    this.log(`${chalk.reset.inverse.bold.blueBright(` RETRY ${index + 1} `)}\n`);
+                    this.log(`${message}\n${stack}\n`);
+                }
+            }
+        }
+
+        this.log(getResultHeader(result, this._globalConfig, config));
+        if (result.console) {
+            this.log(`  ${TITLE_BULLET}Console\n\n${getConsoleOutput(result.console, config, this._globalConfig)}`);
+        }
+    }
+
+    printTestFileFailureMessage(_testPath: string, _config: Config.ProjectConfig, result: TestResult): void {
+        if (result.failureMessage) {
+            this.log(result.failureMessage);
+        }
+        const didUpdate = this._globalConfig.updateSnapshot === "all";
+        const snapshotStatuses = getSnapshotStatus(result.snapshot, didUpdate);
+        for (const status of snapshotStatuses) this.log(status);
+    }
 }

--- a/packages/jest-reporters/src/DefaultReporter.ts
+++ b/packages/jest-reporters/src/DefaultReporter.ts
@@ -5,195 +5,245 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type { WriteStream } from "tty";
-import chalk = require("chalk");
-import { getConsoleOutput } from "@jest/console";
-import type { AggregatedResult, Test, TestCaseResult, TestResult } from "@jest/test-result";
-import type { Config } from "@jest/types";
-import { formatStackTrace, indentAllLines, separateMessageFromStack } from "jest-message-util";
-import { clearLine, isInteractive } from "jest-util";
-import BaseReporter from "./BaseReporter";
-import Status from "./Status";
-import getResultHeader from "./getResultHeader";
-import getSnapshotStatus from "./getSnapshotStatus";
-import type { ReporterOnStartOptions } from "./types";
+import type {WriteStream} from 'tty';
+import chalk = require('chalk');
+import {getConsoleOutput} from '@jest/console';
+import type {
+  AggregatedResult,
+  Test,
+  TestCaseResult,
+  TestResult,
+} from '@jest/test-result';
+import type {Config} from '@jest/types';
+import {
+  formatStackTrace,
+  indentAllLines,
+  separateMessageFromStack,
+} from 'jest-message-util';
+import {clearLine, isInteractive} from 'jest-util';
+import BaseReporter from './BaseReporter';
+import Status from './Status';
+import getResultHeader from './getResultHeader';
+import getSnapshotStatus from './getSnapshotStatus';
+import type {ReporterOnStartOptions} from './types';
 
-type write = WriteStream["write"];
+type write = WriteStream['write'];
 type FlushBufferedOutput = () => void;
 
-const TITLE_BULLET = chalk.bold("\u25CF ");
+const TITLE_BULLET = chalk.bold('\u25CF ');
 
 export default class DefaultReporter extends BaseReporter {
-    private _clear: string; // ANSI clear sequence for the last printed status
-    private readonly _err: write;
-    protected _globalConfig: Config.GlobalConfig;
-    private readonly _out: write;
-    private readonly _status: Status;
-    private readonly _bufferedOutput: Set<FlushBufferedOutput>;
+  private _clear: string; // ANSI clear sequence for the last printed status
+  private readonly _err: write;
+  protected _globalConfig: Config.GlobalConfig;
+  private readonly _out: write;
+  private readonly _status: Status;
+  private readonly _bufferedOutput: Set<FlushBufferedOutput>;
 
-    static readonly filename = __filename;
+  static readonly filename = __filename;
 
-    constructor(globalConfig: Config.GlobalConfig) {
-        super();
-        this._globalConfig = globalConfig;
-        this._clear = "";
-        this._out = process.stdout.write.bind(process.stdout);
-        this._err = process.stderr.write.bind(process.stderr);
-        this._status = new Status(globalConfig);
-        this._bufferedOutput = new Set();
-        this.__wrapStdio(process.stdout);
-        this.__wrapStdio(process.stderr);
-        this._status.onChange(() => {
-            this.__beginSynchronizedUpdate(this._globalConfig.useStderr ? this._err : this._out);
-            this.__clearStatus();
-            this.__printStatus();
-            this.__endSynchronizedUpdate(this._globalConfig.useStderr ? this._err : this._out);
-        });
-    }
+  constructor(globalConfig: Config.GlobalConfig) {
+    super();
+    this._globalConfig = globalConfig;
+    this._clear = '';
+    this._out = process.stdout.write.bind(process.stdout);
+    this._err = process.stderr.write.bind(process.stderr);
+    this._status = new Status(globalConfig);
+    this._bufferedOutput = new Set();
+    this.__wrapStdio(process.stdout);
+    this.__wrapStdio(process.stderr);
+    this._status.onChange(() => {
+      this.__beginSynchronizedUpdate(
+        this._globalConfig.useStderr ? this._err : this._out,
+      );
+      this.__clearStatus();
+      this.__printStatus();
+      this.__endSynchronizedUpdate(
+        this._globalConfig.useStderr ? this._err : this._out,
+      );
+    });
+  }
 
-    protected __wrapStdio(stream: NodeJS.WritableStream | WriteStream): void {
-        const write = stream.write.bind(stream);
+  protected __wrapStdio(stream: NodeJS.WritableStream | WriteStream): void {
+    const write = stream.write.bind(stream);
 
-        let buffer: Array<string> = [];
-        let timeout: NodeJS.Timeout | null = null;
+    let buffer: Array<string> = [];
+    let timeout: NodeJS.Timeout | null = null;
 
-        const flushBufferedOutput = () => {
-            const string = buffer.join("");
-            buffer = [];
+    const flushBufferedOutput = () => {
+      const string = buffer.join('');
+      buffer = [];
 
-            // This is to avoid conflicts between random output and status text
-            this.__beginSynchronizedUpdate(this._globalConfig.useStderr ? this._err : this._out);
-            this.__clearStatus();
-            if (string) {
-                write(string);
-            }
-            this.__printStatus();
-            this.__endSynchronizedUpdate(this._globalConfig.useStderr ? this._err : this._out);
+      // This is to avoid conflicts between random output and status text
+      this.__beginSynchronizedUpdate(
+        this._globalConfig.useStderr ? this._err : this._out,
+      );
+      this.__clearStatus();
+      if (string) {
+        write(string);
+      }
+      this.__printStatus();
+      this.__endSynchronizedUpdate(
+        this._globalConfig.useStderr ? this._err : this._out,
+      );
 
-            this._bufferedOutput.delete(flushBufferedOutput);
-        };
+      this._bufferedOutput.delete(flushBufferedOutput);
+    };
 
-        this._bufferedOutput.add(flushBufferedOutput);
+    this._bufferedOutput.add(flushBufferedOutput);
 
-        const debouncedFlush = () => {
-            // If the process blows up no errors would be printed.
-            // There should be a smart way to buffer stderr, but for now
-            // we just won't buffer it.
-            if (stream === process.stderr) {
-                flushBufferedOutput();
-            } else {
-                if (!timeout) {
-                    timeout = setTimeout(() => {
-                        flushBufferedOutput();
-                        timeout = null;
-                    }, 100);
-                }
-            }
-        };
-
-        stream.write = (chunk: string) => {
-            buffer.push(chunk);
-            debouncedFlush();
-            return true;
-        };
-    }
-
-    // Don't wait for the debounced call and flush all output immediately.
-    forceFlushBufferedOutput(): void {
-        for (const flushBufferedOutput of this._bufferedOutput) {
+    const debouncedFlush = () => {
+      // If the process blows up no errors would be printed.
+      // There should be a smart way to buffer stderr, but for now
+      // we just won't buffer it.
+      if (stream === process.stderr) {
+        flushBufferedOutput();
+      } else {
+        if (!timeout) {
+          timeout = setTimeout(() => {
             flushBufferedOutput();
+            timeout = null;
+          }, 100);
         }
-    }
+      }
+    };
 
-    protected __clearStatus(): void {
-        if (isInteractive) {
-            if (this._globalConfig.useStderr) {
-                this._err(this._clear);
-            } else {
-                this._out(this._clear);
-            }
+    stream.write = (chunk: string) => {
+      buffer.push(chunk);
+      debouncedFlush();
+      return true;
+    };
+  }
+
+  // Don't wait for the debounced call and flush all output immediately.
+  forceFlushBufferedOutput(): void {
+    for (const flushBufferedOutput of this._bufferedOutput) {
+      flushBufferedOutput();
+    }
+  }
+
+  protected __clearStatus(): void {
+    if (isInteractive) {
+      if (this._globalConfig.useStderr) {
+        this._err(this._clear);
+      } else {
+        this._out(this._clear);
+      }
+    }
+  }
+
+  protected __printStatus(): void {
+    const {content, clear} = this._status.get();
+    this._clear = clear;
+    if (isInteractive) {
+      if (this._globalConfig.useStderr) {
+        this._err(content);
+      } else {
+        this._out(content);
+      }
+    }
+  }
+
+  override onRunStart(
+    aggregatedResults: AggregatedResult,
+    options: ReporterOnStartOptions,
+  ): void {
+    this._status.runStarted(aggregatedResults, options);
+  }
+
+  override onTestStart(test: Test): void {
+    this._status.testStarted(test.path, test.context.config);
+  }
+
+  override onTestCaseResult(test: Test, testCaseResult: TestCaseResult): void {
+    this._status.addTestCaseResult(test, testCaseResult);
+  }
+
+  override onRunComplete(): void {
+    this.forceFlushBufferedOutput();
+    this._status.runFinished();
+    process.stdout.write = this._out;
+    process.stderr.write = this._err;
+    clearLine(process.stderr);
+  }
+
+  override onTestResult(
+    test: Test,
+    testResult: TestResult,
+    aggregatedResults: AggregatedResult,
+  ): void {
+    this.testFinished(test.context.config, testResult, aggregatedResults);
+    if (!testResult.skipped) {
+      this.printTestFileHeader(
+        testResult.testFilePath,
+        test.context.config,
+        testResult,
+      );
+      this.printTestFileFailureMessage(
+        testResult.testFilePath,
+        test.context.config,
+        testResult,
+      );
+    }
+    this.forceFlushBufferedOutput();
+  }
+
+  testFinished(
+    config: Config.ProjectConfig,
+    testResult: TestResult,
+    aggregatedResults: AggregatedResult,
+  ): void {
+    this._status.testFinished(config, testResult, aggregatedResults);
+  }
+
+  printTestFileHeader(
+    testPath: string,
+    config: Config.ProjectConfig,
+    result: TestResult,
+  ): void {
+    // log retry errors if any exist
+    for (const testResult of result.testResults) {
+      const testRetryReasons = testResult.retryReasons;
+      if (testRetryReasons && testRetryReasons.length > 0) {
+        this.log(
+          `${chalk.reset.inverse.bold.yellow(' LOGGING RETRY ERRORS ')} ${chalk.bold(testResult.fullName)}`,
+        );
+        for (const [index, retryReasons] of testRetryReasons.entries()) {
+          let {message, stack} = separateMessageFromStack(retryReasons);
+          stack = this._globalConfig.noStackTrace
+            ? ''
+            : chalk.dim(
+                formatStackTrace(stack, config, this._globalConfig, testPath),
+              );
+
+          message = indentAllLines(message);
+
+          this.log(
+            `${chalk.reset.inverse.bold.blueBright(` RETRY ${index + 1} `)}\n`,
+          );
+          this.log(`${message}\n${stack}\n`);
         }
+      }
     }
 
-    protected __printStatus(): void {
-        const { content, clear } = this._status.get();
-        this._clear = clear;
-        if (isInteractive) {
-            if (this._globalConfig.useStderr) {
-                this._err(content);
-            } else {
-                this._out(content);
-            }
-        }
+    this.log(getResultHeader(result, this._globalConfig, config));
+    if (result.console) {
+      this.log(
+        `  ${TITLE_BULLET}Console\n\n${getConsoleOutput(result.console, config, this._globalConfig)}`,
+      );
     }
+  }
 
-    override onRunStart(aggregatedResults: AggregatedResult, options: ReporterOnStartOptions): void {
-        this._status.runStarted(aggregatedResults, options);
+  printTestFileFailureMessage(
+    _testPath: string,
+    _config: Config.ProjectConfig,
+    result: TestResult,
+  ): void {
+    if (result.failureMessage) {
+      this.log(result.failureMessage);
     }
-
-    override onTestStart(test: Test): void {
-        this._status.testStarted(test.path, test.context.config);
-    }
-
-    override onTestCaseResult(test: Test, testCaseResult: TestCaseResult): void {
-        this._status.addTestCaseResult(test, testCaseResult);
-    }
-
-    override onRunComplete(): void {
-        this.forceFlushBufferedOutput();
-        this._status.runFinished();
-        process.stdout.write = this._out;
-        process.stderr.write = this._err;
-        clearLine(process.stderr);
-    }
-
-    override onTestResult(test: Test, testResult: TestResult, aggregatedResults: AggregatedResult): void {
-        this.testFinished(test.context.config, testResult, aggregatedResults);
-        if (!testResult.skipped) {
-            this.printTestFileHeader(testResult.testFilePath, test.context.config, testResult);
-            this.printTestFileFailureMessage(testResult.testFilePath, test.context.config, testResult);
-        }
-        this.forceFlushBufferedOutput();
-    }
-
-    testFinished(config: Config.ProjectConfig, testResult: TestResult, aggregatedResults: AggregatedResult): void {
-        this._status.testFinished(config, testResult, aggregatedResults);
-    }
-
-    printTestFileHeader(testPath: string, config: Config.ProjectConfig, result: TestResult): void {
-        // log retry errors if any exist
-        for (const testResult of result.testResults) {
-            const testRetryReasons = testResult.retryReasons;
-            if (testRetryReasons && testRetryReasons.length > 0) {
-                this.log(
-                    `${chalk.reset.inverse.bold.yellow(" LOGGING RETRY ERRORS ")} ${chalk.bold(testResult.fullName)}`,
-                );
-                for (const [index, retryReasons] of testRetryReasons.entries()) {
-                    let { message, stack } = separateMessageFromStack(retryReasons);
-                    stack = this._globalConfig.noStackTrace
-                        ? ""
-                        : chalk.dim(formatStackTrace(stack, config, this._globalConfig, testPath));
-
-                    message = indentAllLines(message);
-
-                    this.log(`${chalk.reset.inverse.bold.blueBright(` RETRY ${index + 1} `)}\n`);
-                    this.log(`${message}\n${stack}\n`);
-                }
-            }
-        }
-
-        this.log(getResultHeader(result, this._globalConfig, config));
-        if (result.console) {
-            this.log(`  ${TITLE_BULLET}Console\n\n${getConsoleOutput(result.console, config, this._globalConfig)}`);
-        }
-    }
-
-    printTestFileFailureMessage(_testPath: string, _config: Config.ProjectConfig, result: TestResult): void {
-        if (result.failureMessage) {
-            this.log(result.failureMessage);
-        }
-        const didUpdate = this._globalConfig.updateSnapshot === "all";
-        const snapshotStatuses = getSnapshotStatus(result.snapshot, didUpdate);
-        for (const status of snapshotStatuses) this.log(status);
-    }
+    const didUpdate = this._globalConfig.updateSnapshot === 'all';
+    const snapshotStatuses = getSnapshotStatus(result.snapshot, didUpdate);
+    for (const status of snapshotStatuses) this.log(status);
+  }
 }


### PR DESCRIPTION
## Summary
This PR introduces support for DEC private mode 2026, also known as Synchronized Output, to DefaultReporter. The Synchronized Output mode is a terminal feature that helps mitigate screen tearing effects that can occur when the terminal is rendering output while the application is still writing to the screen.

Two new methods have been added to the DefaultReporter:

- `__beginSynchronizedUpdate`: This method sends the control sequence to enable Synchronized Output mode to the terminal.
- `__endSynchronizedUpdate`: This method sends the control sequence to disable Synchronized Output mode to the terminal.

These methods are called before and after the reporter updates the status, respectively. By doing this, we ensure that the terminal renders a consistent state of the screen for each status update, even if we're writing to the screen frequently.

Read more: https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036

## Why / Test plan
Here's Jest output before (notice the flickering):

https://github.com/jestjs/jest/assets/15584994/98d65f35-11ce-46c6-8be4-59ba57e782f5

Here's Jest output after:

https://github.com/jestjs/jest/assets/15584994/951b6563-7518-45da-95b5-4ce1ff60223d
