### PR TITLE
Abort `sl root` call if output resembles a steam locomotive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@
 
 - `[babel-plugin-jest-hoist]` Use `denylist` instead of the deprecated `blacklist` for Babel 8 support ([#14109](https://github.com/jestjs/jest/pull/14109))
 - `[expect]` Check error instance type for `toThrow/toThrowError` ([#14576](https://github.com/jestjs/jest/pull/14576))
+- `[jest-changed-files]` Abort `sl root` call if output resembles a steam locomotive ([#15053](https://github.com/jestjs/jest/pull/15053))
 - `[jest-circus]` [**BREAKING**] Prevent false test failures caused by promise rejections handled asynchronously ([#14315](https://github.com/jestjs/jest/pull/14315))
 - `[jest-circus]` Replace recursive `makeTestResults` implementation with iterative one ([#14760](https://github.com/jestjs/jest/pull/14760))
 - `[jest-circus]` Omit `expect.hasAssertions()` errors if a test already has errors ([#14866](https://github.com/jestjs/jest/pull/14866))

--- a/packages/jest-changed-files/src/sl.ts
+++ b/packages/jest-changed-files/src/sl.ts
@@ -17,6 +17,9 @@ import type {SCMAdapter} from './types';
  */
 const env = {...process.env, HGPLAIN: '1'};
 
+// Whether `sl` is a steam locomotive or not
+let isSteamLocomotive = false;
+
 const adapter: SCMAdapter = {
   findChangedFiles: async (cwd, options) => {
     const includePaths = options.includePaths ?? [];
@@ -55,6 +58,10 @@ const adapter: SCMAdapter = {
   },
 
   getRoot: async cwd => {
+    if (isSteamLocomotive) {
+      return null;
+    }
+
     try {
       const subprocess = execa('sl', ['root'], {cwd, env});
 
@@ -65,6 +72,7 @@ const adapter: SCMAdapter = {
           data = Buffer.isBuffer(data) ? data.toString() : data;
           if (data.codePointAt(0) === 27) {
             subprocess.cancel();
+            isSteamLocomotive = true;
           }
         });
       }

--- a/packages/jest-changed-files/src/sl.ts
+++ b/packages/jest-changed-files/src/sl.ts
@@ -65,7 +65,7 @@ const adapter: SCMAdapter = {
       }
 
       const result = await subprocess;
-      if (result.killed) {
+      if (result.killed && isSteamLocomotive) {
         return null;
       }
 


### PR DESCRIPTION
## Summary

Jest detects whether a repository is a sapling repo by calling the `sl`
binary, and getting the output. If `sl` (steam locomotive) is installed,
the output of `sl root` 1) takes forever to get and 2) is not the root,
but a moving image of a steam locomotive. This change monitors the
stdout stream, and aborts the `sl` call if the first character is an
escape character, which indicates that the terminal is being cleared to
make way for a train to come through.

See also: https://github.com/jestjs/jest/issues/14046

## Test plan

This was tested manually. I don't think I have the time to figure out
automated testing for this, as it requires installing a binary, which
means mucking around in the CI code.

With the existing main branch, with `sl` on `$PATH`:

```sh-session
$ node ~/dev/jest/packages/jest/bin/jest.js --watch
Determining test suites to run...

  ● Test suite failed to run

thrown: [Error]
```

With the existing main branch, in a repo with sapling roots, with sapling on `$PATH`:

```sh-session
$ node ~/dev/jest/packages/jest/bin/jest.js --watch

<a bunch of output>
```

With the proposed changes, with `sl` on `$PATH`:

```sh-session
$ node ~/dev/jest/packages/jest/bin/jest.js --watch
No tests found related to files changed since last commit.
```

With the proposed changes, in a repo with sapling roots, with sapling on `$PATH`:

```sh-session
$ node ~/dev/jest/packages/jest/bin/jest.js --watch

<a bunch of output>
```