### PR TITLE
chore(test): remove redundant `onNodeVersions()` wrappers

### DIFF
--- a/packages/expect/src/__tests__/toThrowMatchers.test.ts
+++ b/packages/expect/src/__tests__/toThrowMatchers.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {alignedAnsiStyleSerializer, onNodeVersions} from '@jest/test-utils';
+import {alignedAnsiStyleSerializer} from '@jest/test-utils';
 import jestExpect from '../';
 
 expect.addSnapshotSerializer(alignedAnsiStyleSerializer);
@@ -302,36 +302,32 @@ describe('toThrow', () => {
         }).not.toThrow(expected);
       });
 
-      onNodeVersions('>=16.9.0', () => {
-        test('isNot true, incorrect cause', () => {
-          jestExpect(() => {
-            throw new Error('good', {cause: errorA});
-          }).not.toThrow(expected);
-        });
+      test('isNot true, incorrect cause', () => {
+        jestExpect(() => {
+          throw new Error('good', {cause: errorA});
+        }).not.toThrow(expected);
       });
     });
 
     describe('fail', () => {
-      onNodeVersions('>=16.9.0', () => {
-        test('isNot false, incorrect message', () => {
-          expect(() =>
-            jestExpect(() => {
-              throw new Error('bad', {cause: errorB});
-            }).toThrow(expected),
-          ).toThrow(
-            /^(?=.*Expected message and cause: ).*Received message and cause: /s,
-          );
-        });
+      test('isNot false, incorrect message', () => {
+        expect(() =>
+          jestExpect(() => {
+            throw new Error('bad', {cause: errorB});
+          }).toThrow(expected),
+        ).toThrow(
+          /^(?=.*Expected message and cause: ).*Received message and cause: /s,
+        );
+      });
 
-        test('isNot true, incorrect cause', () => {
-          expect(() =>
-            jestExpect(() => {
-              throw new Error('good', {cause: errorA});
-            }).toThrow(expected),
-          ).toThrow(
-            /^(?=.*Expected message and cause: ).*Received message and cause: /s,
-          );
-        });
+      test('isNot true, incorrect cause', () => {
+        expect(() =>
+          jestExpect(() => {
+            throw new Error('good', {cause: errorA});
+          }).toThrow(expected),
+        ).toThrow(
+          /^(?=.*Expected message and cause: ).*Received message and cause: /s,
+        );
       });
     });
   });

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
@@ -111,25 +111,6 @@ exports[`no stack 1`] = `
 "
 `;
 
-exports[`on node >=15.0.0 should return the inner errors of an AggregateError 1`] = `
-"  <bold>● </intensity>Test suite failed to run
-
-    AggregateError:
-
-      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:586:22)</intensity>
-
-    Errors contained in AggregateError:
-     Err 1
-
-          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:587:7)</intensity>
-
-     Err 2
-
-          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:588:7)</intensity>
-
-"
-`;
-
 exports[`retains message in babel code frame error 1`] = `
 "<bold><red>  <bold>● </intensity><bold>Babel test</color></intensity>
 
@@ -177,12 +158,31 @@ exports[`should return the error cause if there is one 1`] = `
 
     Test exception
 
-      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:565:17)</intensity>
+      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:564:17)</intensity>
 
     Cause:
      Cause Error
 
