### PR TITLE
feat(babel-jest): add option excludeJestPreset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[babel-jest]` Add option `excludeJestPreset` to allow opting out of `babel-preset-jest` ([#15164](https://github.com/jestjs/jest/pull/15164))
 - `[jest-circus, jest-cli, jest-config]` Add `waitNextEventLoopTurnForUnhandledRejectionEvents` flag to minimise performance impact of correct detection of unhandled promise rejections introduced in [#14315](https://github.com/jestjs/jest/pull/14315) ([#14681](https://github.com/jestjs/jest/pull/14681))
 - `[jest-circus]` Add a `waitBeforeRetry` option to `jest.retryTimes` ([#14738](https://github.com/jestjs/jest/pull/14738))
 - `[jest-circus]` Add a `retryImmediately` option to `jest.retryTimes` ([#14696](https://github.com/jestjs/jest/pull/14696))

--- a/docs/CodeTransformation.md
+++ b/docs/CodeTransformation.md
@@ -15,6 +15,18 @@ Jest will cache the result of a transformation and attempt to invalidate that re
 
 Jest ships with one transformer out of the box &ndash; [`babel-jest`](https://github.com/jestjs/jest/tree/main/packages/babel-jest#setup). It will load your project's Babel configuration and transform any file matching the `/\.[jt]sx?$/` RegExp (in other words, any `.js`, `.jsx`, `.ts` or `.tsx` file). In addition, `babel-jest` will inject the Babel plugin necessary for mock hoisting talked about in [ES Module mocking](ManualMocks.md#using-with-es-module-imports).
 
+:::note
+
+By default, `babel-jest` includes `babel-preset-jest`. You can disable this behavior by specifying `excludeJestPreset: true` to `babel-jest`. Note that this will also stop hoisting `jest.mock`, which may break your tests.
+
+```json
+"transform": {
+  "\\.[jt]sx?$": ["babel-jest", { "excludeJestPreset": true }],
+}
+```
+
+:::
+
 :::tip
 
 Remember to include the default `babel-jest` transformer explicitly, if you wish to use it alongside with additional code preprocessors:

--- a/packages/babel-jest/README.md
+++ b/packages/babel-jest/README.md
@@ -33,3 +33,11 @@ You can also pass further [babel options](https://babeljs.io/docs/options)
   "\\.[jt]sx?$": ["babel-jest", { "extends": "./babel.config.js", "plugins": ["babel-plugin-transform-import-meta"] }]
 },
 ```
+
+By default, `babel-jest` includes `babel-preset-jest`. In addition to the babel options, we introduce a new option, `excludeJestPreset`, which allows you to disable this behavior. Note that this will break `jest.mock` hoisting.
+
+```json
+"transform": {
+  "\\.[jt]sx?$": ["babel-jest", { "excludeJestPreset": true }],
+}
+```

--- a/packages/babel-jest/src/__tests__/index.ts
+++ b/packages/babel-jest/src/__tests__/index.ts
@@ -169,3 +169,34 @@ test('can pass null to createTransformer', async () => {
     }),
   );
 });
+
+test('include babel-preset-jest by default', () => {
+  defaultBabelJestTransformer.process(sourceString, 'dummy_path.js', {
+    cacheFS: new Map<string, string>(),
+    config: makeProjectConfig(),
+    configString: JSON.stringify(makeProjectConfig()),
+    instrument: false,
+    transformerConfig: {},
+  } as TransformOptions<BabelTransformOptions>);
+
+  expect(loadPartialConfig).toHaveBeenCalledTimes(1);
+  expect(loadPartialConfig).toHaveBeenCalledWith(
+    expect.objectContaining({presets: [require.resolve('babel-preset-jest')]}),
+  );
+});
+
+test('can opting out of babel-preset-jest by passing excludeJestPreset: true', async () => {
+  const transformer = await createTransformer({excludeJestPreset: true});
+  transformer.process(sourceString, 'dummy_path.js', {
+    cacheFS: new Map<string, string>(),
+    config: makeProjectConfig(),
+    configString: JSON.stringify(makeProjectConfig()),
+    instrument: false,
+    transformerConfig: {},
+  } as TransformOptions<BabelTransformOptions>);
+
+  expect(loadPartialConfig).toHaveBeenCalledTimes(1);
+  expect(loadPartialConfig).toHaveBeenCalledWith(
+    expect.objectContaining({presets: []}),
+  );
+});


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Add option `jestPreset` to allow opting out of `babel-preset-jest`.

Fixes #15155 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
