### PR TITLE
Fix Array matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - `[jest-config]` Allow `reporters` in project config ([#14768](https://github.com/jestjs/jest/pull/14768))
 - `[jest-config]` Allow Node16/NodeNext/Bundler `moduleResolution` in project's tsconfig ([#14739](https://github.com/jestjs/jest/pull/14739))
 - `[jest-each]` Allow `$keypath` templates with `null` or `undefined` values ([#14831](https://github.com/jestjs/jest/pull/14831))
+- `[jest-expect]` Fix matching of `Array` when instances are created in a new context. ([#15091](https://github.com/jestjs/jest/pull/15091))
 - `[@jest/expect-utils]` Fix comparison of `DataView` ([#14408](https://github.com/jestjs/jest/pull/14408))
 - `[@jest/expect-utils]` [**BREAKING**] exclude non-enumerable in object matching ([#14670](https://github.com/jestjs/jest/pull/14670))
 - `[@jest/expect-utils]` Fix comparison of `URL` ([#14672](https://github.com/jestjs/jest/pull/14672))

--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -21,6 +21,7 @@ import {
   stringNotContaining,
   stringNotMatching,
 } from '../asymmetricMatchers';
+import { runInNewContext } from 'node:vm';
 
 test('Any.asymmetricMatch()', () => {
   class Thing {}
@@ -51,6 +52,7 @@ test('Any.asymmetricMatch() on primitive wrapper classes', () => {
     any(Boolean).asymmetricMatch(new Boolean(true)),
     any(BigInt).asymmetricMatch(Object(1n)),
     any(Symbol).asymmetricMatch(Object(Symbol())),
+    any(Array).asymmetricMatch(runInNewContext('[];')),
     /* eslint-enable */
   ]) {
     jestExpect(test).toBe(true);

--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import {runInNewContext} from 'node:vm';
 import jestExpect from '../';
 import {
   any,
@@ -21,7 +22,6 @@ import {
   stringNotContaining,
   stringNotMatching,
 } from '../asymmetricMatchers';
-import { runInNewContext } from 'node:vm';
 
 test('Any.asymmetricMatch()', () => {
   class Thing {}

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -136,6 +136,10 @@ class Any extends AsymmetricMatcher<any> {
       return typeof other == 'object';
     }
 
+    if (this.sample == Array) {
+      return Array.isArray(other)
+    }
+
     return other instanceof this.sample;
   }
 
@@ -162,6 +166,10 @@ class Any extends AsymmetricMatcher<any> {
 
     if (this.sample == Boolean) {
       return 'boolean';
+    }
+
+    if (Array.isArray(this.sample)) {
+      return 'array';
     }
 
     return fnNameFor(this.sample);

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -137,7 +137,7 @@ class Any extends AsymmetricMatcher<any> {
     }
 
     if (this.sample == Array) {
-      return Array.isArray(other)
+      return Array.isArray(other);
     }
 
     return other instanceof this.sample;


### PR DESCRIPTION
Fixes matching type Array for arrays created in a new context.

## Summary

Fixes #15025
Jest does not correctly match arrays created in different contexts. This causes it to incorrectly match arrays from HTTP requests made by native fetch, failing tests when they should be passing.

## Test plan

Added a unit test to asymmetricMatchers for arrays created in a new context.

Before:
![image](https://github.com/jestjs/jest/assets/29686338/dad491c0-79f7-49d6-b72e-00beeae14baf)

After:
![image](https://github.com/jestjs/jest/assets/29686338/18fc67a4-8f9e-4527-9a12-b15d3b9add64)
