### PR TITLE
Move unnecessary `dependencies` to `devDependencies` for babel plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@
 - `[docs]` Don't use alias matchers in docs ([#14631](https://github.com/jestjs/jest/pull/14631))
 - `[babel-jest, babel-preset-jest]` [**BREAKING**] Increase peer dependency of `@babel/core` to `^7.11` ([#14109](https://github.com/jestjs/jest/pull/14109))
 - `[babel-jest, @jest/transform]` Update `babel-plugin-istanbul` to v6 ([#15156](https://github.com/jestjs/jest/pull/15156))
+- `[babel-plugin-jest-hoist]` Move unnecessary `dependencies` to `devDependencies` ([#15010](https://github.com/jestjs/jest/pull/15010))
 - `[expect]` [**BREAKING**] Remove `.toBeCalled()`, `.toBeCalledTimes()`, `.toBeCalledWith()`, `.lastCalledWith()`, `.nthCalledWith()`, `.toReturn()`, `.toReturnTimes()`, `.toReturnWith()`, `.lastReturnedWith()`, `.nthReturnedWith()` and `.toThrowError()` matcher aliases ([#14632](https://github.com/jestjs/jest/pull/14632))
 - `[jest-cli, jest-config, @jest/types]` [**BREAKING**] Remove deprecated `--init` argument ([#14490](https://github.com/jestjs/jest/pull/14490))
 - `[jest-config, @jest/core, jest-util]` Upgrade `ci-info` ([#14655](https://github.com/jestjs/jest/pull/14655))

--- a/packages/babel-plugin-jest-hoist/package.json
+++ b/packages/babel-plugin-jest-hoist/package.json
@@ -24,8 +24,7 @@
   "dependencies": {
     "@babel/template": "^7.3.3",
     "@babel/types": "^7.3.3",
-    "@types/babel__core": "^7.1.14",
-    "@types/babel__traverse": "^7.0.6"
+    "@types/babel__core": "^7.1.14"
   },
   "devDependencies": {
     "@babel/core": "^7.11.6",
@@ -33,6 +32,7 @@
     "@babel/preset-typescript": "^7.0.0",
     "@prettier/sync": "^0.5.0",
     "@types/babel__template": "^7.0.2",
+    "@types/babel__traverse": "^7.0.6",
     "@types/node": "*",
     "babel-plugin-tester": "^11.0.2",
     "prettier": "^3.0.3"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
I found it at https://github.com/babel/babel/pull/16413 and although I've added the solution in Babel, it looks like removing them in Jest is fine.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
CI green
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
