### PR TITLE
Fix error message for `sl` (steam locomotive)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 - `[babel-plugin-jest-hoist]` Use `denylist` instead of the deprecated `blacklist` for Babel 8 support ([#14109](https://github.com/jestjs/jest/pull/14109))
 - `[expect]` Check error instance type for `toThrow/toThrowError` ([#14576](https://github.com/jestjs/jest/pull/14576))
+- `[jest-changed-files]` Print underlying errors when VCS commands fail ([#15052](https://github.com/jestjs/jest/pull/15052))
 - `[jest-circus]` [**BREAKING**] Prevent false test failures caused by promise rejections handled asynchronously ([#14315](https://github.com/jestjs/jest/pull/14315))
 - `[jest-circus]` Replace recursive `makeTestResults` implementation with iterative one ([#14760](https://github.com/jestjs/jest/pull/14760))
 - `[jest-circus]` Omit `expect.hasAssertions()` errors if a test already has errors ([#14866](https://github.com/jestjs/jest/pull/14866))

--- a/packages/jest-changed-files/src/git.ts
+++ b/packages/jest-changed-files/src/git.ts
@@ -7,7 +7,6 @@
  */
 
 import * as path from 'path';
-import {types} from 'util';
 import execa = require('execa');
 import type {SCMAdapter} from './types';
 
@@ -15,19 +14,7 @@ const findChangedFilesUsingCommand = async (
   args: Array<string>,
   cwd: string,
 ): Promise<Array<string>> => {
-  let result: execa.ExecaReturnValue;
-
-  try {
-    result = await execa('git', args, {cwd});
-  } catch (error) {
-    if (types.isNativeError(error)) {
-      const err = error as execa.ExecaError;
-      // TODO: Should we keep the original `message`?
-      err.message = err.stderr;
-    }
-
-    throw error;
-  }
+  const result = await execa('git', args, {cwd});
 
   return result.stdout
     .split('\n')

--- a/packages/jest-changed-files/src/hg.ts
+++ b/packages/jest-changed-files/src/hg.ts
@@ -7,7 +7,6 @@
  */
 
 import * as path from 'path';
-import {types} from 'util';
 import execa = require('execa');
 import type {SCMAdapter} from './types';
 
@@ -30,19 +29,7 @@ const adapter: SCMAdapter = {
     }
     args.push(...includePaths);
 
-    let result: execa.ExecaReturnValue;
-
-    try {
-      result = await execa('hg', args, {cwd, env});
-    } catch (error) {
-      if (types.isNativeError(error)) {
-        const err = error as execa.ExecaError;
-        // TODO: Should we keep the original `message`?
-        err.message = err.stderr;
-      }
-
-      throw error;
-    }
+    const result = await execa('hg', args, {cwd, env});
 
     return result.stdout
       .split('\n')

--- a/packages/jest-changed-files/src/sl.ts
+++ b/packages/jest-changed-files/src/sl.ts
@@ -7,7 +7,6 @@
  */
 
 import * as path from 'path';
-import {types} from 'util';
 import execa = require('execa');
 import type {SCMAdapter} from './types';
 
@@ -34,19 +33,7 @@ const adapter: SCMAdapter = {
     }
     args.push(...includePaths);
 
-    let result: execa.ExecaReturnValue;
-
-    try {
-      result = await execa('sl', args, {cwd, env});
-    } catch (error) {
-      if (types.isNativeError(error)) {
-        const err = error as execa.ExecaError;
-        // TODO: Should we keep the original `message`?
-        err.message = err.stderr;
-      }
-
-      throw error;
-    }
+    const result = await execa('sl', args, {cwd, env});
 
     return result.stdout
       .split('\n')


### PR DESCRIPTION
## Summary

When running jest in watch mode, with `sl` installed
(https://github.com/mtoyoda/sl), it errors out with the following
message:

```
  ● Test suite failed to run

thrown: [Error]
```

This is bad because the error is extremely hard to debug.

This change makes it error as follows:

```
  ● Test suite failed to run

    Command failed with ENAMETOOLONG: sl status -amnu /Users/rmartine/dev/ias-backstage/packages/backend
    spawn ENAMETOOLONG
```

This, at least, points people in the right direction.

See also: https://github.com/jestjs/jest/issues/14046

## Test plan

Went to a project that uses jest, ensured `sl` was installed and on `$PATH`, and ran:

```sh-session
$ node /path/to/your/JestClone/packages/jest/bin/jest --watch
```

Confirmed error was as before:

```
Determining test suites to run...

  ● Test suite failed to run

thrown: [Error]
```

Made my changes, re-ran:

```sh-session
$ node /path/to/your/JestClone/packages/jest/bin/jest --watch
```

Confirmed error message is now descriptive:

```
Determining test suites to run...

  ● Test suite failed to run

    Command failed with ENAMETOOLONG: sl status -amnu /Users/rmartine/dev/ias-backstage/packages/backend
    spawn ENAMETOOLONG
```