### PR TITLE
chore!: drop support for Node.js 21

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [16.x, 18.x, 20.x, 21.x, 22.x]
+        node-version: [16.x, 18.x, 20.x, 22.x]
     name: Node v${{ matrix.node-version }}
     runs-on: ${{ inputs.os }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,7 +81,7 @@
 ### Chore & Maintenance
 
 - `[*]` Increase version of `micromatch` to `^4.0.7` ([#15082](https://github.com/jestjs/jest/pull/15082))
-- `[*]` [**BREAKING**] Drop support for Node.js versions 14 and 19 ([#14460](https://github.com/jestjs/jest/pull/14460))
+- `[*]` [**BREAKING**] Drop support for Node.js versions 14, 19 and 21 ([#14460](https://github.com/jestjs/jest/pull/14460), [#15118](https://github.com/jestjs/jest/pull/15118))
 - `[*]` [**BREAKING**] Drop support for `typescript@4.3`, minimum version is now `5.0` ([#14542](https://github.com/jestjs/jest/pull/14542))
 - `[*]` Depend on exact versions of monorepo dependencies instead of `^` range ([#14553](https://github.com/jestjs/jest/pull/14553))
 - `[*]` [**BREAKING**] Add ESM wrapper for all of Jest's modules ([#14661](https://github.com/jestjs/jest/pull/14661))

--- a/e2e/__tests__/__snapshots__/wrongEnv.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/wrongEnv.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Wrong globals for environment on node <21 print useful error for navigator 1`] = `
+exports[`Wrong globals for environment on node <=18 print useful error for navigator 1`] = `
 "FAIL __tests__/node.js
   ✕ use navigator
   ○ skipped use document

--- a/e2e/__tests__/wrongEnv.test.ts
+++ b/e2e/__tests__/wrongEnv.test.ts
@@ -24,7 +24,8 @@ describe('Wrong globals for environment', () => {
     assertFailuresAndSnapshot(['node', '-t=document']);
   });
 
-  onNodeVersions('<21', () => {
+  // Node.js 18 is the last LTS version, which is missing the global 'navigator'
+  onNodeVersions('<=18', () => {
     it('print useful error for navigator', () => {
       assertFailuresAndSnapshot(['node', '-t=navigator']);
     });


### PR DESCRIPTION
## Summary

Perhaps it is time to drop Node.js 21? It is end-of-life since 2024-06-01. Reference: https://github.com/nodejs/Release

## Test plan

Green CI.