### PR TITLE
fix: update the return type of `createCacheKey`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@
 - `[jest-config]` Support `coverageReporters` in project config ([#14697](https://github.com/jestjs/jest/pull/14830))
 - `[jest-config]` Allow `reporters` in project config ([#14768](https://github.com/jestjs/jest/pull/14768))
 - `[jest-config]` Allow Node16/NodeNext/Bundler `moduleResolution` in project's tsconfig ([#14739](https://github.com/jestjs/jest/pull/14739))
+- `[@jest/create-cache-key-function]` Correct the return type of `createCacheKey` ([#15159](https://github.com/jestjs/jest/pull/15159))
 - `[jest-each]` Allow `$keypath` templates with `null` or `undefined` values ([#14831](https://github.com/jestjs/jest/pull/14831))
 - `[@jest/expect-utils]` Fix comparison of `DataView` ([#14408](https://github.com/jestjs/jest/pull/14408))
 - `[@jest/expect-utils]` [**BREAKING**] exclude non-enumerable in object matching ([#14670](https://github.com/jestjs/jest/pull/14670))

--- a/packages/jest-create-cache-key-function/src/index.ts
+++ b/packages/jest-create-cache-key-function/src/index.ts
@@ -38,7 +38,7 @@ type NewGetCacheKeyFunction = (
   options: NewCacheKeyOptions,
 ) => string;
 
-type GetCacheKeyFunction = OldGetCacheKeyFunction | NewGetCacheKeyFunction;
+type GetCacheKeyFunction = OldGetCacheKeyFunction & NewGetCacheKeyFunction;
 
 const {NODE_ENV, BABEL_ENV} = process.env;
 
@@ -65,7 +65,7 @@ function getCacheKeyFunction(
   globalCacheKey: string,
   length: number,
 ): GetCacheKeyFunction {
-  return (sourceText, sourcePath, configString, options) => {
+  return ((sourceText, sourcePath, configString, options) => {
     // Jest 27 passes a single options bag which contains `configString` rather than as a separate argument.
     // We can hide that API difference, though, so this module is usable for both jest@<27 and jest@>=27
     const inferredOptions = options || configString;
@@ -81,7 +81,7 @@ function getCacheKeyFunction(
       .update(instrument ? 'instrument' : '')
       .digest('hex')
       .slice(0, length);
-  };
+  }) as GetCacheKeyFunction;
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Because this function supports both jest@<27 and jest@>=27, it should be an intersection of two types rather than a union.

## Test plan

```ts
// no type errors
const getCacheKey: AsyncTransformer["getCacheKey"] = createCacheKey();
````
