### PR TITLE
Update GettingStarted.md with current Vite related information

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -127,9 +127,9 @@ Jest can be used in projects that use [webpack](https://webpack.js.org/) to mana
 
 Jest is not supported by Vite due to incompatibilities with the Vite [plugin system](https://github.com/vitejs/vite/issues/1955#issuecomment-776009094).
 
-There are examples for Jest integration with Vite in the [vite-jest](https://github.com/sodatea/vite-jest) library. However, as of 5/10/24, this library is not compatible with versions of Vite later than 2.4.2.
+There are examples for Jest integration with Vite in the [vite-jest](https://github.com/sodatea/vite-jest) library. However, this library is not compatible with versions of Vite later than 2.4.2.
 
-One current (5/10/24) alternative is [Vitest](https://vitest.dev/) which has an API intended to be similar to Jest and a [migration guide](https://vitest.dev/guide/migration.html#migrating-from-jest).
+One alternative is [Vitest](https://vitest.dev/) which has an API compatible Jest.
 
 ### Using Parcel
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -119,6 +119,10 @@ module.exports = {
 
 </details>
 
+## Using with bundlers
+
+Most of the time you do not need to do anything special to work with different bundlers - the exception is if you have some plugin or configuration which generates files or have custom file resolution rules.
+
 ### Using webpack
 
 Jest can be used in projects that use [webpack](https://webpack.js.org/) to manage assets, styles, and compilation. webpack does offer some unique challenges over other tools. Refer to the [webpack guide](Webpack.md) to get started.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -125,7 +125,11 @@ Jest can be used in projects that use [webpack](https://webpack.js.org/) to mana
 
 ### Using Vite
 
-Jest can be used in projects that use [vite](https://vitejs.dev/) to serve source code over native ESM to provide some frontend tooling, vite is an opinionated tool and does offer some out-of-the box workflows. Jest is not fully supported by vite due to how the [plugin system](https://github.com/vitejs/vite/issues/1955#issuecomment-776009094) from vite works, but there are some working examples for first-class jest integration using `vite-jest`, since this is not fully supported, you might as well read the [limitation of the `vite-jest`](https://github.com/sodatea/vite-jest/tree/main/packages/vite-jest#limitations-and-differences-with-commonjs-tests). Refer to the [vite guide](https://vitejs.dev/guide/) to get started.
+Jest is not supported by Vite due to incompatibilities with the Vite [plugin system](https://github.com/vitejs/vite/issues/1955#issuecomment-776009094).
+
+There are examples for Jest integration with Vite in the [vite-jest](https://github.com/sodatea/vite-jest) library. However, as of 5/10/24, this library is not compatible with versions of Vite later than 2.4.2.
+
+One current (5/10/24) alternative is [Vitest](https://vitest.dev/) which has an API intended to be similar to Jest and a [migration guide](https://vitest.dev/guide/migration.html#migrating-from-jest).
 
 ### Using Parcel
 


### PR DESCRIPTION
## Summary

As per #15121 the current information regarding usage with Vite is out of date. The recommended compatibility library [vite-jest](https://github.com/sodatea/vite-jest) appears to be unmaintained and is not compatible with the current Vite release. 

Additionally, this change points users to [Vitest](https://vitest.dev/), a currently maintained alternative to which I have found migration relatively painless. 

## Test plan

No tests,  just documentation.

<img width="502" alt="Screenshot 2024-06-11 at 12 39 22 PM" src="https://github.com/jestjs/jest/assets/1335043/183ed8ec-170e-46b9-8379-1afa4a023b92">

