### PR TITLE
chore: test on Node.js 22

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -20,10 +20,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js nightly build
         uses: actions/setup-node@v4
         with:
-          node-version: 22-nightly
+          node-version: 23-nightly
           cache: yarn
       - name: install
         run: yarn --immutable
@@ -52,10 +52,10 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - name: Use Node.js LTS
+      - name: Use Node.js nightly build
         uses: actions/setup-node@v4
         with:
-          node-version: 22-nightly
+          node-version: 23-nightly
           cache: yarn
       - name: install
         run: yarn --immutable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x, 21.x]
+        node-version: [16.x, 18.x, 20.x, 21.x, 22.x]
     name: Node v${{ matrix.node-version }}
     runs-on: ${{ inputs.os }}
 

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -16,7 +16,7 @@ Time:        <<REPLACED>>
 Ran all test suites matching native-esm-deep-cjs-reexport.test.js."
 `;
 
-exports[`on node >=16.12.0 supports import assertions 1`] = `
+exports[`on node >=16.12.0 <22.0.0 supports import assertions 1`] = `
 "Test Suites: 1 passed, 1 total
 Tests:       2 passed, 2 total
 Snapshots:   0 total

--- a/e2e/__tests__/nativeEsm.test.ts
+++ b/e2e/__tests__/nativeEsm.test.ts
@@ -137,8 +137,9 @@ test('does not enforce import assertions', () => {
   },
 );
 
-// version where `vm` API gets `import assertions`
-onNodeVersions('>=16.12.0', () => {
+// support for import assertions in dynamic imports was added in Node.js 16.12.0
+// support for import assertions was removed in Node.js 22.0.0
+onNodeVersions('>=16.12.0 <22.0.0', () => {
   test('supports import assertions', () => {
     const {exitCode, stderr, stdout} = runJest(
       DIR,
@@ -154,7 +155,7 @@ onNodeVersions('>=16.12.0', () => {
   });
 });
 
-onNodeVersions('<16.12.0', () => {
+onNodeVersions('<16.12.0 || >=22.0.0', () => {
   test('syntax error for import assertions', () => {
     const {exitCode, stderr, stdout} = runJest(
       DIR,


### PR DESCRIPTION
## Summary

Node.js 22 is released: https://github.com/nodejs/node/releases/tag/v22.0.0

This PR add Node.js 22 to the test matrix and bumps nightly version to 23 (it will get incremented as well, or?).

## Test plan

Green CI