### PR TITLE
chore: migrate type tests to TSTyche 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "strip-json-comments": "^3.1.1",
     "tempy": "^1.0.0",
     "ts-node": "^10.5.0",
-    "tstyche": "^2.0.0-beta.0",
+    "tstyche": "^2.0.0-beta.1",
     "typescript": "^5.0.4",
     "webpack": "^5.68.0",
     "webpack-node-externals": "^3.0.0",

--- a/packages/expect-utils/__typetests__/utils.test.ts
+++ b/packages/expect-utils/__typetests__/utils.test.ts
@@ -27,10 +27,10 @@ test('isA', () => {
   }
 
   if (isA<Map<unknown, unknown>>('Map', sample)) {
-    expect(sample).type.toEqual<Map<unknown, unknown>>();
+    expect(sample).type.toBe<Map<unknown, unknown>>();
   }
 
   if (isA<Set<unknown>>('Set', sample)) {
-    expect(sample).type.toEqual<Set<unknown>>();
+    expect(sample).type.toBe<Set<unknown>>();
   }
 });

--- a/packages/expect/__typetests__/expect.test.ts
+++ b/packages/expect/__typetests__/expect.test.ts
@@ -43,9 +43,9 @@ describe('Expect', () => {
     const tester1: Tester = function (a, b, customTesters) {
       expect(a).type.toBeAny();
       expect(b).type.toBeAny();
-      expect(customTesters).type.toEqual<Array<Tester>>();
-      expect(this).type.toEqual<TesterContext>();
-      expect(this.equals).type.toEqual<EqualsFunction>();
+      expect(customTesters).type.toBe<Array<Tester>>();
+      expect(this).type.toBe<TesterContext>();
+      expect(this.equals).type.toBe<EqualsFunction>();
 
       return undefined;
     };
@@ -57,7 +57,7 @@ describe('Expect', () => {
         (a, b, customTesters) => {
           expect(a).type.toBeAny();
           expect(b).type.toBeAny();
-          expect(customTesters).type.toEqual<Array<Tester>>();
+          expect(customTesters).type.toBe<Array<Tester>>();
           expect(this).type.toBeUndefined();
 
           return true;
@@ -66,9 +66,9 @@ describe('Expect', () => {
         function anotherTester(a, b, customTesters) {
           expect(a).type.toBeAny();
           expect(b).type.toBeAny();
-          expect(customTesters).type.toEqual<Array<Tester>>();
-          expect(this).type.toEqual<TesterContext>();
-          expect(this.equals).type.toEqual<EqualsFunction>();
+          expect(customTesters).type.toBe<Array<Tester>>();
+          expect(this).type.toBe<TesterContext>();
+          expect(this.equals).type.toBe<EqualsFunction>();
 
           return undefined;
         },
@@ -87,26 +87,26 @@ describe('Expect', () => {
         // TODO `actual` should be allowed to have only `unknown` type
         toBeWithinRange(actual: number, floor: number, ceiling: number) {
           expect(this.assertionCalls).type.toBeNumber();
-          expect(this.currentTestName).type.toEqual<string | undefined>();
-          expect(this.customTesters).type.toEqual<Array<Tester>>();
-          expect(this.dontThrow).type.toEqual<() => void>();
-          expect(this.error).type.toEqual<Error | undefined>();
-          expect(this.equals).type.toEqual<EqualsFunction>();
-          expect(this.expand).type.toEqual<boolean | undefined>();
-          expect(this.expectedAssertionsNumber).type.toEqual<number | null>();
-          expect(this.expectedAssertionsNumberError).type.toEqual<
+          expect(this.currentTestName).type.toBe<string | undefined>();
+          expect(this.customTesters).type.toBe<Array<Tester>>();
+          expect(this.dontThrow).type.toBe<() => void>();
+          expect(this.error).type.toBe<Error | undefined>();
+          expect(this.equals).type.toBe<EqualsFunction>();
+          expect(this.expand).type.toBe<boolean | undefined>();
+          expect(this.expectedAssertionsNumber).type.toBe<number | null>();
+          expect(this.expectedAssertionsNumberError).type.toBe<
             Error | undefined
           >();
           expect(this.isExpectingAssertions).type.toBeBoolean();
-          expect(this.isExpectingAssertionsError).type.toEqual<
+          expect(this.isExpectingAssertionsError).type.toBe<
             Error | undefined
           >();
-          expect(this.isNot).type.toEqual<boolean | undefined>();
+          expect(this.isNot).type.toBe<boolean | undefined>();
           expect(this.numPassingAsserts).type.toBeNumber();
-          expect(this.promise).type.toEqual<string | undefined>();
-          expect(this.suppressedErrors).type.toEqual<Array<Error>>();
-          expect(this.testPath).type.toEqual<string | undefined>();
-          expect(this.utils).type.toEqual<MatcherUtils>();
+          expect(this.promise).type.toBe<string | undefined>();
+          expect(this.suppressedErrors).type.toBe<Array<Error>>();
+          expect(this.testPath).type.toBe<string | undefined>();
+          expect(this.utils).type.toBe<MatcherUtils>();
 
           const pass = actual >= floor && actual <= ceiling;
           if (pass) {
@@ -162,7 +162,7 @@ describe('MatcherFunction', () => {
       };
     };
 
-    expect<ToBeWithinRange>().type.toBeAssignable(toBeWithinRange);
+    expect<ToBeWithinRange>().type.toBeAssignableWith(toBeWithinRange);
   });
 
   test('requires the `actual` argument to be of type `unknown`', () => {
@@ -173,7 +173,7 @@ describe('MatcherFunction', () => {
       };
     };
 
-    expect<MatcherFunction>().type.not.toBeAssignable(actualMustBeUnknown);
+    expect<MatcherFunction>().type.not.toBeAssignableWith(actualMustBeUnknown);
   });
 
   test('allows omitting the `expected` argument', () => {
@@ -193,7 +193,9 @@ describe('MatcherFunction', () => {
       };
     };
 
-    expect<AllowOmittingExpected>().type.toBeAssignable(allowOmittingExpected);
+    expect<AllowOmittingExpected>().type.toBeAssignableWith(
+      allowOmittingExpected,
+    );
   });
 
   test('the `message` property is required in the return type', () => {
@@ -203,7 +205,7 @@ describe('MatcherFunction', () => {
       };
     };
 
-    expect<MatcherFunction>().type.not.toBeAssignable(lacksMessage);
+    expect<MatcherFunction>().type.not.toBeAssignableWith(lacksMessage);
   });
 
   test('the `pass` property is required in the return type', () => {
@@ -213,7 +215,7 @@ describe('MatcherFunction', () => {
       };
     };
 
-    expect<MatcherFunction>().type.not.toBeAssignable(lacksPass);
+    expect<MatcherFunction>().type.not.toBeAssignableWith(lacksPass);
   });
 
   test('context is defined inside a matcher function', () => {
@@ -221,7 +223,7 @@ describe('MatcherFunction', () => {
       actual: unknown,
       ...expected: Array<unknown>
     ) {
-      expect(this).type.toEqual<MatcherContext>();
+      expect(this).type.toBe<MatcherContext>();
 
       if (expected.length > 0) {
         throw new Error('This matcher does not take any expected argument.');
@@ -243,7 +245,7 @@ describe('MatcherFunction', () => {
       actual: unknown,
       ...expected: Array<unknown>
     ) {
-      expect(this).type.toEqual<CustomContext>();
+      expect(this).type.toBe<CustomContext>();
       expect(this.customMethod()).type.toBeVoid();
 
       if (expected.length > 0) {
@@ -272,7 +274,7 @@ describe('MatcherFunction', () => {
       CustomContext,
       [count: number]
     > = function (actual: unknown, count: unknown) {
-      expect(this).type.toEqual<CustomContext>();
+      expect(this).type.toBe<CustomContext>();
       expect(this.customMethod()).type.toBeVoid();
 
       return {
@@ -281,7 +283,7 @@ describe('MatcherFunction', () => {
       };
     };
 
-    expect<CustomStateAndExpected>().type.toBeAssignable(
+    expect<CustomStateAndExpected>().type.toBeAssignableWith(
       customContextAndExpected,
     );
   });

--- a/packages/jest-cli/__typetests__/jest-cli.test.ts
+++ b/packages/jest-cli/__typetests__/jest-cli.test.ts
@@ -10,5 +10,5 @@ import type {Options} from 'yargs';
 import {yargsOptions} from 'jest-cli';
 
 test('yargsOptions', () => {
-  expect(yargsOptions).type.toEqual<{[key: string]: Options}>();
+  expect(yargsOptions).type.toBe<{[key: string]: Options}>();
 });

--- a/packages/jest-mock/__typetests__/Mocked.test.ts
+++ b/packages/jest-mock/__typetests__/Mocked.test.ts
@@ -23,12 +23,12 @@ describe('Mocked', () => {
 
     const MockSomeClass = SomeClass as Mocked<typeof SomeClass>;
 
-    expect(MockSomeClass.mock.calls[0]).type.toEqual<
+    expect(MockSomeClass.mock.calls[0]).type.toBe<
       [one: string, two?: boolean]
     >();
 
-    expect(MockSomeClass.prototype.methodA.mock.calls[0]).type.toEqual<[]>();
-    expect(MockSomeClass.prototype.methodB.mock.calls[0]).type.toEqual<
+    expect(MockSomeClass.prototype.methodA.mock.calls[0]).type.toBe<[]>();
+    expect(MockSomeClass.prototype.methodB.mock.calls[0]).type.toBe<
       [a: string, b?: number]
     >();
 
@@ -43,10 +43,10 @@ describe('Mocked', () => {
       ),
     ).type.toRaiseError();
 
-    expect(MockSomeClass.mock.instances[0].methodA.mock.calls[0]).type.toEqual<
+    expect(MockSomeClass.mock.instances[0].methodA.mock.calls[0]).type.toBe<
       []
     >();
-    expect(MockSomeClass.prototype.methodB.mock.calls[0]).type.toEqual<
+    expect(MockSomeClass.prototype.methodB.mock.calls[0]).type.toBe<
       [a: string, b?: number]
     >();
 
@@ -54,8 +54,8 @@ describe('Mocked', () => {
       InstanceType<typeof MockSomeClass>
     >;
 
-    expect(mockSomeInstance.methodA.mock.calls[0]).type.toEqual<[]>();
-    expect(mockSomeInstance.methodB.mock.calls[0]).type.toEqual<
+    expect(mockSomeInstance.methodA.mock.calls[0]).type.toBe<[]>();
+    expect(mockSomeInstance.methodB.mock.calls[0]).type.toBe<
       [a: string, b?: number]
     >();
 
@@ -68,7 +68,7 @@ describe('Mocked', () => {
       }),
     ).type.toRaiseError();
 
-    expect(new SomeClass('sample')).type.toBeAssignable(mockSomeInstance);
+    expect(new SomeClass('sample')).type.toBeAssignableWith(mockSomeInstance);
   });
 
   test('wraps a function type with type definitions of the Jest mock function', () => {
@@ -78,14 +78,14 @@ describe('Mocked', () => {
 
     const mockFunction = someFunction as Mocked<typeof someFunction>;
 
-    expect(mockFunction.mock.calls[0]).type.toEqual<[a: string, b?: number]>();
+    expect(mockFunction.mock.calls[0]).type.toBe<[a: string, b?: number]>();
 
     expect(mockFunction.mockReturnValue(123)).type.toRaiseError();
     expect(
       mockFunction.mockImplementation((a: boolean, b?: number) => true),
     ).type.toRaiseError();
 
-    expect(someFunction).type.toBeAssignable(mockFunction);
+    expect(someFunction).type.toBeAssignableWith(mockFunction);
   });
 
   test('wraps an async function type with type definitions of the Jest mock function', () => {
@@ -97,7 +97,7 @@ describe('Mocked', () => {
       typeof someAsyncFunction
     >;
 
-    expect(mockAsyncFunction.mock.calls[0]).type.toEqual<[Array<boolean>]>();
+    expect(mockAsyncFunction.mock.calls[0]).type.toBe<[Array<boolean>]>();
 
     expect(mockAsyncFunction.mockResolvedValue(123)).type.toRaiseError();
     expect(
@@ -106,7 +106,7 @@ describe('Mocked', () => {
       ),
     ).type.toRaiseError();
 
-    expect(someAsyncFunction).type.toBeAssignable(mockAsyncFunction);
+    expect(someAsyncFunction).type.toBeAssignableWith(mockAsyncFunction);
   });
 
   test('wraps a function object type with type definitions of the Jest mock function', () => {
@@ -126,7 +126,7 @@ describe('Mocked', () => {
       typeof someFunctionObject
     >;
 
-    expect(mockFunctionObject.mock.calls[0]).type.toEqual<
+    expect(mockFunctionObject.mock.calls[0]).type.toBe<
       [a: number, b?: string]
     >();
 
@@ -135,7 +135,7 @@ describe('Mocked', () => {
       mockFunctionObject.mockImplementation(() => true),
     ).type.toRaiseError();
 
-    expect(mockFunctionObject.one.more.time.mock.calls[0]).type.toEqual<
+    expect(mockFunctionObject.one.more.time.mock.calls[0]).type.toBe<
       [time: number]
     >();
 
@@ -148,7 +148,7 @@ describe('Mocked', () => {
       }),
     ).type.toRaiseError();
 
-    expect(someFunctionObject).type.toBeAssignable(mockFunctionObject);
+    expect(someFunctionObject).type.toBeAssignableWith(mockFunctionObject);
   });
 
   test('wraps an object type with type definitions of the Jest mock function', () => {
@@ -190,26 +190,24 @@ describe('Mocked', () => {
 
     const mockObject = someObject as Mocked<typeof someObject>;
 
-    expect(mockObject.methodA.mock.calls[0]).type.toEqual<[]>();
-    expect(mockObject.methodB.mock.calls[0]).type.toEqual<[b: string]>();
-    expect(mockObject.methodC.mock.calls[0]).type.toEqual<[c: number]>();
+    expect(mockObject.methodA.mock.calls[0]).type.toBe<[]>();
+    expect(mockObject.methodB.mock.calls[0]).type.toBe<[b: string]>();
+    expect(mockObject.methodC.mock.calls[0]).type.toBe<[c: number]>();
 
-    expect(mockObject.one.more.time.mock.calls[0]).type.toEqual<[t: number]>();
+    expect(mockObject.one.more.time.mock.calls[0]).type.toBe<[t: number]>();
 
-    expect(mockObject.SomeClass.mock.calls[0]).type.toEqual<
+    expect(mockObject.SomeClass.mock.calls[0]).type.toBe<
       [one: string, two?: boolean]
     >();
-    expect(mockObject.SomeClass.prototype.methodA.mock.calls[0]).type.toEqual<
+    expect(mockObject.SomeClass.prototype.methodA.mock.calls[0]).type.toBe<
       []
     >();
-    expect(mockObject.SomeClass.prototype.methodB.mock.calls[0]).type.toEqual<
+    expect(mockObject.SomeClass.prototype.methodB.mock.calls[0]).type.toBe<
       [a: string, b?: number]
     >();
 
-    expect(mockObject.someClassInstance.methodA.mock.calls[0]).type.toEqual<
-      []
-    >();
-    expect(mockObject.someClassInstance.methodB.mock.calls[0]).type.toEqual<
+    expect(mockObject.someClassInstance.methodA.mock.calls[0]).type.toBe<[]>();
+    expect(mockObject.someClassInstance.methodB.mock.calls[0]).type.toBe<
       [a: string, b?: number]
     >();
 
@@ -265,16 +263,16 @@ describe('Mocked', () => {
       ),
     ).type.toRaiseError();
 
-    expect(someObject).type.toBeAssignable(mockObject);
+    expect(someObject).type.toBeAssignableWith(mockObject);
   });
 
   test('wraps the global `console` object type with type definitions of the Jest mock function', () => {
     const mockConsole = console as Mocked<typeof console>;
 
-    expect(console.log).type.toBeAssignable(
+    expect(console.log).type.toBeAssignableWith(
       mockConsole.log.mockImplementation(() => {}),
     );
-    expect<MockInstance<typeof console.log>>().type.toBeAssignable(
+    expect<MockInstance<typeof console.log>>().type.toBeAssignableWith(
       mockConsole.log.mockImplementation(() => {}),
     );
   });

--- a/packages/jest-mock/__typetests__/ModuleMocker.test.ts
+++ b/packages/jest-mock/__typetests__/ModuleMocker.test.ts
@@ -48,7 +48,7 @@ const moduleMocker = new ModuleMocker(globalThis);
 const exampleMetadata = moduleMocker.getMetadata(exampleModule);
 
 test('getMetadata', () => {
-  expect(exampleMetadata).type.toEqual<MockMetadata<
+  expect(exampleMetadata).type.toBe<MockMetadata<
     typeof exampleModule
   > | null>();
 });
@@ -56,24 +56,24 @@ test('getMetadata', () => {
 test('generateFromMetadata', () => {
   const exampleMock = moduleMocker.generateFromMetadata(exampleMetadata!);
 
-  expect(exampleMock).type.toEqual<Mocked<typeof exampleModule>>();
+  expect(exampleMock).type.toBe<Mocked<typeof exampleModule>>();
 
-  expect(exampleMock.methodA.mock.calls).type.toEqual<
+  expect(exampleMock.methodA.mock.calls).type.toBe<
     Array<[a: number, b: number]>
   >();
-  expect(exampleMock.methodB.mock.calls).type.toEqual<
+  expect(exampleMock.methodB.mock.calls).type.toBe<
     Array<[a: number, b: number]>
   >();
 
-  expect(exampleMock.instance.memberA).type.toEqual<Array<number>>();
-  expect(exampleMock.instance.memberB.mock.calls).type.toEqual<Array<[]>>();
+  expect(exampleMock.instance.memberA).type.toBe<Array<number>>();
+  expect(exampleMock.instance.memberB.mock.calls).type.toBe<Array<[]>>();
 
   expect(exampleMock.propertyA.one).type.toBeString();
-  expect(exampleMock.propertyA.two.mock.calls).type.toEqual<Array<[]>>();
+  expect(exampleMock.propertyA.two.mock.calls).type.toBe<Array<[]>>();
   expect(exampleMock.propertyA.three.nine).type.toBeNumber();
-  expect(exampleMock.propertyA.three.ten).type.toEqual<Array<number>>();
+  expect(exampleMock.propertyA.three.ten).type.toBe<Array<number>>();
 
-  expect(exampleMock.propertyB).type.toEqual<Array<number>>();
+  expect(exampleMock.propertyB).type.toBe<Array<number>>();
   expect(exampleMock.propertyC).type.toBeNumber();
   expect(exampleMock.propertyD).type.toBeString();
   expect(exampleMock.propertyE).type.toBeBoolean();

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -47,7 +47,7 @@ describe('jest.fn()', () => {
         .mockReturnThis()
         .mockReturnValue('value')
         .mockReturnValueOnce('value'),
-    ).type.toEqual<Mock<() => string>>();
+    ).type.toBe<Mock<() => string>>();
 
     expect(
       fn(() => 'value').mockReturnValue(Promise.resolve('value')),
@@ -72,7 +72,7 @@ describe('jest.fn()', () => {
         .mockReturnThis()
         .mockReturnValue(Promise.resolve('value'))
         .mockReturnValueOnce(Promise.resolve('value')),
-    ).type.toEqual<Mock<() => Promise<string>>>();
+    ).type.toBe<Mock<() => Promise<string>>>();
 
     expect(fn(() => 'value').mockResolvedValue('value')).type.toRaiseError();
     expect(
@@ -89,30 +89,30 @@ describe('jest.fn()', () => {
     // eslint-disable-next-line @typescript-eslint/ban-types
     expect(fn()).type.toMatch<Function>();
 
-    expect(fn()).type.toEqual<Mock<(...args: Array<unknown>) => unknown>>();
-    expect(fn(() => {})).type.toEqual<Mock<() => void>>();
-    expect(fn((a: string, b?: number) => true)).type.toEqual<
+    expect(fn()).type.toBe<Mock<(...args: Array<unknown>) => unknown>>();
+    expect(fn(() => {})).type.toBe<Mock<() => void>>();
+    expect(fn((a: string, b?: number) => true)).type.toBe<
       Mock<(a: string, b?: number | undefined) => boolean>
     >();
     expect(
       fn((e: any) => {
         throw new Error();
       }),
-    ).type.toEqual<Mock<(e: any) => never>>();
+    ).type.toBe<Mock<(e: any) => never>>();
 
     expect(fn('moduleName')).type.toRaiseError();
   });
 
   test('infers argument and return types of mocked function', () => {
     expect(mockFn('one', 2)).type.toBeBoolean();
-    expect(mockAsyncFn(false)).type.toEqual<Promise<string>>();
+    expect(mockAsyncFn(false)).type.toBe<Promise<string>>();
 
     expect(mockFn()).type.toRaiseError();
     expect(mockAsyncFn()).type.toRaiseError();
   });
 
   test('infers argument and return types of mocked object', () => {
-    expect(new MockObject('credentials')).type.toEqual<{
+    expect(new MockObject('credentials')).type.toBe<{
       connect(): Mock<(...args: Array<unknown>) => unknown>;
       disconnect(): void;
     }>();
@@ -121,7 +121,7 @@ describe('jest.fn()', () => {
   });
 
   test('.getMockImplementation()', () => {
-    expect(mockFn.getMockImplementation()).type.toEqual<
+    expect(mockFn.getMockImplementation()).type.toBe<
       ((a: string, b?: number | undefined) => boolean) | undefined
     >();
 
@@ -138,20 +138,20 @@ describe('jest.fn()', () => {
     expect(mockFn.mock.calls.length).type.toBeNumber();
 
     expect(mockFn.mock.calls[0][0]).type.toBeString();
-    expect(mockFn.mock.calls[0][1]).type.toEqual<number | undefined>();
+    expect(mockFn.mock.calls[0][1]).type.toBe<number | undefined>();
 
     expect(mockFn.mock.calls[1][0]).type.toBeString();
-    expect(mockFn.mock.calls[1][1]).type.toEqual<number | undefined>();
+    expect(mockFn.mock.calls[1][1]).type.toBe<number | undefined>();
 
-    expect(mockFn.mock.contexts).type.toEqual<Array<Date>>();
+    expect(mockFn.mock.contexts).type.toBe<Array<Date>>();
 
-    expect(mockFn.mock.lastCall).type.toEqual<
+    expect(mockFn.mock.lastCall).type.toBe<
       [a: string, b?: number | undefined] | undefined
     >();
 
-    expect(mockFn.mock.invocationCallOrder).type.toEqual<Array<number>>();
+    expect(mockFn.mock.invocationCallOrder).type.toBe<Array<number>>();
 
-    expect(MockObject.mock.instances).type.toEqual<
+    expect(MockObject.mock.instances).type.toBe<
       Array<{
         connect(): Mock<(...args: Array<unknown>) => unknown>;
         disconnect(): void;
@@ -160,7 +160,7 @@ describe('jest.fn()', () => {
 
     const returnValue = mockFn.mock.results[0];
 
-    expect(returnValue.type).type.toEqual<'incomplete' | 'return' | 'throw'>();
+    expect(returnValue.type).type.toBe<'incomplete' | 'return' | 'throw'>();
     expect(returnValue.value).type.toBeUnknown();
 
     if (returnValue.type === 'incomplete') {
@@ -177,7 +177,7 @@ describe('jest.fn()', () => {
   });
 
   test('.mockClear()', () => {
-    expect(mockFn.mockClear()).type.toEqual<
+    expect(mockFn.mockClear()).type.toBe<
       Mock<(a: string, b?: number | undefined) => boolean>
     >();
 
@@ -185,7 +185,7 @@ describe('jest.fn()', () => {
   });
 
   test('.mockReset()', () => {
-    expect(mockFn.mockReset()).type.toEqual<
+    expect(mockFn.mockReset()).type.toBe<
       Mock<(a: string, b?: number | undefined) => boolean>
     >();
 
@@ -202,10 +202,10 @@ describe('jest.fn()', () => {
     expect(
       mockFn.mockImplementation((a, b) => {
         expect(a).type.toBeString();
-        expect(b).type.toEqual<number | undefined>();
+        expect(b).type.toBe<number | undefined>();
         return false;
       }),
-    ).type.toEqual<Mock<(a: string, b?: number | undefined) => boolean>>();
+    ).type.toBe<Mock<(a: string, b?: number | undefined) => boolean>>();
 
     expect(mockFn.mockImplementation((a: number) => false)).type.toRaiseError();
     expect(mockFn.mockImplementation(a => 'false')).type.toRaiseError();
@@ -216,7 +216,7 @@ describe('jest.fn()', () => {
         expect(a).type.toBeBoolean();
         return 'mock value';
       }),
-    ).type.toEqual<Mock<(p: boolean) => Promise<string>>>();
+    ).type.toBe<Mock<(p: boolean) => Promise<string>>>();
 
     expect(
       mockAsyncFn.mockImplementation(a => 'mock value'),
@@ -227,10 +227,10 @@ describe('jest.fn()', () => {
     expect(
       mockFn.mockImplementationOnce((a, b) => {
         expect(a).type.toBeString();
-        expect(b).type.toEqual<number | undefined>();
+        expect(b).type.toBe<number | undefined>();
         return false;
       }),
-    ).type.toEqual<Mock<(a: string, b?: number | undefined) => boolean>>();
+    ).type.toBe<Mock<(a: string, b?: number | undefined) => boolean>>();
 
     expect(
       mockFn.mockImplementationOnce((a: number) => false),
@@ -243,14 +243,14 @@ describe('jest.fn()', () => {
         expect(a).type.toBeBoolean();
         return 'mock value';
       }),
-    ).type.toEqual<Mock<(p: boolean) => Promise<string>>>();
+    ).type.toBe<Mock<(p: boolean) => Promise<string>>>();
     expect(
       mockAsyncFn.mockImplementationOnce(a => 'mock value'),
     ).type.toRaiseError();
   });
 
   test('.mockName()', () => {
-    expect(mockFn.mockName('mockedFunction')).type.toEqual<
+    expect(mockFn.mockName('mockedFunction')).type.toBe<
       Mock<(a: string, b?: number | undefined) => boolean>
     >();
 
@@ -259,7 +259,7 @@ describe('jest.fn()', () => {
   });
 
   test('.mockReturnThis()', () => {
-    expect(mockFn.mockReturnThis()).type.toEqual<
+    expect(mockFn.mockReturnThis()).type.toBe<
       Mock<(a: string, b?: number | undefined) => boolean>
     >();
 
@@ -267,7 +267,7 @@ describe('jest.fn()', () => {
   });
 
   test('.mockReturnValue()', () => {
-    expect(mockFn.mockReturnValue(false)).type.toEqual<
+    expect(mockFn.mockReturnValue(false)).type.toBe<
       Mock<(a: string, b?: number | undefined) => boolean>
     >();
 
@@ -276,7 +276,7 @@ describe('jest.fn()', () => {
 
     expect(
       mockAsyncFn.mockReturnValue(Promise.resolve('mock value')),
-    ).type.toEqual<Mock<(p: boolean) => Promise<string>>>();
+    ).type.toBe<Mock<(p: boolean) => Promise<string>>>();
 
     expect(
       mockAsyncFn.mockReturnValue(Promise.resolve(true)),
@@ -284,7 +284,7 @@ describe('jest.fn()', () => {
   });
 
   test('.mockReturnValueOnce()', () => {
-    expect(mockFn.mockReturnValueOnce(false)).type.toEqual<
+    expect(mockFn.mockReturnValueOnce(false)).type.toBe<
       Mock<(a: string, b?: number | undefined) => boolean>
     >();
     expect(mockFn.mockReturnValueOnce('true')).type.toRaiseError();
@@ -293,7 +293,7 @@ describe('jest.fn()', () => {
 
     expect(
       mockAsyncFn.mockReturnValueOnce(Promise.resolve('mock value')),
-    ).type.toEqual<Mock<(p: boolean) => Promise<string>>>();
+    ).type.toBe<Mock<(p: boolean) => Promise<string>>>();
 
     expect(
       mockAsyncFn.mockReturnValueOnce(Promise.resolve(true)),
@@ -303,7 +303,7 @@ describe('jest.fn()', () => {
   test('.mockResolvedValue()', () => {
     expect(
       fn(() => Promise.resolve('')).mockResolvedValue('Mock value'),
-    ).type.toEqual<Mock<() => Promise<string>>>();
+    ).type.toBe<Mock<() => Promise<string>>>();
 
     expect(
       fn(() => Promise.resolve('')).mockResolvedValue(123),
@@ -316,7 +316,7 @@ describe('jest.fn()', () => {
   test('.mockResolvedValueOnce()', () => {
     expect(
       fn(() => Promise.resolve('')).mockResolvedValueOnce('Mock value'),
-    ).type.toEqual<Mock<() => Promise<string>>>();
+    ).type.toBe<Mock<() => Promise<string>>>();
 
     expect(
       fn(() => Promise.resolve('')).mockResolvedValueOnce(123),
@@ -329,10 +329,10 @@ describe('jest.fn()', () => {
   test('.mockRejectedValue()', () => {
     expect(
       fn(() => Promise.resolve('')).mockRejectedValue(new Error('Mock error')),
-    ).type.toEqual<Mock<() => Promise<string>>>();
+    ).type.toBe<Mock<() => Promise<string>>>();
     expect(
       fn(() => Promise.resolve('')).mockRejectedValue('Mock error'),
-    ).type.toEqual<Mock<() => Promise<string>>>();
+    ).type.toBe<Mock<() => Promise<string>>>();
 
     expect(
       fn(() => Promise.resolve('')).mockRejectedValue(),
@@ -344,10 +344,10 @@ describe('jest.fn()', () => {
       fn(() => Promise.resolve('')).mockRejectedValueOnce(
         new Error('Mock error'),
       ),
-    ).type.toEqual<Mock<() => Promise<string>>>();
+    ).type.toBe<Mock<() => Promise<string>>>();
     expect(
       fn(() => Promise.resolve('')).mockRejectedValueOnce('Mock error'),
-    ).type.toEqual<Mock<() => Promise<string>>>();
+    ).type.toBe<Mock<() => Promise<string>>>();
 
     expect(
       fn(() => Promise.resolve('')).mockRejectedValueOnce(),
@@ -356,7 +356,7 @@ describe('jest.fn()', () => {
 
   test('.withImplementation()', () => {
     expect(mockFn.withImplementation(mockFnImpl, () => {})).type.toBeVoid();
-    expect(mockFn.withImplementation(mockFnImpl, async () => {})).type.toEqual<
+    expect(mockFn.withImplementation(mockFnImpl, async () => {})).type.toBe<
       Promise<void>
     >();
 
@@ -429,30 +429,30 @@ describe('jest.spyOn()', () => {
     expect(spy()).type.toRaiseError();
     expect(new spy()).type.toRaiseError();
 
-    expect(spyOn(spiedObject, 'methodA')).type.toEqual<
+    expect(spyOn(spiedObject, 'methodA')).type.toBe<
       SpiedFunction<typeof spiedObject.methodA>
     >();
-    expect(spyOn(spiedObject, 'methodB')).type.toEqual<
+    expect(spyOn(spiedObject, 'methodB')).type.toBe<
       SpiedFunction<typeof spiedObject.methodB>
     >();
-    expect(spyOn(spiedObject, 'methodC')).type.toEqual<
+    expect(spyOn(spiedObject, 'methodC')).type.toBe<
       SpiedFunction<typeof spiedObject.methodC>
     >();
 
-    expect(spyOn(spiedObject, 'propertyB', 'get')).type.toEqual<
+    expect(spyOn(spiedObject, 'propertyB', 'get')).type.toBe<
       SpiedGetter<typeof spiedObject.propertyB>
     >();
-    expect(spyOn(spiedObject, 'propertyB', 'set')).type.toEqual<
+    expect(spyOn(spiedObject, 'propertyB', 'set')).type.toBe<
       SpiedSetter<typeof spiedObject.propertyB>
     >();
     expect(spyOn(spiedObject, 'propertyB')).type.toRaiseError();
     expect(spyOn(spiedObject, 'methodB', 'get')).type.toRaiseError();
     expect(spyOn(spiedObject, 'methodB', 'set')).type.toRaiseError();
 
-    expect(spyOn(spiedObject, 'propertyA', 'get')).type.toEqual<
+    expect(spyOn(spiedObject, 'propertyA', 'get')).type.toBe<
       SpiedGetter<typeof spiedObject.propertyA>
     >();
-    expect(spyOn(spiedObject, 'propertyA', 'set')).type.toEqual<
+    expect(spyOn(spiedObject, 'propertyA', 'set')).type.toBe<
       SpiedSetter<typeof spiedObject.propertyA>
     >();
     expect(spyOn(spiedObject, 'propertyA')).type.toRaiseError();
@@ -466,37 +466,37 @@ describe('jest.spyOn()', () => {
 
     expect(
       spyOn(spiedArray as unknown as ArrayConstructor, 'isArray'),
-    ).type.toEqual<SpiedFunction<typeof Array.isArray>>();
+    ).type.toBe<SpiedFunction<typeof Array.isArray>>();
     expect(spyOn(spiedArray, 'isArray')).type.toRaiseError();
 
     expect(
       // eslint-disable-next-line @typescript-eslint/ban-types
       spyOn(spiedFunction as unknown as Function, 'toString'),
-    ).type.toEqual<SpiedFunction<typeof spiedFunction.toString>>();
+    ).type.toBe<SpiedFunction<typeof spiedFunction.toString>>();
     expect(spyOn(spiedFunction, 'toString')).type.toRaiseError();
 
-    expect(spyOn(globalThis, 'Date')).type.toEqual<SpiedClass<typeof Date>>();
-    expect(spyOn(Date, 'now')).type.toEqual<SpiedFunction<typeof Date.now>>();
+    expect(spyOn(globalThis, 'Date')).type.toBe<SpiedClass<typeof Date>>();
+    expect(spyOn(Date, 'now')).type.toBe<SpiedFunction<typeof Date.now>>();
   });
 
   test('handles object with index signature', () => {
-    expect(spyOn(indexSpiedObject, 'methodA')).type.toEqual<
+    expect(spyOn(indexSpiedObject, 'methodA')).type.toBe<
       SpiedFunction<typeof indexSpiedObject.methodA>
     >();
-    expect(spyOn(indexSpiedObject, 'methodB')).type.toEqual<
+    expect(spyOn(indexSpiedObject, 'methodB')).type.toBe<
       SpiedFunction<typeof indexSpiedObject.methodB>
     >();
-    expect(spyOn(indexSpiedObject, 'methodC')).type.toEqual<
+    expect(spyOn(indexSpiedObject, 'methodC')).type.toBe<
       SpiedFunction<typeof indexSpiedObject.methodC>
     >();
-    expect(spyOn(indexSpiedObject, 'methodE')).type.toEqual<
+    expect(spyOn(indexSpiedObject, 'methodE')).type.toBe<
       SpiedFunction<typeof indexSpiedObject.methodE>
     >();
 
-    expect(spyOn(indexSpiedObject, 'propertyA', 'get')).type.toEqual<
+    expect(spyOn(indexSpiedObject, 'propertyA', 'get')).type.toBe<
       SpiedGetter<typeof indexSpiedObject.propertyA>
     >();
-    expect(spyOn(indexSpiedObject, 'propertyA', 'set')).type.toEqual<
+    expect(spyOn(indexSpiedObject, 'propertyA', 'set')).type.toBe<
       SpiedSetter<typeof indexSpiedObject.propertyA>
     >();
     expect(spyOn(indexSpiedObject, 'propertyA')).type.toRaiseError();
@@ -531,10 +531,10 @@ describe('jest.spyOn()', () => {
 
     const optionalSpiedObject = {} as OptionalInterface;
 
-    expect(spyOn(optionalSpiedObject, 'constructorA')).type.toEqual<
+    expect(spyOn(optionalSpiedObject, 'constructorA')).type.toBe<
       SpiedClass<NonNullable<typeof optionalSpiedObject.constructorA>>
     >();
-    expect(spyOn(optionalSpiedObject, 'constructorB')).type.toEqual<
+    expect(spyOn(optionalSpiedObject, 'constructorB')).type.toBe<
       SpiedClass<typeof optionalSpiedObject.constructorB>
     >();
 
@@ -545,38 +545,38 @@ describe('jest.spyOn()', () => {
       spyOn(optionalSpiedObject, 'constructorA', 'set'),
     ).type.toRaiseError();
 
-    expect(spyOn(optionalSpiedObject, 'methodA')).type.toEqual<
+    expect(spyOn(optionalSpiedObject, 'methodA')).type.toBe<
       SpiedFunction<NonNullable<typeof optionalSpiedObject.methodA>>
     >();
-    expect(spyOn(optionalSpiedObject, 'methodB')).type.toEqual<
+    expect(spyOn(optionalSpiedObject, 'methodB')).type.toBe<
       SpiedFunction<typeof optionalSpiedObject.methodB>
     >();
 
     expect(spyOn(optionalSpiedObject, 'methodA', 'get')).type.toRaiseError();
     expect(spyOn(optionalSpiedObject, 'methodA', 'set')).type.toRaiseError();
 
-    expect(spyOn(optionalSpiedObject, 'propertyA', 'get')).type.toEqual<
+    expect(spyOn(optionalSpiedObject, 'propertyA', 'get')).type.toBe<
       SpiedGetter<NonNullable<typeof optionalSpiedObject.propertyA>>
     >();
-    expect(spyOn(optionalSpiedObject, 'propertyA', 'set')).type.toEqual<
+    expect(spyOn(optionalSpiedObject, 'propertyA', 'set')).type.toBe<
       SpiedSetter<NonNullable<typeof optionalSpiedObject.propertyA>>
     >();
-    expect(spyOn(optionalSpiedObject, 'propertyB', 'get')).type.toEqual<
+    expect(spyOn(optionalSpiedObject, 'propertyB', 'get')).type.toBe<
       SpiedGetter<NonNullable<typeof optionalSpiedObject.propertyB>>
     >();
-    expect(spyOn(optionalSpiedObject, 'propertyB', 'set')).type.toEqual<
+    expect(spyOn(optionalSpiedObject, 'propertyB', 'set')).type.toBe<
       SpiedSetter<NonNullable<typeof optionalSpiedObject.propertyB>>
     >();
-    expect(spyOn(optionalSpiedObject, 'propertyC', 'get')).type.toEqual<
+    expect(spyOn(optionalSpiedObject, 'propertyC', 'get')).type.toBe<
       SpiedGetter<typeof optionalSpiedObject.propertyC>
     >();
-    expect(spyOn(optionalSpiedObject, 'propertyC', 'set')).type.toEqual<
+    expect(spyOn(optionalSpiedObject, 'propertyC', 'set')).type.toBe<
       SpiedSetter<typeof optionalSpiedObject.propertyC>
     >();
-    expect(spyOn(optionalSpiedObject, 'propertyD', 'get')).type.toEqual<
+    expect(spyOn(optionalSpiedObject, 'propertyD', 'get')).type.toBe<
       SpiedGetter<typeof optionalSpiedObject.propertyD>
     >();
-    expect(spyOn(optionalSpiedObject, 'propertyD', 'set')).type.toEqual<
+    expect(spyOn(optionalSpiedObject, 'propertyD', 'set')).type.toBe<
       SpiedSetter<typeof optionalSpiedObject.propertyD>
     >();
 
@@ -589,7 +589,7 @@ describe('jest.spyOn()', () => {
       spyOn(Storage.prototype, 'setItem').mockImplementation(
         (key: string, value: string) => {},
       ),
-    ).type.toEqual<SpiedFunction<(key: string, value: string) => void>>();
+    ).type.toBe<SpiedFunction<(key: string, value: string) => void>>();
 
     expect(
       spyOn(Storage.prototype, 'setItem').mockImplementation(
@@ -620,10 +620,10 @@ describe('jest.replaceProperty()', () => {
   const objectWithDynamicProperties = {} as ObjectWithDynamicProperties;
 
   test('models typings of replaced property', () => {
-    expect(replaceProperty(replaceObject, 'property', 1)).type.toEqual<
+    expect(replaceProperty(replaceObject, 'property', 1)).type.toBe<
       Replaced<number>
     >();
-    expect(replaceProperty(replaceObject, 'method', () => {})).type.toEqual<
+    expect(replaceProperty(replaceObject, 'method', () => {})).type.toBe<
       Replaced<() => void>
     >();
     expect(
@@ -643,8 +643,8 @@ describe('jest.replaceProperty()', () => {
 
     expect(
       replaceProperty(complexObject, 'numberOrUndefined', undefined),
-    ).type.toEqual<Replaced<number | undefined>>();
-    expect(replaceProperty(complexObject, 'numberOrUndefined', 1)).type.toEqual<
+    ).type.toBe<Replaced<number | undefined>>();
+    expect(replaceProperty(complexObject, 'numberOrUndefined', 1)).type.toBe<
       Replaced<number | undefined>
     >();
 
@@ -656,16 +656,16 @@ describe('jest.replaceProperty()', () => {
       ),
     ).type.toRaiseError();
 
-    expect(
-      replaceProperty(complexObject, 'optionalString', 'foo'),
-    ).type.toEqual<Replaced<string | undefined>>();
+    expect(replaceProperty(complexObject, 'optionalString', 'foo')).type.toBe<
+      Replaced<string | undefined>
+    >();
     expect(
       replaceProperty(complexObject, 'optionalString', undefined),
-    ).type.toEqual<Replaced<string | undefined>>();
+    ).type.toBe<Replaced<string | undefined>>();
 
     expect(
       replaceProperty(objectWithDynamicProperties, 'dynamic prop 1', true),
-    ).type.toEqual<Replaced<boolean>>();
+    ).type.toBe<Replaced<boolean>>();
     expect(
       replaceProperty(objectWithDynamicProperties, 'dynamic prop 1', undefined),
     ).type.toRaiseError();
@@ -679,6 +679,6 @@ describe('jest.replaceProperty()', () => {
         .replaceValue('foo')
         .replaceValue({foo: 1})
         .replaceValue(null),
-    ).type.toEqual<Replaced<ComplexObject['multipleTypes']>>();
+    ).type.toBe<Replaced<ComplexObject['multipleTypes']>>();
   });
 });

--- a/packages/jest-mock/__typetests__/utility-types.test.ts
+++ b/packages/jest-mock/__typetests__/utility-types.test.ts
@@ -106,62 +106,62 @@ type IndexObject = {
 };
 
 test('ClassLike', () => {
-  expect<ClassLike>().type.toBeAssignable(SomeClass);
+  expect<ClassLike>().type.toBeAssignableWith(SomeClass);
 
-  expect<ClassLike>().type.not.toBeAssignable(() => {});
-  expect<ClassLike>().type.not.toBeAssignable(function abc() {
+  expect<ClassLike>().type.not.toBeAssignableWith(() => {});
+  expect<ClassLike>().type.not.toBeAssignableWith(function abc() {
     return;
   });
-  expect<ClassLike>().type.not.toBeAssignable('abc');
-  expect<ClassLike>().type.not.toBeAssignable(123);
-  expect<ClassLike>().type.not.toBeAssignable(false);
-  expect<ClassLike>().type.not.toBeAssignable(someObject);
+  expect<ClassLike>().type.not.toBeAssignableWith('abc');
+  expect<ClassLike>().type.not.toBeAssignableWith(123);
+  expect<ClassLike>().type.not.toBeAssignableWith(false);
+  expect<ClassLike>().type.not.toBeAssignableWith(someObject);
 });
 
 test('FunctionLike', () => {
-  expect<FunctionLike>().type.toBeAssignable(() => {});
-  expect<FunctionLike>().type.toBeAssignable(function abc() {
+  expect<FunctionLike>().type.toBeAssignableWith(() => {});
+  expect<FunctionLike>().type.toBeAssignableWith(function abc() {
     return;
   });
 
-  expect<FunctionLike>().type.not.toBeAssignable('abc');
-  expect<FunctionLike>().type.not.toBeAssignable(123);
-  expect<FunctionLike>().type.not.toBeAssignable(false);
-  expect<FunctionLike>().type.not.toBeAssignable(SomeClass);
-  expect<FunctionLike>().type.not.toBeAssignable(someObject);
+  expect<FunctionLike>().type.not.toBeAssignableWith('abc');
+  expect<FunctionLike>().type.not.toBeAssignableWith(123);
+  expect<FunctionLike>().type.not.toBeAssignableWith(false);
+  expect<FunctionLike>().type.not.toBeAssignableWith(SomeClass);
+  expect<FunctionLike>().type.not.toBeAssignableWith(someObject);
 });
 
 test('ConstructorKeys', () => {
-  expect<ConstructorLikeKeys<OptionalInterface>>().type.toEqual<
+  expect<ConstructorLikeKeys<OptionalInterface>>().type.toBe<
     'constructorA' | 'constructorB'
   >();
-  expect<ConstructorLikeKeys<SomeObject>>().type.toEqual<'SomeClass'>();
+  expect<ConstructorLikeKeys<SomeObject>>().type.toBe<'SomeClass'>();
 });
 
 test('MethodKeys', () => {
-  expect<MethodLikeKeys<SomeClass>>().type.toEqual<'methodA' | 'methodB'>();
-  expect<MethodLikeKeys<IndexClass>>().type.toEqual<'methodA' | 'methodB'>();
-  expect<MethodLikeKeys<OptionalInterface>>().type.toEqual<
+  expect<MethodLikeKeys<SomeClass>>().type.toBe<'methodA' | 'methodB'>();
+  expect<MethodLikeKeys<IndexClass>>().type.toBe<'methodA' | 'methodB'>();
+  expect<MethodLikeKeys<OptionalInterface>>().type.toBe<
     'methodA' | 'methodB'
   >();
-  expect<MethodLikeKeys<SomeObject>>().type.toEqual<
+  expect<MethodLikeKeys<SomeObject>>().type.toBe<
     'methodA' | 'methodB' | 'methodC'
   >();
-  expect<MethodLikeKeys<IndexObject>>().type.toEqual<
+  expect<MethodLikeKeys<IndexObject>>().type.toBe<
     'methodA' | 'methodB' | 'methodC'
   >();
 });
 
 test('PropertyKeys', () => {
-  expect<PropertyLikeKeys<SomeClass>>().type.toEqual<
+  expect<PropertyLikeKeys<SomeClass>>().type.toBe<
     'propertyA' | 'propertyB' | 'propertyC'
   >();
-  expect<PropertyLikeKeys<IndexClass>>().type.toEqual<string | number>();
-  expect<PropertyLikeKeys<OptionalInterface>>().type.toEqual<
+  expect<PropertyLikeKeys<IndexClass>>().type.toBe<string | number>();
+  expect<PropertyLikeKeys<OptionalInterface>>().type.toBe<
     'propertyA' | 'propertyB' | 'propertyC' | 'propertyD'
   >();
-  expect<PropertyLikeKeys<SomeObject>>().type.toEqual<
+  expect<PropertyLikeKeys<SomeObject>>().type.toBe<
     'propertyA' | 'propertyB' | 'someClassInstance'
   >();
-  expect<PropertyLikeKeys<IndexObject>>().type.toEqual<string | number>();
+  expect<PropertyLikeKeys<IndexObject>>().type.toBe<string | number>();
 });

--- a/packages/jest-reporters/__typetests__/jest-reporters.test.ts
+++ b/packages/jest-reporters/__typetests__/jest-reporters.test.ts
@@ -48,7 +48,7 @@ expect(utils.getResultHeader(testResult, globalConfig, {})).type.toRaiseError();
 
 // utils.getSnapshotStatus()
 
-expect(utils.getSnapshotStatus(snapshot, true)).type.toEqual<Array<string>>();
+expect(utils.getSnapshotStatus(snapshot, true)).type.toBe<Array<string>>();
 expect(utils.getSnapshotStatus()).type.toRaiseError();
 expect(utils.getSnapshotStatus({}, true)).type.toRaiseError();
 expect(utils.getSnapshotStatus(snapshot, 123)).type.toRaiseError();
@@ -57,7 +57,7 @@ expect(utils.getSnapshotStatus(snapshot, 123)).type.toRaiseError();
 
 expect(
   utils.getSnapshotSummary(snapshotSummary, globalConfig, 'press `u`'),
-).type.toEqual<Array<string>>();
+).type.toBe<Array<string>>();
 expect(utils.getSnapshotSummary()).type.toRaiseError();
 expect(
   utils.getSnapshotSummary({}, globalConfig, 'press `u`'),
@@ -85,11 +85,11 @@ expect(utils.printDisplayName({})).type.toRaiseError();
 
 // utils.relativePath()
 
-expect(utils.relativePath(globalConfig, 'some/path')).type.toEqual<{
+expect(utils.relativePath(globalConfig, 'some/path')).type.toBe<{
   basename: string;
   dirname: string;
 }>();
-expect(utils.relativePath(projectConfig, 'some/path')).type.toEqual<{
+expect(utils.relativePath(projectConfig, 'some/path')).type.toBe<{
   basename: string;
   dirname: string;
 }>();

--- a/packages/jest-resolve/__typetests__/resolver.test.ts
+++ b/packages/jest-resolve/__typetests__/resolver.test.ts
@@ -18,7 +18,7 @@ import type {
 
 // PackageJSON
 
-expect<PackageJSON>().type.toBeAssignable({
+expect<PackageJSON>().type.toBeAssignableWith({
   caption: 'test',
   count: 100,
   isTest: true,
@@ -26,7 +26,7 @@ expect<PackageJSON>().type.toBeAssignable({
   values: [0, 10, 20, {x: 1, y: 2}, true, 'test', ['a', 'b']],
 });
 
-expect<PackageJSON>().type.not.toBeAssignable({
+expect<PackageJSON>().type.not.toBeAssignableWith({
   filter: () => {},
 });
 
@@ -34,21 +34,21 @@ expect<PackageJSON>().type.not.toBeAssignable({
 
 const packageFilter = (pkg: PackageJSON, file: string, dir: string) => pkg;
 
-expect<PackageFilter>().type.toBeAssignable(packageFilter);
+expect<PackageFilter>().type.toBeAssignableWith(packageFilter);
 
 // PathFilter
 
 const pathFilter = (pkg: PackageJSON, path: string, relativePath: string) =>
   relativePath;
 
-expect<PathFilter>().type.toBeAssignable(pathFilter);
+expect<PathFilter>().type.toBeAssignableWith(pathFilter);
 
 // ResolverOptions
 
 function customSyncResolver(path: string, options: ResolverOptions): string {
   return path;
 }
-expect<SyncResolver>().type.toBeAssignable(customSyncResolver);
+expect<SyncResolver>().type.toBeAssignableWith(customSyncResolver);
 
 async function customAsyncResolver(
   path: string,
@@ -56,7 +56,7 @@ async function customAsyncResolver(
 ): Promise<string> {
   return path;
 }
-expect<AsyncResolver>().type.toBeAssignable(customAsyncResolver);
+expect<AsyncResolver>().type.toBeAssignableWith(customAsyncResolver);
 
 // AsyncResolver
 
@@ -64,20 +64,22 @@ const asyncResolver: AsyncResolver = async (path, options) => {
   expect(path).type.toBeString();
 
   expect(options.basedir).type.toBeString();
-  expect(options.conditions).type.toEqual<Array<string> | undefined>();
-  expect(options.defaultResolver).type.toEqual<SyncResolver>();
-  expect(options.extensions).type.toEqual<Array<string> | undefined>();
-  expect(options.moduleDirectory).type.toEqual<Array<string> | undefined>();
-  expect(options.packageFilter).type.toEqual<PackageFilter | undefined>();
-  expect(options.pathFilter).type.toEqual<PathFilter | undefined>();
-  expect(options.paths).type.toEqual<Array<string> | undefined>();
-  expect(options.rootDir).type.toEqual<string | undefined>();
+  expect(options.conditions).type.toBe<Array<string> | undefined>();
+  expect(options.defaultResolver).type.toBe<SyncResolver>();
+  expect(options.extensions).type.toBe<Array<string> | undefined>();
+  expect(options.moduleDirectory).type.toBe<Array<string> | undefined>();
+  expect(options.packageFilter).type.toBe<PackageFilter | undefined>();
+  expect(options.pathFilter).type.toBe<PathFilter | undefined>();
+  expect(options.paths).type.toBe<Array<string> | undefined>();
+  expect(options.rootDir).type.toBe<string | undefined>();
 
   return path;
 };
 
 const notReturningAsyncResolver = async () => {};
-expect<AsyncResolver>().type.not.toBeAssignable(notReturningAsyncResolver());
+expect<AsyncResolver>().type.not.toBeAssignableWith(
+  notReturningAsyncResolver(),
+);
 
 // SyncResolver
 
@@ -85,27 +87,27 @@ const syncResolver: SyncResolver = (path, options) => {
   expect(path).type.toBeString();
 
   expect(options.basedir).type.toBeString();
-  expect(options.conditions).type.toEqual<Array<string> | undefined>();
-  expect(options.defaultResolver).type.toEqual<SyncResolver>();
-  expect(options.extensions).type.toEqual<Array<string> | undefined>();
-  expect(options.moduleDirectory).type.toEqual<Array<string> | undefined>();
-  expect(options.packageFilter).type.toEqual<PackageFilter | undefined>();
-  expect(options.pathFilter).type.toEqual<PathFilter | undefined>();
-  expect(options.paths).type.toEqual<Array<string> | undefined>();
-  expect(options.rootDir).type.toEqual<string | undefined>();
+  expect(options.conditions).type.toBe<Array<string> | undefined>();
+  expect(options.defaultResolver).type.toBe<SyncResolver>();
+  expect(options.extensions).type.toBe<Array<string> | undefined>();
+  expect(options.moduleDirectory).type.toBe<Array<string> | undefined>();
+  expect(options.packageFilter).type.toBe<PackageFilter | undefined>();
+  expect(options.pathFilter).type.toBe<PathFilter | undefined>();
+  expect(options.paths).type.toBe<Array<string> | undefined>();
+  expect(options.rootDir).type.toBe<string | undefined>();
 
   return path;
 };
 
 const notReturningSyncResolver = () => {};
-expect<SyncResolver>().type.not.toBeAssignable(notReturningSyncResolver());
+expect<SyncResolver>().type.not.toBeAssignableWith(notReturningSyncResolver());
 
 // JestResolver
 
-expect<JestResolver>().type.toBeAssignable({async: asyncResolver});
-expect<JestResolver>().type.toBeAssignable({sync: syncResolver});
-expect<JestResolver>().type.toBeAssignable({
+expect<JestResolver>().type.toBeAssignableWith({async: asyncResolver});
+expect<JestResolver>().type.toBeAssignableWith({sync: syncResolver});
+expect<JestResolver>().type.toBeAssignableWith({
   async: asyncResolver,
   sync: syncResolver,
 });
-expect<JestResolver>().type.not.toBeAssignable({});
+expect<JestResolver>().type.not.toBeAssignableWith({});

--- a/packages/jest-runner/__typetests__/jest-runner.test.ts
+++ b/packages/jest-runner/__typetests__/jest-runner.test.ts
@@ -37,8 +37,8 @@ class CallbackRunner extends CallbackTestRunner {
     onFailure: OnTestFailure,
     options: TestRunnerOptions,
   ): Promise<void> {
-    expect(this._globalConfig).type.toEqual<Config.GlobalConfig>();
-    expect(this._context).type.toEqual<TestRunnerContext>();
+    expect(this._globalConfig).type.toBe<Config.GlobalConfig>();
+    expect(this._context).type.toBe<TestRunnerContext>();
 
     return;
   }
@@ -46,8 +46,8 @@ class CallbackRunner extends CallbackTestRunner {
 
 const callbackRunner = new CallbackRunner(globalConfig, runnerContext);
 
-expect(callbackRunner.isSerial).type.toEqual<boolean | undefined>();
-expect(callbackRunner.supportsEventEmitters).type.toEqual<false>();
+expect(callbackRunner.isSerial).type.toBe<boolean | undefined>();
+expect(callbackRunner.supportsEventEmitters).type.toBe<false>();
 
 // CallbackTestRunnerInterface
 
@@ -68,7 +68,7 @@ class CustomCallbackRunner implements CallbackTestRunnerInterface {
     onFailure: OnTestFailure,
     options: TestRunnerOptions,
   ): Promise<void> {
-    expect(this.#globalConfig).type.toEqual<Config.GlobalConfig>();
+    expect(this.#globalConfig).type.toBe<Config.GlobalConfig>();
     expect(this.#maxConcurrency).type.toBeNumber();
 
     return;
@@ -83,8 +83,8 @@ class EmittingRunner extends EmittingTestRunner {
     watcher: TestWatcher,
     options: TestRunnerOptions,
   ): Promise<void> {
-    expect(this._globalConfig).type.toEqual<Config.GlobalConfig>();
-    expect(this._context).type.toEqual<TestRunnerContext>();
+    expect(this._globalConfig).type.toBe<Config.GlobalConfig>();
+    expect(this._context).type.toBe<TestRunnerContext>();
 
     return;
   }
@@ -99,8 +99,8 @@ class EmittingRunner extends EmittingTestRunner {
 
 const emittingRunner = new EmittingRunner(globalConfig, runnerContext);
 
-expect(emittingRunner.isSerial).type.toEqual<boolean | undefined>();
-expect(emittingRunner.supportsEventEmitters).type.toEqual<true>();
+expect(emittingRunner.isSerial).type.toBe<boolean | undefined>();
+expect(emittingRunner.supportsEventEmitters).type.toBe<true>();
 
 // EmittingTestRunnerInterface
 
@@ -119,7 +119,7 @@ class CustomEmittingRunner implements EmittingTestRunnerInterface {
     watcher: TestWatcher,
     options: TestRunnerOptions,
   ): Promise<void> {
-    expect(this.#globalConfig).type.toEqual<Config.GlobalConfig>();
+    expect(this.#globalConfig).type.toBe<Config.GlobalConfig>();
     expect(this.#maxConcurrency).type.toBeNumber();
 
     return;

--- a/packages/jest-snapshot/__typetests__/SnapshotResolver.test.ts
+++ b/packages/jest-snapshot/__typetests__/SnapshotResolver.test.ts
@@ -13,13 +13,13 @@ import type {SnapshotResolver} from 'jest-snapshot';
 const snapshotResolver: SnapshotResolver = {
   resolveSnapshotPath: (testPath, snapshotExtension) => {
     expect(testPath).type.toBeString();
-    expect(snapshotExtension).type.toEqual<string | undefined>();
+    expect(snapshotExtension).type.toBe<string | undefined>();
     return 'snapshot/path';
   },
 
   resolveTestPath: (snapshotPath, snapshotExtension) => {
     expect(snapshotPath).type.toBeString();
-    expect(snapshotExtension).type.toEqual<string | undefined>();
+    expect(snapshotExtension).type.toBe<string | undefined>();
     return 'test/path';
   },
 
@@ -28,65 +28,65 @@ const snapshotResolver: SnapshotResolver = {
 
 // resolveSnapshotPath
 
-expect<SnapshotResolver>().type.not.toBeAssignable({
+expect<SnapshotResolver>().type.not.toBeAssignableWith({
   resolveSnapshotPath: (testPath: string, snapshotExtension: boolean) =>
     'snapshot/path',
   resolveTestPath: () => 'test/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
-expect<SnapshotResolver>().type.not.toBeAssignable({
+expect<SnapshotResolver>().type.not.toBeAssignableWith({
   resolveSnapshotPath: (testPath: boolean) => 'snapshot/path',
   resolveTestPath: () => 'test/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
-expect<SnapshotResolver>().type.not.toBeAssignable({
+expect<SnapshotResolver>().type.not.toBeAssignableWith({
   resolveSnapshotPath: () => true,
   resolveTestPath: () => 'test/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
-expect<SnapshotResolver>().type.not.toBeAssignable({
+expect<SnapshotResolver>().type.not.toBeAssignableWith({
   resolveTestPath: () => 'test/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
 // resolveTestPath
 
-expect<SnapshotResolver>().type.not.toBeAssignable({
+expect<SnapshotResolver>().type.not.toBeAssignableWith({
   resolveSnapshotPath: () => 'snapshot/path',
   resolveTestPath: (snapshotPath: string, snapshotExtension: boolean) =>
     'test/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
-expect<SnapshotResolver>().type.not.toBeAssignable({
+expect<SnapshotResolver>().type.not.toBeAssignableWith({
   resolveSnapshotPath: () => 'snapshot/path',
   resolveTestPath: (snapshotPath: boolean) => 'test/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
-expect<SnapshotResolver>().type.not.toBeAssignable({
+expect<SnapshotResolver>().type.not.toBeAssignableWith({
   resolveSnapshotPath: () => 'snapshot/path',
   resolveTestPath: () => true,
   testPathForConsistencyCheck: 'test/path/example',
 });
 
-expect<SnapshotResolver>().type.not.toBeAssignable({
+expect<SnapshotResolver>().type.not.toBeAssignableWith({
   resolveSnapshotPath: () => 'snapshot/path',
   testPathForConsistencyCheck: 'test/path/example',
 });
 
 // testPathForConsistencyCheck
 
-expect<SnapshotResolver>().type.not.toBeAssignable({
+expect<SnapshotResolver>().type.not.toBeAssignableWith({
   resolveSnapshotPath: () => 'snapshot/path',
   resolveTestPath: () => 'test/path',
   testPathForConsistencyCheck: true,
 });
 
-expect<SnapshotResolver>().type.not.toBeAssignable({
+expect<SnapshotResolver>().type.not.toBeAssignableWith({
   resolveSnapshotPath: () => 'snapshot/path',
   resolveTestPath: () => 'test/path',
 });

--- a/packages/jest-snapshot/__typetests__/matchers.test.ts
+++ b/packages/jest-snapshot/__typetests__/matchers.test.ts
@@ -18,21 +18,21 @@ import {
 
 // Context
 
-expect(({} as Context).snapshotState).type.toEqual<SnapshotState>();
+expect(({} as Context).snapshotState).type.toBe<SnapshotState>();
 
 // toMatchSnapshot
 
 expect(
   toMatchSnapshot.call({} as Context, {received: 'value'}),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(
   toMatchSnapshot.call({} as Context, {received: 'value'}, 'someHint'),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(
   toMatchSnapshot.call({} as Context, {received: 'value'}, {property: 'match'}),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(
   toMatchSnapshot.call(
@@ -41,7 +41,7 @@ expect(
     {property: 'match'},
     'someHint',
   ),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(toMatchSnapshot({received: 'value'})).type.toRaiseError();
 
@@ -49,7 +49,7 @@ expect(toMatchSnapshot({received: 'value'})).type.toRaiseError();
 
 expect(
   toMatchInlineSnapshot.call({} as Context, {received: 'value'}),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(
   toMatchInlineSnapshot.call(
@@ -57,7 +57,7 @@ expect(
     {received: 'value'},
     'inlineSnapshot',
   ),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(
   toMatchInlineSnapshot.call(
@@ -65,7 +65,7 @@ expect(
     {received: 'value'},
     {property: 'match'},
   ),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(
   toMatchInlineSnapshot.call(
@@ -74,7 +74,7 @@ expect(
     {property: 'match'},
     'inlineSnapshot',
   ),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(toMatchInlineSnapshot({received: 'value'})).type.toRaiseError();
 
@@ -82,7 +82,7 @@ expect(toMatchInlineSnapshot({received: 'value'})).type.toRaiseError();
 
 expect(
   toThrowErrorMatchingSnapshot.call({} as Context, new Error('received')),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(
   toThrowErrorMatchingSnapshot.call(
@@ -90,7 +90,7 @@ expect(
     new Error('received'),
     'someHint',
   ),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(
   toThrowErrorMatchingSnapshot.call(
@@ -99,7 +99,7 @@ expect(
     'someHint',
     true, // fromPromise
   ),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(
   toThrowErrorMatchingSnapshot.call(
@@ -108,7 +108,7 @@ expect(
     undefined,
     false, // fromPromise
   ),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(toThrowErrorMatchingSnapshot({received: 'value'})).type.toRaiseError();
 
@@ -116,7 +116,7 @@ expect(toThrowErrorMatchingSnapshot({received: 'value'})).type.toRaiseError();
 
 expect(
   toThrowErrorMatchingInlineSnapshot.call({} as Context, new Error('received')),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(
   toThrowErrorMatchingInlineSnapshot.call(
@@ -124,7 +124,7 @@ expect(
     new Error('received'),
     'inlineSnapshot',
   ),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(
   toThrowErrorMatchingInlineSnapshot.call(
@@ -133,7 +133,7 @@ expect(
     'inlineSnapshot',
     true, // fromPromise
   ),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(
   toThrowErrorMatchingInlineSnapshot.call(
@@ -142,7 +142,7 @@ expect(
     undefined,
     false, // fromPromise
   ),
-).type.toEqual<ExpectationResult>();
+).type.toBe<ExpectationResult>();
 
 expect(
   toThrowErrorMatchingInlineSnapshot({received: 'value'}),

--- a/packages/jest-types/__typetests__/config.test.ts
+++ b/packages/jest-types/__typetests__/config.test.ts
@@ -12,7 +12,7 @@ const config: Config = {};
 
 describe('Config', () => {
   test('coverageThreshold', () => {
-    expect(config).type.toBeAssignable({
+    expect(config).type.toBeAssignableWith({
       coverageThreshold: {
         './src/api/very-important-module.js': {
           branches: 100,
@@ -56,7 +56,7 @@ describe('Config', () => {
       'clearTimeout' as const,
     ];
 
-    expect(config).type.toBeAssignable({
+    expect(config).type.toBeAssignableWith({
       fakeTimers: {
         advanceTimers: true,
         doNotFake,
@@ -66,48 +66,48 @@ describe('Config', () => {
       },
     });
 
-    expect(config).type.toBeAssignable({
+    expect(config).type.toBeAssignableWith({
       fakeTimers: {
         advanceTimers: 40,
         now: Date.now(),
       },
     });
 
-    expect(config).type.not.toBeAssignable({
+    expect(config).type.not.toBeAssignableWith({
       fakeTimers: {
         now: new Date(),
       },
     });
 
-    expect(config).type.toBeAssignable({
+    expect(config).type.toBeAssignableWith({
       fakeTimers: {
         enableGlobally: true,
         legacyFakeTimers: true as const,
       },
     });
 
-    expect(config).type.not.toBeAssignable({
+    expect(config).type.not.toBeAssignableWith({
       fakeTimers: {
         advanceTimers: true,
         legacyFakeTimers: true as const,
       },
     });
 
-    expect(config).type.not.toBeAssignable({
+    expect(config).type.not.toBeAssignableWith({
       fakeTimers: {
         doNotFake,
         legacyFakeTimers: true as const,
       },
     });
 
-    expect(config).type.not.toBeAssignable({
+    expect(config).type.not.toBeAssignableWith({
       fakeTimers: {
         legacyFakeTimers: true as const,
         now: 1_483_228_800_000,
       },
     });
 
-    expect(config).type.not.toBeAssignable({
+    expect(config).type.not.toBeAssignableWith({
       fakeTimers: {
         legacyFakeTimers: true as const,
         timerLimit: 1000,
@@ -116,7 +116,7 @@ describe('Config', () => {
   });
 
   test('projects', () => {
-    expect(config).type.toBeAssignable({
+    expect(config).type.toBeAssignableWith({
       projects: [
         // projects can be globs or objects
         './src/**',

--- a/packages/jest-types/__typetests__/expect.test.ts
+++ b/packages/jest-types/__typetests__/expect.test.ts
@@ -135,23 +135,23 @@ expect(jestExpect.assertions()).type.toRaiseError();
 expect(jestExpect.hasAssertions()).type.toBeVoid();
 expect(jestExpect.hasAssertions(true)).type.toRaiseError();
 
-expect(
-  jestExpect(Promise.resolve('lemon')).resolves.toBe('lemon'),
-).type.toEqual<Promise<void>>();
+expect(jestExpect(Promise.resolve('lemon')).resolves.toBe('lemon')).type.toBe<
+  Promise<void>
+>();
 
 expect(
   jestExpect(Promise.resolve('lemon')).resolves.not.toBe('lemon'),
-).type.toEqual<Promise<void>>();
+).type.toBe<Promise<void>>();
 
 expect(
   jestExpect(Promise.reject(new Error('octopus'))).rejects.toThrow('octopus'),
-).type.toEqual<Promise<void>>();
+).type.toBe<Promise<void>>();
 
 expect(
   jestExpect(Promise.reject(new Error('octopus'))).rejects.not.toThrow(
     'octopus',
   ),
-).type.toEqual<Promise<void>>();
+).type.toBe<Promise<void>>();
 
 expect(jestExpect(1).not).type.not.toHaveProperty('not');
 expect(jestExpect(1).not).type.not.toHaveProperty('resolves');
@@ -483,23 +483,21 @@ expect(
   jestExpect.extend({
     toBeWithinRange(actual: number, floor: number, ceiling: number) {
       expect(this.assertionCalls).type.toBeNumber();
-      expect(this.currentTestName).type.toEqual<string | undefined>();
-      expect(this.dontThrow).type.toEqual<() => void>();
-      expect(this.error).type.toEqual<Error | undefined>();
-      expect(this.equals).type.toEqual<EqualsFunction>();
-      expect(this.expand).type.toEqual<boolean | undefined>();
-      expect(this.expectedAssertionsNumber).type.toEqual<number | null>();
-      expect(this.expectedAssertionsNumberError).type.toEqual<
-        Error | undefined
-      >();
+      expect(this.currentTestName).type.toBe<string | undefined>();
+      expect(this.dontThrow).type.toBe<() => void>();
+      expect(this.error).type.toBe<Error | undefined>();
+      expect(this.equals).type.toBe<EqualsFunction>();
+      expect(this.expand).type.toBe<boolean | undefined>();
+      expect(this.expectedAssertionsNumber).type.toBe<number | null>();
+      expect(this.expectedAssertionsNumberError).type.toBe<Error | undefined>();
       expect(this.isExpectingAssertions).type.toBeBoolean();
-      expect(this.isExpectingAssertionsError).type.toEqual<Error | undefined>();
-      expect(this.isNot).type.toEqual<boolean | undefined>();
+      expect(this.isExpectingAssertionsError).type.toBe<Error | undefined>();
+      expect(this.isNot).type.toBe<boolean | undefined>();
       expect(this.numPassingAsserts).type.toBeNumber();
-      expect(this.promise).type.toEqual<string | undefined>();
-      expect(this.suppressedErrors).type.toEqual<Array<Error>>();
-      expect(this.testPath).type.toEqual<string | undefined>();
-      expect(this.utils).type.toEqual<MatcherUtils>();
+      expect(this.promise).type.toBe<string | undefined>();
+      expect(this.suppressedErrors).type.toBe<Array<Error>>();
+      expect(this.testPath).type.toBe<string | undefined>();
+      expect(this.utils).type.toBe<MatcherUtils>();
 
       const pass = actual >= floor && actual <= ceiling;
       if (pass) {

--- a/packages/jest-types/__typetests__/globals.test.ts
+++ b/packages/jest-types/__typetests__/globals.test.ts
@@ -43,7 +43,7 @@ test(testName, done => {
 });
 
 test(testName, done => {
-  expect(done).type.toEqual<Global.DoneFn>();
+  expect(done).type.toBe<Global.DoneFn>();
 });
 
 test(testName, done => {
@@ -57,7 +57,7 @@ expect(beforeAll(asyncFn)).type.toBeVoid();
 expect(beforeAll(genFn)).type.toBeVoid();
 expect(
   beforeAll(done => {
-    expect(done).type.toEqual<Global.DoneFn>();
+    expect(done).type.toBe<Global.DoneFn>();
   }),
 ).type.toBeVoid();
 
@@ -66,7 +66,7 @@ expect(beforeAll(asyncFn, timeout)).type.toBeVoid();
 expect(beforeAll(genFn, timeout)).type.toBeVoid();
 expect(
   beforeAll(done => {
-    expect(done).type.toEqual<Global.DoneFn>();
+    expect(done).type.toBe<Global.DoneFn>();
   }, timeout),
 ).type.toBeVoid();
 
@@ -91,7 +91,7 @@ expect(beforeEach(asyncFn)).type.toBeVoid();
 expect(beforeEach(genFn)).type.toBeVoid();
 expect(
   beforeEach(done => {
-    expect(done).type.toEqual<Global.DoneFn>();
+    expect(done).type.toBe<Global.DoneFn>();
   }),
 ).type.toBeVoid();
 
@@ -100,7 +100,7 @@ expect(beforeEach(asyncFn, timeout)).type.toBeVoid();
 expect(beforeEach(genFn, timeout)).type.toBeVoid();
 expect(
   beforeEach(done => {
-    expect(done).type.toEqual<Global.DoneFn>();
+    expect(done).type.toBe<Global.DoneFn>();
   }, timeout),
 ).type.toBeVoid();
 
@@ -125,7 +125,7 @@ expect(afterAll(asyncFn)).type.toBeVoid();
 expect(afterAll(genFn)).type.toBeVoid();
 expect(
   afterAll(done => {
-    expect(done).type.toEqual<Global.DoneFn>();
+    expect(done).type.toBe<Global.DoneFn>();
   }),
 ).type.toBeVoid();
 
@@ -134,7 +134,7 @@ expect(afterAll(asyncFn, timeout)).type.toBeVoid();
 expect(afterAll(genFn, timeout)).type.toBeVoid();
 expect(
   afterAll(done => {
-    expect(done).type.toEqual<Global.DoneFn>();
+    expect(done).type.toBe<Global.DoneFn>();
   }, timeout),
 ).type.toBeVoid();
 
@@ -159,7 +159,7 @@ expect(afterEach(asyncFn)).type.toBeVoid();
 expect(afterEach(genFn)).type.toBeVoid();
 expect(
   afterEach(done => {
-    expect(done).type.toEqual<Global.DoneFn>();
+    expect(done).type.toBe<Global.DoneFn>();
   }),
 ).type.toBeVoid();
 
@@ -168,7 +168,7 @@ expect(afterEach(asyncFn, timeout)).type.toBeVoid();
 expect(afterEach(genFn, timeout)).type.toBeVoid();
 expect(
   afterEach(done => {
-    expect(done).type.toEqual<Global.DoneFn>();
+    expect(done).type.toBe<Global.DoneFn>();
   }, timeout),
 ).type.toBeVoid();
 
@@ -193,7 +193,7 @@ expect(test(testName, asyncFn)).type.toBeVoid();
 expect(test(testName, genFn)).type.toBeVoid();
 expect(
   test(testName, done => {
-    expect(done).type.toEqual<Global.DoneFn>();
+    expect(done).type.toBe<Global.DoneFn>();
   }),
 ).type.toBeVoid();
 
@@ -204,7 +204,7 @@ expect(
   test(
     testName,
     done => {
-      expect(done).type.toEqual<Global.DoneFn>();
+      expect(done).type.toBe<Global.DoneFn>();
     },
     timeout,
   ),
@@ -271,21 +271,21 @@ expect(test.concurrent.failing(function named() {}, asyncFn)).type.toBeVoid();
 expect(test.concurrent.failing(class {}, asyncFn)).type.toBeVoid();
 expect(test.concurrent.failing(class Named {}, asyncFn)).type.toBeVoid();
 
-expect(test.concurrent.failing.each).type.toEqual(test.concurrent.each);
+expect(test.concurrent.failing.each).type.toBe(test.concurrent.each);
 
 expect(test.concurrent.failing(testName, fn)).type.toRaiseError();
 
 // test.concurrent.only
 
-expect(test.concurrent.only.each).type.toEqual(test.concurrent.each);
-expect(test.concurrent.only.failing).type.toEqual(test.concurrent.failing);
-expect(test.concurrent.only.failing.each).type.toEqual(test.concurrent.each);
+expect(test.concurrent.only.each).type.toBe(test.concurrent.each);
+expect(test.concurrent.only.failing).type.toBe(test.concurrent.failing);
+expect(test.concurrent.only.failing.each).type.toBe(test.concurrent.each);
 
 // test.concurrent.skip
 
-expect(test.concurrent.skip.each).type.toEqual(test.concurrent.each);
-expect(test.concurrent.skip.failing).type.toEqual(test.concurrent.failing);
-expect(test.concurrent.skip.failing.each).type.toEqual(test.concurrent.each);
+expect(test.concurrent.skip.each).type.toBe(test.concurrent.each);
+expect(test.concurrent.skip.failing).type.toBe(test.concurrent.failing);
+expect(test.concurrent.skip.failing.each).type.toBe(test.concurrent.each);
 
 // test.each
 
@@ -309,7 +309,7 @@ expect(test.failing(function named() {}, fn)).type.toBeVoid();
 expect(test.failing(class {}, fn)).type.toBeVoid();
 expect(test.failing(class Named {}, fn)).type.toBeVoid();
 
-expect(test.failing.each).type.toEqual(test.each);
+expect(test.failing.each).type.toBe(test.each);
 
 // test.only
 
@@ -322,9 +322,9 @@ expect(test.only(function named() {}, fn)).type.toBeVoid();
 expect(test.only(class {}, fn)).type.toBeVoid();
 expect(test.only(class Named {}, fn)).type.toBeVoid();
 
-expect(test.only.each).type.toEqual(test.each);
-expect(test.only.failing).type.toEqual(test.failing);
-expect(test.only.failing.each).type.toEqual(test.each);
+expect(test.only.each).type.toBe(test.each);
+expect(test.only.failing).type.toBe(test.failing);
+expect(test.only.failing.each).type.toBe(test.each);
 
 // test.skip
 
@@ -337,9 +337,9 @@ expect(test.skip(function named() {}, fn)).type.toBeVoid();
 expect(test.skip(class {}, fn)).type.toBeVoid();
 expect(test.skip(class Named {}, fn)).type.toBeVoid();
 
-expect(test.skip.each).type.toEqual(test.each);
-expect(test.skip.failing).type.toEqual(test.failing);
-expect(test.skip.failing.each).type.toEqual(test.each);
+expect(test.skip.each).type.toBe(test.each);
+expect(test.skip.failing).type.toBe(test.failing);
+expect(test.skip.failing.each).type.toBe(test.each);
 
 // test.todo
 
@@ -391,7 +391,7 @@ expect(describe.only(function named() {}, fn)).type.toBeVoid();
 expect(describe.only(class {}, fn)).type.toBeVoid();
 expect(describe.only(class Named {}, fn)).type.toBeVoid();
 
-expect(describe.only.each).type.toEqual(describe.each);
+expect(describe.only.each).type.toBe(describe.each);
 
 // describe.skip
 
@@ -407,4 +407,4 @@ expect(describe.skip(function named() {}, fn)).type.toBeVoid();
 expect(describe.skip(class {}, fn)).type.toBeVoid();
 expect(describe.skip(class Named {}, fn)).type.toBeVoid();
 
-expect(describe.skip.each).type.toEqual(describe.each);
+expect(describe.skip.each).type.toBe(describe.each);

--- a/packages/jest-types/__typetests__/jest.test.ts
+++ b/packages/jest-types/__typetests__/jest.test.ts
@@ -54,12 +54,12 @@ expect(
     .useFakeTimers()
     .useFakeTimers({legacyFakeTimers: true})
     .useRealTimers(),
-).type.toEqual<typeof jest>();
+).type.toBe<typeof jest>();
 
-expect(jest.autoMockOff()).type.toEqual<typeof jest>();
+expect(jest.autoMockOff()).type.toBe<typeof jest>();
 expect(jest.autoMockOff(true)).type.toRaiseError();
 
-expect(jest.autoMockOn()).type.toEqual<typeof jest>();
+expect(jest.autoMockOn()).type.toBe<typeof jest>();
 expect(jest.autoMockOn(false)).type.toRaiseError();
 
 const someModule = {
@@ -68,21 +68,21 @@ const someModule = {
 };
 
 expect(jest.createMockFromModule('moduleName')).type.toBeUnknown();
-expect(jest.createMockFromModule<typeof someModule>('moduleName')).type.toEqual<
+expect(jest.createMockFromModule<typeof someModule>('moduleName')).type.toBe<
   Mocked<typeof someModule>
 >();
 expect(jest.createMockFromModule()).type.toRaiseError();
 
-expect(jest.deepUnmock('moduleName')).type.toEqual<typeof jest>();
+expect(jest.deepUnmock('moduleName')).type.toBe<typeof jest>();
 expect(jest.deepUnmock()).type.toRaiseError();
 
-expect(jest.doMock('moduleName')).type.toEqual<typeof jest>();
-expect(jest.doMock('moduleName', jest.fn())).type.toEqual<typeof jest>();
+expect(jest.doMock('moduleName')).type.toBe<typeof jest>();
+expect(jest.doMock('moduleName', jest.fn())).type.toBe<typeof jest>();
 expect(
   jest.doMock<{some: 'test'}>('moduleName', () => ({some: 'test'})),
-).type.toEqual<typeof jest>();
-expect(jest.doMock('moduleName', jest.fn(), {})).type.toEqual<typeof jest>();
-expect(jest.doMock('moduleName', jest.fn(), {virtual: true})).type.toEqual<
+).type.toBe<typeof jest>();
+expect(jest.doMock('moduleName', jest.fn(), {})).type.toBe<typeof jest>();
+expect(jest.doMock('moduleName', jest.fn(), {virtual: true})).type.toBe<
   typeof jest
 >();
 expect(jest.doMock()).type.toRaiseError();
@@ -90,29 +90,29 @@ expect(
   jest.doMock<{some: 'test'}>('moduleName', () => false),
 ).type.toRaiseError();
 
-expect(jest.dontMock('moduleName')).type.toEqual<typeof jest>();
+expect(jest.dontMock('moduleName')).type.toBe<typeof jest>();
 expect(jest.dontMock()).type.toRaiseError();
 
-expect(jest.disableAutomock()).type.toEqual<typeof jest>();
+expect(jest.disableAutomock()).type.toBe<typeof jest>();
 expect(jest.disableAutomock(true)).type.toRaiseError();
 
-expect(jest.enableAutomock()).type.toEqual<typeof jest>();
+expect(jest.enableAutomock()).type.toBe<typeof jest>();
 expect(jest.enableAutomock('moduleName')).type.toRaiseError();
 
-expect(jest.isolateModules(() => {})).type.toEqual<typeof jest>();
+expect(jest.isolateModules(() => {})).type.toBe<typeof jest>();
 expect(jest.isolateModules()).type.toRaiseError();
 
-expect(jest.isolateModulesAsync(async () => {})).type.toEqual<Promise<void>>();
+expect(jest.isolateModulesAsync(async () => {})).type.toBe<Promise<void>>();
 expect(jest.isolateModulesAsync(() => {})).type.toRaiseError();
 expect(jest.isolateModulesAsync()).type.toRaiseError();
 
-expect(jest.mock('moduleName')).type.toEqual<typeof jest>();
-expect(jest.mock('moduleName', jest.fn())).type.toEqual<typeof jest>();
+expect(jest.mock('moduleName')).type.toBe<typeof jest>();
+expect(jest.mock('moduleName', jest.fn())).type.toBe<typeof jest>();
 expect(
   jest.mock<{some: 'test'}>('moduleName', () => ({some: 'test'})),
-).type.toEqual<typeof jest>();
-expect(jest.mock('moduleName', jest.fn(), {})).type.toEqual<typeof jest>();
-expect(jest.mock('moduleName', jest.fn(), {virtual: true})).type.toEqual<
+).type.toBe<typeof jest>();
+expect(jest.mock('moduleName', jest.fn(), {})).type.toBe<typeof jest>();
+expect(jest.mock('moduleName', jest.fn(), {virtual: true})).type.toBe<
   typeof jest
 >();
 expect(jest.mock()).type.toRaiseError();
@@ -120,38 +120,38 @@ expect(
   jest.mock<{some: 'test'}>('moduleName', () => false),
 ).type.toRaiseError();
 
-expect(jest.unstable_mockModule('moduleName', jest.fn())).type.toEqual<
+expect(jest.unstable_mockModule('moduleName', jest.fn())).type.toBe<
   typeof jest
 >();
 expect(
   jest.unstable_mockModule<{some: 'test'}>('moduleName', () => ({
     some: 'test',
   })),
-).type.toEqual<typeof jest>();
+).type.toBe<typeof jest>();
 expect(
   jest.unstable_mockModule('moduleName', () => Promise.resolve(jest.fn())),
-).type.toEqual<typeof jest>();
+).type.toBe<typeof jest>();
 expect(
   jest.unstable_mockModule<{some: 'test'}>('moduleName', () =>
     Promise.resolve({
       some: 'test',
     }),
   ),
-).type.toEqual<typeof jest>();
-expect(jest.unstable_mockModule('moduleName', jest.fn(), {})).type.toEqual<
+).type.toBe<typeof jest>();
+expect(jest.unstable_mockModule('moduleName', jest.fn(), {})).type.toBe<
   typeof jest
 >();
 expect(
   jest.unstable_mockModule('moduleName', () => Promise.resolve(jest.fn()), {}),
-).type.toEqual<typeof jest>();
+).type.toBe<typeof jest>();
 expect(
   jest.unstable_mockModule('moduleName', jest.fn(), {virtual: true}),
-).type.toEqual<typeof jest>();
+).type.toBe<typeof jest>();
 expect(
   jest.unstable_mockModule('moduleName', () => Promise.resolve(jest.fn()), {
     virtual: true,
   }),
-).type.toEqual<typeof jest>();
+).type.toBe<typeof jest>();
 expect(jest.unstable_mockModule('moduleName')).type.toRaiseError();
 expect(
   jest.unstable_mockModule<{some: 'test'}>('moduleName', () => false),
@@ -163,35 +163,35 @@ expect(
 ).type.toRaiseError();
 
 expect(jest.requireActual('./pathToModule')).type.toBeUnknown();
-expect(jest.requireActual<{some: 'module'}>('./pathToModule')).type.toEqual<{
+expect(jest.requireActual<{some: 'module'}>('./pathToModule')).type.toBe<{
   some: 'module';
 }>();
 expect(jest.requireActual()).type.toRaiseError();
 
 expect(jest.requireMock('./pathToModule')).type.toBeUnknown();
-expect(jest.requireMock<{some: 'module'}>('./pathToModule')).type.toEqual<{
+expect(jest.requireMock<{some: 'module'}>('./pathToModule')).type.toBe<{
   some: 'module';
 }>();
 expect(jest.requireMock()).type.toRaiseError();
 
-expect(jest.resetModules()).type.toEqual<typeof jest>();
+expect(jest.resetModules()).type.toBe<typeof jest>();
 expect(jest.resetModules('moduleName')).type.toRaiseError();
 
-expect(jest.setMock('moduleName', {a: 'b'})).type.toEqual<typeof jest>();
+expect(jest.setMock('moduleName', {a: 'b'})).type.toBe<typeof jest>();
 expect(jest.setMock('moduleName')).type.toRaiseError();
 
-expect(jest.unmock('moduleName')).type.toEqual<typeof jest>();
+expect(jest.unmock('moduleName')).type.toBe<typeof jest>();
 expect(jest.unmock()).type.toRaiseError();
 
 // Mock Functions
 
-expect(jest.clearAllMocks()).type.toEqual<typeof jest>();
+expect(jest.clearAllMocks()).type.toBe<typeof jest>();
 expect(jest.clearAllMocks('moduleName')).type.toRaiseError();
 
-expect(jest.resetAllMocks()).type.toEqual<typeof jest>();
+expect(jest.resetAllMocks()).type.toBe<typeof jest>();
 expect(jest.resetAllMocks(true)).type.toRaiseError();
 
-expect(jest.restoreAllMocks()).type.toEqual<typeof jest>();
+expect(jest.restoreAllMocks()).type.toBe<typeof jest>();
 expect(jest.restoreAllMocks(false)).type.toRaiseError();
 
 expect(jest.isMockFunction(() => {})).type.toBeBoolean();
@@ -200,20 +200,20 @@ expect(jest.isMockFunction()).type.toRaiseError();
 const maybeMock = (a: string, b: number) => true;
 
 if (jest.isMockFunction(maybeMock)) {
-  expect(maybeMock).type.toEqual<Mock<(a: string, b: number) => boolean>>();
+  expect(maybeMock).type.toBe<Mock<(a: string, b: number) => boolean>>();
 
   maybeMock.mockReturnValueOnce(false);
   expect(maybeMock.mockReturnValueOnce(123)).type.toRaiseError();
 }
 
 if (!jest.isMockFunction(maybeMock)) {
-  expect(maybeMock).type.toEqual<(a: string, b: number) => boolean>();
+  expect(maybeMock).type.toBe<(a: string, b: number) => boolean>();
 }
 
 const surelyMock = jest.fn((a: string, b: number) => true);
 
 if (jest.isMockFunction(surelyMock)) {
-  expect(surelyMock).type.toEqual<Mock<(a: string, b: number) => boolean>>();
+  expect(surelyMock).type.toBe<Mock<(a: string, b: number) => boolean>>();
 
   surelyMock.mockReturnValueOnce(false);
   expect(surelyMock.mockReturnValueOnce(123)).type.toRaiseError();
@@ -232,7 +232,7 @@ const spiedObject = {
 const surelySpy = jest.spyOn(spiedObject, 'methodA');
 
 if (jest.isMockFunction(surelySpy)) {
-  expect(surelySpy).type.toEqual<
+  expect(surelySpy).type.toBe<
     MockInstance<(a: number, b: string) => boolean>
   >();
 
@@ -247,7 +247,7 @@ if (!jest.isMockFunction(surelySpy)) {
 declare const stringMaybeMock: string;
 
 if (jest.isMockFunction(stringMaybeMock)) {
-  expect(stringMaybeMock).type.toEqual<
+  expect(stringMaybeMock).type.toBe<
     string & Mock<(...args: Array<unknown>) => unknown>
   >();
 }
@@ -259,9 +259,7 @@ if (!jest.isMockFunction(stringMaybeMock)) {
 declare const anyMaybeMock: any;
 
 if (jest.isMockFunction(anyMaybeMock)) {
-  expect(anyMaybeMock).type.toEqual<
-    Mock<(...args: Array<unknown>) => unknown>
-  >();
+  expect(anyMaybeMock).type.toBe<Mock<(...args: Array<unknown>) => unknown>>();
 }
 
 if (!jest.isMockFunction(anyMaybeMock)) {
@@ -271,7 +269,7 @@ if (!jest.isMockFunction(anyMaybeMock)) {
 declare const unknownMaybeMock: unknown;
 
 if (jest.isMockFunction(unknownMaybeMock)) {
-  expect(unknownMaybeMock).type.toEqual<
+  expect(unknownMaybeMock).type.toBe<
     Mock<(...args: Array<unknown>) => unknown>
   >();
 }
@@ -280,16 +278,16 @@ if (!jest.isMockFunction(unknownMaybeMock)) {
   expect(unknownMaybeMock).type.toBeUnknown();
 }
 
-expect(jest.fn).type.toEqual<ModuleMocker['fn']>();
+expect(jest.fn).type.toBe<ModuleMocker['fn']>();
 
-expect(jest.spyOn).type.toEqual<ModuleMocker['spyOn']>();
+expect(jest.spyOn).type.toBe<ModuleMocker['spyOn']>();
 
-expect(jest.replaceProperty).type.toEqual<ModuleMocker['replaceProperty']>();
+expect(jest.replaceProperty).type.toBe<ModuleMocker['replaceProperty']>();
 
 // Mock<T>
 
-expect({} as jest.Mock<() => boolean>).type.toEqual<Mock<() => boolean>>();
-expect({} as jest.Mock<(a: string) => string>).type.toEqual<
+expect({} as jest.Mock<() => boolean>).type.toBe<Mock<() => boolean>>();
+expect({} as jest.Mock<(a: string) => string>).type.toBe<
   Mock<(a: string) => string>
 >();
 
@@ -345,29 +343,29 @@ const someObject = {
   someClassInstance: new SomeClass('value'),
 };
 
-expect(someObject as jest.Mocked<typeof someObject>).type.toEqual<
+expect(someObject as jest.Mocked<typeof someObject>).type.toBe<
   Mocked<typeof someObject>
 >();
 
-expect(SomeClass as jest.MockedClass<typeof SomeClass>).type.toEqual<
+expect(SomeClass as jest.MockedClass<typeof SomeClass>).type.toBe<
   MockedClass<typeof SomeClass>
 >();
 
-expect(someFunction as jest.MockedFunction<typeof someFunction>).type.toEqual<
+expect(someFunction as jest.MockedFunction<typeof someFunction>).type.toBe<
   MockedFunction<typeof someFunction>
 >();
 
-expect(someObject as jest.MockedObject<typeof someObject>).type.toEqual<
+expect(someObject as jest.MockedObject<typeof someObject>).type.toBe<
   MockedObject<typeof someObject>
 >();
 
 // mocked()
 
-expect(jest.mocked(someObject)).type.toEqual<Mocked<typeof someObject>>();
-expect(jest.mocked(someObject, {shallow: false})).type.toEqual<
+expect(jest.mocked(someObject)).type.toBe<Mocked<typeof someObject>>();
+expect(jest.mocked(someObject, {shallow: false})).type.toBe<
   Mocked<typeof someObject>
 >();
-expect(jest.mocked(someObject, {shallow: true})).type.toEqual<
+expect(jest.mocked(someObject, {shallow: true})).type.toBe<
   MockedShallow<typeof someObject>
 >();
 
@@ -375,24 +373,22 @@ expect(jest.mocked('abc')).type.toRaiseError();
 
 const mockObjectA = jest.mocked(someObject);
 
-expect(mockObjectA.methodA.mock.calls[0]).type.toEqual<[]>();
-expect(mockObjectA.methodB.mock.calls[0]).type.toEqual<[b: string]>();
-expect(mockObjectA.methodC.mock.calls[0]).type.toEqual<[c: number]>();
+expect(mockObjectA.methodA.mock.calls[0]).type.toBe<[]>();
+expect(mockObjectA.methodB.mock.calls[0]).type.toBe<[b: string]>();
+expect(mockObjectA.methodC.mock.calls[0]).type.toBe<[c: number]>();
 
-expect(mockObjectA.one.more.time.mock.calls[0]).type.toEqual<[t: number]>();
+expect(mockObjectA.one.more.time.mock.calls[0]).type.toBe<[t: number]>();
 
-expect(mockObjectA.SomeClass.mock.calls[0]).type.toEqual<
+expect(mockObjectA.SomeClass.mock.calls[0]).type.toBe<
   [one: string, two?: boolean]
 >();
-expect(mockObjectA.SomeClass.prototype.methodA.mock.calls[0]).type.toEqual<
-  []
->();
-expect(mockObjectA.SomeClass.prototype.methodB.mock.calls[0]).type.toEqual<
+expect(mockObjectA.SomeClass.prototype.methodA.mock.calls[0]).type.toBe<[]>();
+expect(mockObjectA.SomeClass.prototype.methodB.mock.calls[0]).type.toBe<
   [a: string, b?: number]
 >();
 
-expect(mockObjectA.someClassInstance.methodA.mock.calls[0]).type.toEqual<[]>();
-expect(mockObjectA.someClassInstance.methodB.mock.calls[0]).type.toEqual<
+expect(mockObjectA.someClassInstance.methodA.mock.calls[0]).type.toBe<[]>();
+expect(mockObjectA.someClassInstance.methodB.mock.calls[0]).type.toBe<
   [a: string, b?: number]
 >();
 
@@ -444,25 +440,23 @@ expect(
   mockObjectA.someClassInstance.methodB.mockImplementation((a: number) => 123),
 ).type.toRaiseError();
 
-expect<typeof someObject>().type.toBeAssignable(mockObjectA);
+expect<typeof someObject>().type.toBeAssignableWith(mockObjectA);
 
 // shallow mocked()
 
 const mockObjectB = jest.mocked(someObject, {shallow: true});
 
-expect(mockObjectB.methodA.mock.calls[0]).type.toEqual<[]>();
-expect(mockObjectB.methodB.mock.calls[0]).type.toEqual<[b: string]>();
-expect(mockObjectB.methodC.mock.calls[0]).type.toEqual<[c: number]>();
+expect(mockObjectB.methodA.mock.calls[0]).type.toBe<[]>();
+expect(mockObjectB.methodB.mock.calls[0]).type.toBe<[b: string]>();
+expect(mockObjectB.methodC.mock.calls[0]).type.toBe<[c: number]>();
 
 expect(mockObjectB.one.more.time.mock.calls[0]).type.toRaiseError();
 
-expect(mockObjectB.SomeClass.mock.calls[0]).type.toEqual<
+expect(mockObjectB.SomeClass.mock.calls[0]).type.toBe<
   [one: string, two?: boolean]
 >();
-expect(mockObjectB.SomeClass.prototype.methodA.mock.calls[0]).type.toEqual<
-  []
->();
-expect(mockObjectB.SomeClass.prototype.methodB.mock.calls[0]).type.toEqual<
+expect(mockObjectB.SomeClass.prototype.methodA.mock.calls[0]).type.toBe<[]>();
+expect(mockObjectB.SomeClass.prototype.methodB.mock.calls[0]).type.toBe<
   [a: string, b?: number]
 >();
 
@@ -499,39 +493,39 @@ expect(
   ),
 ).type.toRaiseError();
 
-expect<typeof someObject>().type.toBeAssignable(mockObjectB);
+expect<typeof someObject>().type.toBeAssignableWith(mockObjectB);
 
 // Replaced
 
-expect<jest.Replaced<number>>().type.toBeAssignable(
+expect<jest.Replaced<number>>().type.toBeAssignableWith(
   jest.replaceProperty(someObject, 'propertyA', 123),
 );
 
 // Spied
 
-expect<jest.Spied<typeof someObject.methodA>>().type.toBeAssignable(
+expect<jest.Spied<typeof someObject.methodA>>().type.toBeAssignableWith(
   jest.spyOn(someObject, 'methodA'),
 );
 
-expect<jest.Spied<typeof someObject.SomeClass>>().type.toBeAssignable(
+expect<jest.Spied<typeof someObject.SomeClass>>().type.toBeAssignableWith(
   jest.spyOn(someObject, 'SomeClass'),
 );
 
 // Spied*
 
-expect<jest.SpiedClass<typeof someObject.SomeClass>>().type.toBeAssignable(
+expect<jest.SpiedClass<typeof someObject.SomeClass>>().type.toBeAssignableWith(
   jest.spyOn(someObject, 'SomeClass'),
 );
 
-expect<jest.SpiedFunction<typeof someObject.methodB>>().type.toBeAssignable(
+expect<jest.SpiedFunction<typeof someObject.methodB>>().type.toBeAssignableWith(
   jest.spyOn(someObject, 'methodB'),
 );
 
-expect<jest.SpiedGetter<typeof someObject.propertyC>>().type.toBeAssignable(
+expect<jest.SpiedGetter<typeof someObject.propertyC>>().type.toBeAssignableWith(
   jest.spyOn(someObject, 'propertyC', 'get'),
 );
 
-expect<jest.SpiedSetter<typeof someObject.propertyC>>().type.toBeAssignable(
+expect<jest.SpiedSetter<typeof someObject.propertyC>>().type.toBeAssignableWith(
   jest.spyOn(someObject, 'propertyC', 'set'),
 );
 
@@ -540,15 +534,15 @@ expect<jest.SpiedSetter<typeof someObject.propertyC>>().type.toBeAssignable(
 expect(jest.advanceTimersByTime(6000)).type.toBeVoid();
 expect(jest.advanceTimersByTime()).type.toRaiseError();
 
-expect(jest.advanceTimersByTimeAsync(6000)).type.toEqual<Promise<void>>();
+expect(jest.advanceTimersByTimeAsync(6000)).type.toBe<Promise<void>>();
 expect(jest.advanceTimersByTimeAsync()).type.toRaiseError();
 
 expect(jest.advanceTimersToNextTimer()).type.toBeVoid();
 expect(jest.advanceTimersToNextTimer(2)).type.toBeVoid();
 expect(jest.advanceTimersToNextTimer('2')).type.toRaiseError();
 
-expect(jest.advanceTimersToNextTimerAsync()).type.toEqual<Promise<void>>();
-expect(jest.advanceTimersToNextTimerAsync(2)).type.toEqual<Promise<void>>();
+expect(jest.advanceTimersToNextTimerAsync()).type.toBe<Promise<void>>();
+expect(jest.advanceTimersToNextTimerAsync(2)).type.toBe<Promise<void>>();
 expect(jest.advanceTimersToNextTimerAsync('2')).type.toRaiseError();
 
 expect(jest.clearAllTimers()).type.toBeVoid();
@@ -572,13 +566,13 @@ expect(jest.runAllTicks(true)).type.toRaiseError();
 expect(jest.runAllTimers()).type.toBeVoid();
 expect(jest.runAllTimers(false)).type.toRaiseError();
 
-expect(jest.runAllTimersAsync()).type.toEqual<Promise<void>>();
+expect(jest.runAllTimersAsync()).type.toBe<Promise<void>>();
 expect(jest.runAllTimersAsync(false)).type.toRaiseError();
 
 expect(jest.runOnlyPendingTimers()).type.toBeVoid();
 expect(jest.runOnlyPendingTimers(true)).type.toRaiseError();
 
-expect(jest.runOnlyPendingTimersAsync()).type.toEqual<Promise<void>>();
+expect(jest.runOnlyPendingTimersAsync()).type.toBe<Promise<void>>();
 expect(jest.runOnlyPendingTimersAsync(true)).type.toRaiseError();
 
 expect(jest.advanceTimersToNextFrame()).type.toBeVoid();
@@ -591,13 +585,13 @@ expect(jest.setSystemTime(Date.now())).type.toBeVoid();
 expect(jest.setSystemTime(new Date(1995, 11, 17))).type.toBeVoid();
 expect(jest.setSystemTime('1995-12-17T03:24:00')).type.toRaiseError();
 
-expect(jest.useFakeTimers()).type.toEqual<typeof jest>();
+expect(jest.useFakeTimers()).type.toBe<typeof jest>();
 
-expect(jest.useFakeTimers({advanceTimers: true})).type.toEqual<typeof jest>();
-expect(jest.useFakeTimers({advanceTimers: 10})).type.toEqual<typeof jest>();
+expect(jest.useFakeTimers({advanceTimers: true})).type.toBe<typeof jest>();
+expect(jest.useFakeTimers({advanceTimers: 10})).type.toBe<typeof jest>();
 expect(jest.useFakeTimers({advanceTimers: 'fast'})).type.toRaiseError();
 
-expect(jest.useFakeTimers({doNotFake: ['Date']})).type.toEqual<typeof jest>();
+expect(jest.useFakeTimers({doNotFake: ['Date']})).type.toBe<typeof jest>();
 expect(
   jest.useFakeTimers({
     doNotFake: [
@@ -618,12 +612,10 @@ expect(
       'clearTimeout',
     ],
   }),
-).type.toEqual<typeof jest>();
+).type.toBe<typeof jest>();
 expect(jest.useFakeTimers({doNotFake: ['globalThis']})).type.toRaiseError();
 
-expect(jest.useFakeTimers({legacyFakeTimers: true})).type.toEqual<
-  typeof jest
->();
+expect(jest.useFakeTimers({legacyFakeTimers: true})).type.toBe<typeof jest>();
 expect(jest.useFakeTimers({legacyFakeTimers: 1000})).type.toRaiseError();
 expect(
   jest.useFakeTimers({doNotFake: ['Date'], legacyFakeTimers: true}),
@@ -638,44 +630,40 @@ expect(
   jest.useFakeTimers({legacyFakeTimers: true, timerLimit: 1000}),
 ).type.toRaiseError();
 
-expect(jest.useFakeTimers({now: 1_483_228_800_000})).type.toEqual<
-  typeof jest
->();
-expect(jest.useFakeTimers({now: Date.now()})).type.toEqual<typeof jest>();
-expect(jest.useFakeTimers({now: new Date(1995, 11, 17)})).type.toEqual<
+expect(jest.useFakeTimers({now: 1_483_228_800_000})).type.toBe<typeof jest>();
+expect(jest.useFakeTimers({now: Date.now()})).type.toBe<typeof jest>();
+expect(jest.useFakeTimers({now: new Date(1995, 11, 17)})).type.toBe<
   typeof jest
 >();
 expect(jest.useFakeTimers({now: '1995-12-17T03:24:00'})).type.toRaiseError();
 
-expect(jest.useFakeTimers({timerLimit: 1000})).type.toEqual<typeof jest>();
+expect(jest.useFakeTimers({timerLimit: 1000})).type.toBe<typeof jest>();
 expect(jest.useFakeTimers({timerLimit: true})).type.toRaiseError();
 
 expect(jest.useFakeTimers({enableGlobally: true})).type.toRaiseError();
 expect(jest.useFakeTimers('legacy')).type.toRaiseError();
 expect(jest.useFakeTimers('modern')).type.toRaiseError();
 
-expect(jest.useRealTimers()).type.toEqual<typeof jest>();
+expect(jest.useRealTimers()).type.toBe<typeof jest>();
 expect(jest.useRealTimers(true)).type.toRaiseError();
 
 // Misc
 
-expect(jest.retryTimes(3)).type.toEqual<typeof jest>();
-expect(jest.retryTimes(3, {logErrorsBeforeRetry: true})).type.toEqual<
+expect(jest.retryTimes(3)).type.toBe<typeof jest>();
+expect(jest.retryTimes(3, {logErrorsBeforeRetry: true})).type.toBe<
   typeof jest
 >();
 expect(jest.retryTimes(3, {logErrorsBeforeRetry: 'all'})).type.toRaiseError();
 expect(jest.retryTimes({logErrorsBeforeRetry: true})).type.toRaiseError();
-expect(jest.retryTimes(3, {waitBeforeRetry: 1000})).type.toEqual<typeof jest>();
+expect(jest.retryTimes(3, {waitBeforeRetry: 1000})).type.toBe<typeof jest>();
 expect(jest.retryTimes(3, {waitBeforeRetry: true})).type.toRaiseError();
-expect(jest.retryTimes(3, {retryImmediately: true})).type.toEqual<
-  typeof jest
->();
+expect(jest.retryTimes(3, {retryImmediately: true})).type.toBe<typeof jest>();
 expect(jest.retryTimes(3, {retryImmediately: 'now'})).type.toRaiseError();
 expect(jest.retryTimes(3, {retryImmediately: 1000})).type.toRaiseError();
 expect(jest.retryTimes({logErrorsBeforeRetry: 'all'})).type.toRaiseError();
 expect(jest.retryTimes()).type.toRaiseError();
 
-expect(jest.setTimeout(6000)).type.toEqual<typeof jest>();
+expect(jest.setTimeout(6000)).type.toBe<typeof jest>();
 expect(jest.setTimeout()).type.toRaiseError();
 
 expect(jest.getSeed()).type.toBeNumber();

--- a/packages/jest-worker/__typetests__/jest-worker.test.ts
+++ b/packages/jest-worker/__typetests__/jest-worker.test.ts
@@ -34,27 +34,23 @@ test('unknown JestWorkerFarm', () => {
   expect(unknownWorkerFarm).type.not.toHaveProperty('setup');
   expect(unknownWorkerFarm).type.not.toHaveProperty('teardown');
 
-  expect(unknownWorkerFarm.start()).type.toEqual<Promise<void>>();
-  expect(unknownWorkerFarm.end()).type.toEqual<
-    Promise<{forceExited: boolean}>
-  >();
+  expect(unknownWorkerFarm.start()).type.toBe<Promise<void>>();
+  expect(unknownWorkerFarm.end()).type.toBe<Promise<{forceExited: boolean}>>();
 
-  expect(unknownWorkerFarm.getStderr()).type.toEqual<NodeJS.ReadableStream>();
-  expect(unknownWorkerFarm.getStdout()).type.toEqual<NodeJS.ReadableStream>();
+  expect(unknownWorkerFarm.getStderr()).type.toBe<NodeJS.ReadableStream>();
+  expect(unknownWorkerFarm.getStdout()).type.toBe<NodeJS.ReadableStream>();
 });
 
 declare const inferredWorkerFarm: JestWorkerFarm<typeof testWorker>;
 
 test('inferred JestWorkerFarm', () => {
-  expect(inferredWorkerFarm.runTest('abc', true)).type.toEqual<Promise<void>>();
-  expect(inferredWorkerFarm.runTestAsync(123, 456)).type.toEqual<
-    Promise<void>
-  >();
+  expect(inferredWorkerFarm.runTest('abc', true)).type.toBe<Promise<void>>();
+  expect(inferredWorkerFarm.runTestAsync(123, 456)).type.toBe<Promise<void>>();
 
-  expect(inferredWorkerFarm.doSomething()).type.toEqual<Promise<void>>();
-  expect(inferredWorkerFarm.doSomething()).type.toEqual<Promise<void>>();
-  expect(inferredWorkerFarm.doSomethingAsync()).type.toEqual<Promise<void>>();
-  expect(inferredWorkerFarm.doSomethingAsync()).type.toEqual<Promise<void>>();
+  expect(inferredWorkerFarm.doSomething()).type.toBe<Promise<void>>();
+  expect(inferredWorkerFarm.doSomething()).type.toBe<Promise<void>>();
+  expect(inferredWorkerFarm.doSomethingAsync()).type.toBe<Promise<void>>();
+  expect(inferredWorkerFarm.doSomethingAsync()).type.toBe<Promise<void>>();
 
   expect(inferredWorkerFarm.runTest()).type.toRaiseError();
   expect(inferredWorkerFarm.runTest('abc')).type.toRaiseError();
@@ -69,20 +65,18 @@ test('inferred JestWorkerFarm', () => {
   expect(inferredWorkerFarm).type.not.toHaveProperty('setup');
   expect(inferredWorkerFarm).type.not.toHaveProperty('teardown');
 
-  expect(inferredWorkerFarm.start()).type.toEqual<Promise<void>>();
-  expect(inferredWorkerFarm.end()).type.toEqual<
-    Promise<{forceExited: boolean}>
-  >();
+  expect(inferredWorkerFarm.start()).type.toBe<Promise<void>>();
+  expect(inferredWorkerFarm.end()).type.toBe<Promise<{forceExited: boolean}>>();
 
-  expect(inferredWorkerFarm.getStderr()).type.toEqual<NodeJS.ReadableStream>();
-  expect(inferredWorkerFarm.getStdout()).type.toEqual<NodeJS.ReadableStream>();
+  expect(inferredWorkerFarm.getStderr()).type.toBe<NodeJS.ReadableStream>();
+  expect(inferredWorkerFarm.getStdout()).type.toBe<NodeJS.ReadableStream>();
 });
 
 declare const typedWorkerFarm: JestWorkerFarm<TestWorker>;
 
 test('typed JestWorkerFarm', () => {
-  expect(typedWorkerFarm.runTest('abc', 123)).type.toEqual<Promise<void>>();
-  expect(typedWorkerFarm.doSomething()).type.toEqual<Promise<void>>();
+  expect(typedWorkerFarm.runTest('abc', 123)).type.toBe<Promise<void>>();
+  expect(typedWorkerFarm.doSomething()).type.toBe<Promise<void>>();
 
   expect(typedWorkerFarm.runTest()).type.toRaiseError();
   expect(typedWorkerFarm.runTest('abc')).type.toRaiseError();
@@ -94,9 +88,9 @@ test('typed JestWorkerFarm', () => {
   expect(typedWorkerFarm).type.not.toHaveProperty('setup');
   expect(typedWorkerFarm).type.not.toHaveProperty('teardown');
 
-  expect(typedWorkerFarm.start()).type.toEqual<Promise<void>>();
-  expect(typedWorkerFarm.end()).type.toEqual<Promise<{forceExited: boolean}>>();
+  expect(typedWorkerFarm.start()).type.toBe<Promise<void>>();
+  expect(typedWorkerFarm.end()).type.toBe<Promise<{forceExited: boolean}>>();
 
-  expect(typedWorkerFarm.getStderr()).type.toEqual<NodeJS.ReadableStream>();
-  expect(typedWorkerFarm.getStdout()).type.toEqual<NodeJS.ReadableStream>();
+  expect(typedWorkerFarm.getStderr()).type.toBe<NodeJS.ReadableStream>();
+  expect(typedWorkerFarm.getStdout()).type.toBe<NodeJS.ReadableStream>();
 });

--- a/packages/jest/__typetests__/jest.test.ts
+++ b/packages/jest/__typetests__/jest.test.ts
@@ -12,6 +12,6 @@ describe('Config', () => {
   test('is a reexport of the `InitialOptions`', () => {
     type InitialOptions = import('@jest/types').Config.InitialOptions;
 
-    expect<Config>().type.toEqual<InitialOptions>();
+    expect<Config>().type.toBe<InitialOptions>();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,7 +3105,7 @@ __metadata:
     strip-json-comments: ^3.1.1
     tempy: ^1.0.0
     ts-node: ^10.5.0
-    tstyche: ^2.0.0-beta.0
+    tstyche: ^2.0.0-beta.1
     typescript: ^5.0.4
     webpack: ^5.68.0
     webpack-node-externals: ^3.0.0
@@ -20169,17 +20169,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tstyche@npm:^2.0.0-beta.0":
-  version: 2.0.0-beta.0
-  resolution: "tstyche@npm:2.0.0-beta.0"
+"tstyche@npm:^2.0.0-beta.1":
+  version: 2.0.0-beta.1
+  resolution: "tstyche@npm:2.0.0-beta.1"
   peerDependencies:
     typescript: 4.x || 5.x
   peerDependenciesMeta:
     typescript:
       optional: true
   bin:
-    tstyche: build/bin.js
-  checksum: 3b8d08111c5f6a13febc5ed65e403e667006c34c173d69c9ec087865ae18686699f8eb436b348d421544abdafb85adf0615450fe9114f3837cc1230afe6c19b2
+    tstyche: ./build/bin.js
+  checksum: ebdbd5852e883f29afe594179947bdb4a4905ac0d0b7840a39695eb24b605084071ebcae956e078478cfab2ce1f346689ec4d6a6e9874e169c8c6875fb42d418
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Some matchers got deprecated and renamed in TSTyche 2. This is simple find-and-replace change:

- `toEqual` > `toBe`
- `toBeAssignable` > `toBeAssignableWith`

## Test plan

Green CI (and there are no warnings in type tests).
