### PR TITLE
refactor!: remove deprecated `jest.genMockFromModule()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `[@jest/core]` [**BREAKING**] Changed `--filter` to accept an object with shape `{ filtered: Array<string> }` to match [documentation](https://jestjs.io/docs/cli#--filterfile) ([#13319](https://github.com/jestjs/jest/pull/13319))
 - `[@jest/core]` Support `--outputFile` option for [`--listTests`](https://jestjs.io/docs/cli#--listtests) ([#14980](https://github.com/jestjs/jest/pull/14980))
 - `[@jest/core, @jest/test-sequencer]` [**BREAKING**] Exposes `globalConfig` & `contexts` to `TestSequencer` ([#14535](https://github.com/jestjs/jest/pull/14535), & [#14543](https://github.com/jestjs/jest/pull/14543))
+- `[@jest/environment]` [**BREAKING**] Remove deprecated `jest.genMockFromModule()` ([#15042](https://github.com/jestjs/jest/pull/15042))
 - `[jest-environment-jsdom]` [**BREAKING**] Upgrade JSDOM to v22 ([#13825](https://github.com/jestjs/jest/pull/13825))
 - `[@jest/environment-jsdom-abstract]` Introduce new package which abstracts over the `jsdom` environment, allowing usage of custom versions of JSDOM ([#14717](https://github.com/jestjs/jest/pull/14717))
 - `[jest-environment-node]` Update jest environment with dispose symbols `Symbol` ([#14888](https://github.com/jestjs/jest/pull/14888) & [#14909](https://github.com/jestjs/jest/pull/14909))
@@ -2393,7 +2394,7 @@ We skipped 24.2.0 because a draft was accidentally published. Please use `24.3.0
 
 - `[jest-snapshot]` Mark snapshots as obsolete when moved to an inline snapshot ([#6773](https://github.com/facebook/jest/pull/6773))
 - `[jest-config]` Fix `--coverage` with `--findRelatedTests` overwriting `collectCoverageFrom` options ([#6736](https://github.com/facebook/jest/pull/6736))
-- `[jest-config]` Update default config for testURL from 'about:blank' to 'http://localhost' to address latest JSDOM security warning. ([#6792](https://github.com/facebook/jest/pull/6792))
+- `[jest-config]` Update default config for testURL from 'about:blank' to '<http://localhost>' to address latest JSDOM security warning. ([#6792](https://github.com/facebook/jest/pull/6792))
 - `[jest-cli]` Fix `testMatch` not working with negations ([#6648](https://github.com/facebook/jest/pull/6648))
 - `[jest-cli]` Don't report promises as open handles ([#6716](https://github.com/facebook/jest/pull/6716))
 - `[jest-each]` Add timeout support to parameterised tests ([#6660](https://github.com/facebook/jest/pull/6660))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2394,7 +2394,7 @@ We skipped 24.2.0 because a draft was accidentally published. Please use `24.3.0
 
 - `[jest-snapshot]` Mark snapshots as obsolete when moved to an inline snapshot ([#6773](https://github.com/facebook/jest/pull/6773))
 - `[jest-config]` Fix `--coverage` with `--findRelatedTests` overwriting `collectCoverageFrom` options ([#6736](https://github.com/facebook/jest/pull/6736))
-- `[jest-config]` Update default config for testURL from 'about:blank' to '<http://localhost>' to address latest JSDOM security warning. ([#6792](https://github.com/facebook/jest/pull/6792))
+- `[jest-config]` Update default config for testURL from 'about:blank' to 'http://localhost' to address latest JSDOM security warning. ([#6792](https://github.com/facebook/jest/pull/6792))
 - `[jest-cli]` Fix `testMatch` not working with negations ([#6648](https://github.com/facebook/jest/pull/6648))
 - `[jest-cli]` Don't report promises as open handles ([#6716](https://github.com/facebook/jest/pull/6716))
 - `[jest-each]` Add timeout support to parameterised tests ([#6660](https://github.com/facebook/jest/pull/6660))

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -153,17 +153,6 @@ export interface Jest {
    * Creates a mock function. Optionally takes a mock implementation.
    */
   fn: ModuleMocker['fn'];
-  // TODO remove `genMockFromModule()` in Jest 30
-  /**
-   * Given the name of a module, use the automatic mocking system to generate a
-   * mocked version of the module for you.
-   *
-   * This is useful when you want to create a manual mock that extends the
-   * automatic mock's behavior.
-   *
-   * @deprecated Use `jest.createMockFromModule()` instead
-   */
-  genMockFromModule<T = unknown>(moduleName: string): Mocked<T>;
   /**
    * When mocking time, `Date.now()` will also be mocked. If you for some reason
    * need access to the real current time, you can invoke this function.

--- a/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
@@ -231,28 +231,6 @@ describe('dependencyExtractor', () => {
     );
   });
 
-  it('should extract dependencies from `jest.genMockFromModule` calls', () => {
-    const code = `
-      // Good
-      jest.genMockFromModule('dep1');
-      const dep2 = jest.genMockFromModule(
-        "dep2",
-      );
-      if (jest.genMockFromModule(\`dep3\`).cond) {}
-      jest
-        .requireMock('dep4');
-
-      // Bad
-      foo . jest.genMockFromModule('inv1')
-      xjest.genMockFromModule('inv2');
-      jest.genMockFromModulex('inv3');
-      jest.genMockFromModule('inv4', 'inv5');
-    `;
-    expect(extractor.extract(code)).toEqual(
-      new Set(['dep1', 'dep2', 'dep3', 'dep4']),
-    );
-  });
-
   it('should extract dependencies from `jest.createMockFromModule` calls', () => {
     const code = `
       // Good

--- a/packages/jest-haste-map/src/lib/dependencyExtractor.ts
+++ b/packages/jest-haste-map/src/lib/dependencyExtractor.ts
@@ -60,7 +60,7 @@ const IMPORT_OR_EXPORT_RE = createRegExp(
 const JEST_EXTENSIONS_RE = createRegExp(
   [
     ...functionCallStart(
-      'jest\\s*\\.\\s*(?:requireActual|requireMock|genMockFromModule|createMockFromModule)',
+      'jest\\s*\\.\\s*(?:requireActual|requireMock|createMockFromModule)',
     ),
     CAPTURE_STRING_LITERAL(1),
     WHITESPACE,

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -2359,7 +2359,6 @@ export default class Runtime {
       dontMock: unmock,
       enableAutomock,
       fn,
-      genMockFromModule: moduleName => this._generateMock(from, moduleName),
       getRealSystemTime: () => {
         const fakeTimers = _getFakeTimers();
 


### PR DESCRIPTION
## Summary

This PR removes deprecated `jest.genMockFromModule()`, which was replaced with `jest.createMockFromModule()` in Jest 26 (see: https://github.com/jestjs/jest/pull/9962). 

## Test plan

Green CI.
