### PR TITLE
Update Immutable.ts

### DIFF
--- a/packages/pretty-format/src/plugins/Immutable.ts
+++ b/packages/pretty-format/src/plugins/Immutable.ts
@@ -36,7 +36,7 @@ const printImmutableEntries = (
   ++depth > config.maxDepth
     ? printAsLeaf(getImmutableName(type))
     : `${getImmutableName(type) + SPACE}{${printIteratorEntries(
-        val.entries(),
+        'entries' in val ? val.entries() : [].entries(),
         config,
         indentation,
         depth,


### PR DESCRIPTION
Fix issue where `.entries()` doesn't exist on value

context:

in certain situations when using `expect(expected).toEqual(actual)` `.entries()` would not be defined and cause the test to blow up unnecessarily

I saw this personally when using `new Proxy()` which I guess there might be some false positives around using proxies in the test environment

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
