### PR TITLE
Add --onlyFailures to documentation

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -289,6 +289,10 @@ Activates notifications for test results. Good for when you don't want your cons
 
 Alias: `-o`. Attempts to identify which tests to run based on which files have changed in the current repository. Only works if you're running tests in a git/hg repository at the moment and requires a static dependency graph (ie. no dynamic requires).
 
+### `--onlyFailures`
+
+Alias: `-f`. Run tests that failed in the previous execution.
+
 ### `--openHandlesTimeout=<milliseconds>`
 
 When `--detectOpenHandles` and `--forceExit` are _disabled_, Jest will print a warning if the process has not exited cleanly after this number of milliseconds. A value of `0` disables the warning. Defaults to `1000`.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

The `--onlyFailures` flag was not documented on <https://jestjs.io/docs/cli>, but it was shown when running `jest --help`. Added it here to avoid confusion.
