### PR TITLE
fix: remove needless check for equalCompare after Object.is

### DIFF
--- a/packages/expect-utils/src/__tests__/utils.test.ts
+++ b/packages/expect-utils/src/__tests__/utils.test.ts
@@ -703,3 +703,26 @@ describe('arrayBufferEquality', () => {
     expect(equals(a, b)).toBeFalsy();
   });
 });
+
+describe('jasmineUtils primitives comparison', () => {
+  const falseCases: Array<[any, any]> = [
+    [null, undefined],
+    [null, 0],
+    [false, 0],
+    [false, ''],
+  ];
+
+  for (const [a, b] of falseCases) {
+    test(`${JSON.stringify(a)} and ${JSON.stringify(b)} returns false`, () => {
+      expect(equals(a, b)).toBe(false);
+    });
+  }
+
+  const trueCases: Array<any> = [null, 0, false, '', undefined];
+
+  for (const value of trueCases) {
+    test(`${JSON.stringify(value)} returns true`, () => {
+      expect(equals(value, value)).toBe(true);
+    });
+  }
+});

--- a/packages/expect-utils/src/jasmineUtils.ts
+++ b/packages/expect-utils/src/jasmineUtils.ts
@@ -92,7 +92,7 @@ function eq(
   }
   // A strict comparison is necessary because `null == undefined`.
   if (a === null || b === null) {
-    return a === b;
+    return false;
   }
   const className = Object.prototype.toString.call(a);
   if (className != Object.prototype.toString.call(b)) {
@@ -107,7 +107,7 @@ function eq(
         return false;
       } else if (typeof a !== 'object' && typeof b !== 'object') {
         // both are proper primitives
-        return Object.is(a, b);
+        return false;
       } else {
         // both are `new Primitive()`s
         return Object.is(a.valueOf(), b.valueOf());


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
i removed a reductant check in two cases because `Object.is(a, b)` in 90th line covered it. It always `false`.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
I added a small test, but I think it was already covered well.
