### PR TITLE
fix: optimize getting extraEntryPoints in buildUtils

### DIFF
--- a/scripts/buildUtils.mjs
+++ b/scripts/buildUtils.mjs
@@ -239,22 +239,21 @@ export function createBuildConfigs() {
       pkg.name === 'expect'
         ? {}
         : Object.keys(pkg.exports)
-            .filter(
-              key =>
+            .reduce((previousValue, currentValue) => {
+              if (
                 key !== '.' &&
                 key !== './package.json' &&
-                !key.startsWith('./bin'),
-            )
-            .reduce((previousValue, currentValue) => {
-              return {
-                ...previousValue,
+                !key.startsWith('./bin')
+              ) {
                 // skip `./`
-                [currentValue.slice(2)]: path.resolve(
+                previousValue[currentValue.slice(2)] = path.resolve(
                   packageDir,
                   './src',
                   `${currentValue}.ts`,
-                ),
-              };
+                );
+              }
+
+              return previousValue;
             }, {});
 
     return {

--- a/scripts/buildUtils.mjs
+++ b/scripts/buildUtils.mjs
@@ -238,23 +238,22 @@ export function createBuildConfigs() {
       // skip expect for now
       pkg.name === 'expect'
         ? {}
-        : Object.keys(pkg.exports)
-            .reduce((previousValue, currentValue) => {
-              if (
-                key !== '.' &&
-                key !== './package.json' &&
-                !key.startsWith('./bin')
-              ) {
-                // skip `./`
-                previousValue[currentValue.slice(2)] = path.resolve(
-                  packageDir,
-                  './src',
-                  `${currentValue}.ts`,
-                );
-              }
+        : Object.keys(pkg.exports).reduce((previousValue, currentValue) => {
+            if (
+              currentValue !== '.' &&
+              currentValue !== './package.json' &&
+              !currentValue.startsWith('./bin')
+            ) {
+              // skip `./`
+              previousValue[currentValue.slice(2)] = path.resolve(
+                packageDir,
+                './src',
+                `${currentValue}.ts`,
+              );
+            }
 
-              return previousValue;
-            }, {});
+            return previousValue;
+          }, {});
 
     return {
       packageDir,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
I did a little optimization for avoid `filter` and n*n complexity in `reduce`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
