### PR TITLE
Update jest-validate/utils.ts to import chalk as ESM

### DIFF
--- a/packages/jest-config/src/utils.ts
+++ b/packages/jest-config/src/utils.ts
@@ -6,7 +6,7 @@
  */
 
 import * as path from 'path';
-import chalk = require('chalk');
+import chalk from 'chalk';
 import Resolver from 'jest-resolve';
 import {ValidationError} from 'jest-validate';
 

--- a/packages/jest-validate/src/utils.ts
+++ b/packages/jest-validate/src/utils.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import chalk = require('chalk');
+import chalk from 'chalk';
 import leven from 'leven';
 import {format as prettyFormat} from 'pretty-format';
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->
will update the changelog if this is a valid change

## Summary

attempting to run experimental vm modules throws this error

```
> node --experimental-vm-modules node_modules/.bin/jest

Error [ERR_REQUIRE_ESM]: require() of ES Module /Users/.../node_modules/chalk/source/index.js from /Users/.../node_modules/jest-validate/build/utils.js not supported.
Instead change the require of index.js in /Users/.../node_modules/jest-validate/build/utils.js to a dynamic import() which is available in all CommonJS modules.
    at _chalk (/Users/.../node_modules/jest-validate/build/utils.js:16:39)
    at Object.<anonymous> (/Users/.../node_modules/jest-validate/build/utils.js:46:16)
```

## Test plan

following the usage docs for `chalk` https://github.com/chalk/chalk?tab=readme-ov-file#usage
