### PR TITLE
refactor!: make it mandatory to pass `globalConfig` to the `Runtime` constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 - `[jest-runtime]` Exposing new modern timers function `jest.advanceTimersToFrame()` from `@jest/fake-timers` ([#14598](https://github.com/jestjs/jest/pull/14598))
 - `[jest-runtime]` Support `import.meta.filename` and `import.meta.dirname` (available from [Node 20.11](https://nodejs.org/en/blog/release/v20.11.0)) ([#14854](https://github.com/jestjs/jest/pull/14854))
 - `[jest-runtime]` Support `import.meta.resolve` ([#14930](https://github.com/jestjs/jest/pull/14930))
+- `[jest-runtime]` [**BREAKING**] Make it mandatory to pass `globalConfig` to the `Runtime` constructor ([#15044](https://github.com/jestjs/jest/pull/15044))
 - `[@jest/schemas]` Upgrade `@sinclair/typebox` to v0.31 ([#14072](https://github.com/jestjs/jest/pull/14072))
 - `[@jest/types]` `test.each()`: Accept a readonly (`as const`) table properly ([#14565](https://github.com/jestjs/jest/pull/14565))
 - `[@jest/types]` Improve argument type inference passed to `test` and `describe` callback functions from `each` tables ([#14920](https://github.com/jestjs/jest/pull/14920))

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -165,7 +165,7 @@ export default class Runtime {
   private readonly _cacheFS: Map<string, string>;
   private readonly _cacheFSBuffer = new Map<string, Buffer>();
   private readonly _config: Config.ProjectConfig;
-  private readonly _globalConfig?: Config.GlobalConfig;
+  private readonly _globalConfig: Config.GlobalConfig;
   private readonly _coverageOptions: ShouldInstrumentOptions;
   private _currentlyExecutingModulePath: string;
   private readonly _environment: JestEnvironment;
@@ -225,8 +225,7 @@ export default class Runtime {
     cacheFS: Map<string, string>,
     coverageOptions: ShouldInstrumentOptions,
     testPath: string,
-    // TODO: make mandatory in Jest 30
-    globalConfig?: Config.GlobalConfig,
+    globalConfig: Config.GlobalConfig,
   ) {
     this._cacheFS = cacheFS;
     this._config = config;
@@ -2372,7 +2371,7 @@ export default class Runtime {
       },
       getSeed: () => {
         // TODO: remove this check in Jest 30
-        if (this._globalConfig?.seed === undefined) {
+        if (this._globalConfig.seed === undefined) {
           throw new Error(
             'The seed value is not available. Likely you are using older versions of the jest dependencies.',
           );


### PR DESCRIPTION
## Summary

This PR makes it mandatory to pass `globalConfig` to the `Runtime` constructor.

## Test plan

Green CI.