### PR TITLE
Link updated in docs

### DIFF
--- a/website/blog/2017-02-21-jest-19-immersive-watch-mode-test-platform-improvements.md
+++ b/website/blog/2017-02-21-jest-19-immersive-watch-mode-test-platform-improvements.md
@@ -87,9 +87,9 @@ We're close to almost full feature parity with the `expect` npm package. [Michae
 
 Thanks to [Jonathan Kim](https://twitter.com/jonnykim) Jest finally has its own official ESLint plugin. It exposes three rules:
 
-- [no-disabled-tests](https://github.com/jestjs/jest/blob/main/packages/eslint-plugin-jest/docs/rules/no-disabled-tests.md) - this rule prevents you from accidentally committing disabled tests.
-- [no-focused-tests](https://github.com/jestjs/jest/blob/main/packages/eslint-plugin-jest/docs/rules/no-focused-tests.md) - this rule prevents you from committing focused tests which would disable all other tests in the same suite.
-- [no-identical-title](https://github.com/jestjs/jest/blob/main/packages/eslint-plugin-jest/docs/rules/no-identical-title.md) - disallows identical titles in test names.
+- [no-disabled-tests](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-disabled-tests.md) - this rule prevents you from accidentally committing disabled tests.
+- [no-focused-tests](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md) - this rule prevents you from committing focused tests which would disable all other tests in the same suite.
+- [no-identical-title](https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-identical-title.md) - disallows identical titles in test names.
 
 You can install it using `npm install --save-dev eslint-plugin-jest` or `yarn add --dev eslint eslint-plugin-jest` and it can be enabled by adding `{"plugins": ["jest"]}` to your eslint configuration.
 

--- a/website/blog/2017-02-21-jest-19-immersive-watch-mode-test-platform-improvements.md
+++ b/website/blog/2017-02-21-jest-19-immersive-watch-mode-test-platform-improvements.md
@@ -83,7 +83,7 @@ We now also error on invalid CLI arguments instead of ignoring them. But we've g
 
 We're close to almost full feature parity with the `expect` npm package. [Michael Jackson](https://twitter.com/mjackson), the author of the package, agreed to [donate](https://github.com/jestjs/jest/issues/1679) it to the Jest project, which means that `jest-matchers` will be renamed to `expect`. Since our version of `expect` is not intended to be fully compatible, [Christopher Chedeau](https://twitter.com/Vjeux) is working on a codemod to make the transition painless. Christopher also worked on a number of improvements to `jest-matchers` which enables it to be used outside of Jest and even [works inside browsers](https://github.com/jestjs/jest/pull/2795).
 
-## [eslint-plugin-jest](https://github.com/jestjs/jest/tree/main/packages/eslint-plugin-jest) – our very own ESLint plugin
+## [eslint-plugin-jest](https://github.com/jest-community/eslint-plugin-jest) – our very own ESLint plugin
 
 Thanks to [Jonathan Kim](https://twitter.com/jonnykim) Jest finally has its own official ESLint plugin. It exposes three rules:
 


### PR DESCRIPTION
A minor update of a url in Jest documentation directing to jest plugin

under:
`https://jestjs.io/blog/2017/02/21/jest-19-immersive-watch-mode-test-platform-improvements#eslint-plugin-jest--our-very-own-eslint-plugin`