-          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:568:17)</intensity>
+          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:567:17)</intensity>
+
+"
+`;
+
+exports[`should return the inner errors of an AggregateError 1`] = `
+"  <bold>● </intensity>Test suite failed to run
+
+    AggregateError:
+
+      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:583:20)</intensity>
+
+    Errors contained in AggregateError:
+     Err 1
+
+          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:583:40)</intensity>
+
+     Err 2
+
+          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:583:60)</intensity>
 
 "
 `;

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -9,7 +9,6 @@
 import {readFileSync} from 'graceful-fs';
 import slash = require('slash');
 import tempy = require('tempy');
-import {onNodeVersions} from '@jest/test-utils';
 import {
   formatExecError,
   formatResultsErrors,
@@ -579,24 +578,18 @@ it('should return the error cause if there is one', () => {
   expect(message).toMatchSnapshot();
 });
 
-// TODO remove this wrapper when the lowest supported Node version is v16
-onNodeVersions('>=15.0.0', () => {
-  it('should return the inner errors of an AggregateError', () => {
-    // See https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V15.md#v8-86---35415
-    const aggError = new AggregateError([
-      new Error('Err 1'),
-      new Error('Err 2'),
-    ]);
-    const message = formatExecError(
-      aggError,
-      {
-        rootDir: '',
-        testMatch: [],
-      },
-      {
-        noStackTrace: false,
-      },
-    );
-    expect(message).toMatchSnapshot();
-  });
+it('should return the inner errors of an AggregateError', () => {
+  // See https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V15.md#v8-86---35415
+  const aggError = new AggregateError([new Error('Err 1'), new Error('Err 2')]);
+  const message = formatExecError(
+    aggError,
+    {
+      rootDir: '',
+      testMatch: [],
+    },
+    {
+      noStackTrace: false,
+    },
+  );
+  expect(message).toMatchSnapshot();
 });

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -12,7 +12,6 @@ import {builtinModules, createRequire} from 'module';
 import * as path from 'path';
 import {pathToFileURL} from 'url';
 import slash from 'slash';
-import {onNodeVersions} from '@jest/test-utils';
 
 let createRuntime;
 
@@ -195,17 +194,15 @@ describe('Runtime requireModule', () => {
     }).not.toThrow();
   });
 
-  onNodeVersions('^16.0.0', () => {
-    it('finds node core built-in modules with node:prefix', async () => {
-      const runtime = await createRuntime(__filename);
+  it('finds node core built-in modules with node:prefix', async () => {
+    const runtime = await createRuntime(__filename);
 
-      expect(runtime.requireModule(runtime.__mockRootPath, 'fs')).toBe(
-        runtime.requireModule(runtime.__mockRootPath, 'node:fs'),
-      );
-      expect(runtime.requireModule(runtime.__mockRootPath, 'module')).toBe(
-        runtime.requireModule(runtime.__mockRootPath, 'node:module'),
-      );
-    });
+    expect(runtime.requireModule(runtime.__mockRootPath, 'fs')).toBe(
+      runtime.requireModule(runtime.__mockRootPath, 'node:fs'),
+    );
+    expect(runtime.requireModule(runtime.__mockRootPath, 'module')).toBe(
+      runtime.requireModule(runtime.__mockRootPath, 'node:module'),
+    );
   });
 
   it('finds and loads JSON files without file extension', async () => {
@@ -415,38 +412,5 @@ describe('Runtime requireModule', () => {
 
     expect(exports.syncBuiltinESMExports).not.toThrow();
     expect(exports.builtinModules).toEqual(builtinModules);
-  });
-
-  onNodeVersions('<16.0.0', () => {
-    it('overrides module.createRequireFromPath', async () => {
-      const runtime = await createRuntime(__filename);
-      const exports = runtime.requireModule(runtime.__mockRootPath, 'module');
-
-      // createRequire with relative module path
-      expect(() => exports.createRequireFromPath('./relative/path')).toThrow(
-        new TypeError(
-          "The argument 'filename' must be a file URL object, file URL string, or absolute path string. Received './relative/path'",
-        ),
-      );
-
-      // createRequireFromPath with absolute module path
-      {
-        const customRequire = exports.createRequireFromPath(
-          runtime.__mockRootPath,
-        );
-        expect(customRequire('./create_require_module').foo).toBe('foo');
-      }
-
-      // createRequireFromPath with file URL object
-      expect(() =>
-        exports.createRequireFromPath(pathToFileURL(runtime.__mockRootPath)),
-      ).toThrow(
-        new TypeError(
-          `The argument 'filename' must be string. Received '${pathToFileURL(
-            runtime.__mockRootPath,
-          )}'. Use createRequire for URL filename.`,
-        ),
-      );
-    });
   });
 });


### PR DESCRIPTION
## Summary

Currently the lowest supported Node.js version is `16.10.0`. This means that several `onNodeVersions()` wrappers can be removed, because they are targeting lower versions.

## Test plan

Green CI.