### PR TITLE
fix: properly compare `TypedArray`s of all types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - `[@jest/environment-jsdom-abstract]` Introduce new package which abstracts over the `jsdom` environment, allowing usage of custom versions of JSDOM ([#14717](https://github.com/jestjs/jest/pull/14717))
 - `[jest-environment-node]` Update jest environment with dispose symbols `Symbol` ([#14888](https://github.com/jestjs/jest/pull/14888) & [#14909](https://github.com/jestjs/jest/pull/14909))
 - `[expect, @jest/expect]` [**BREAKING**] Add type inference for function parameters in `CalledWith` assertions ([#15129](https://github.com/facebook/jest/pull/15129))
+- `[@jest/expect-utils]` Properly compare all types of `TypedArray`s ([#15178](https://github.com/facebook/jest/pull/15178))
 - `[@jest/fake-timers]` [**BREAKING**] Upgrade `@sinonjs/fake-timers` to v11 ([#14544](https://github.com/jestjs/jest/pull/14544))
 - `[@jest/fake-timers]` Exposing new modern timers function `advanceTimersToFrame()` which advances all timers by the needed milliseconds to execute callbacks currently scheduled with `requestAnimationFrame` ([#14598](https://github.com/jestjs/jest/pull/14598))
 - `[jest-matcher-utils]` Add `SERIALIZABLE_PROPERTIES` to allow custom serialization of objects ([#14893](https://github.com/jestjs/jest/pull/14893))

--- a/packages/expect-utils/src/__tests__/utils.test.ts
+++ b/packages/expect-utils/src/__tests__/utils.test.ts
@@ -670,37 +670,55 @@ describe('arrayBufferEquality', () => {
   test('returns false when given non-matching buffers', () => {
     const a = Uint8Array.from([2, 4]).buffer;
     const b = Uint16Array.from([1, 7]).buffer;
-    expect(arrayBufferEquality(a, b)).not.toBeTruthy();
+    expect(arrayBufferEquality(a, b)).toBe(false);
+  });
+
+  test('returns false when given matching buffers of different byte length', () => {
+    const a = Uint8Array.from([1, 2]).buffer;
+    const b = Uint16Array.from([1, 2]).buffer;
+    expect(arrayBufferEquality(a, b)).toBe(false);
   });
 
   test('returns true when given matching buffers', () => {
     const a = Uint8Array.from([1, 2]).buffer;
     const b = Uint8Array.from([1, 2]).buffer;
-    expect(arrayBufferEquality(a, b)).toBeTruthy();
+    expect(arrayBufferEquality(a, b)).toBe(true);
   });
 
   test('returns true when given matching DataView', () => {
     const a = new DataView(Uint8Array.from([1, 2, 3]).buffer);
     const b = new DataView(Uint8Array.from([1, 2, 3]).buffer);
-    expect(arrayBufferEquality(a, b)).toBeTruthy();
+    expect(arrayBufferEquality(a, b)).toBe(true);
   });
 
   test('returns false when given non-matching DataView', () => {
     const a = new DataView(Uint8Array.from([1, 2, 3]).buffer);
     const b = new DataView(Uint8Array.from([3, 2, 1]).buffer);
-    expect(arrayBufferEquality(a, b)).toBeFalsy();
+    expect(arrayBufferEquality(a, b)).toBe(false);
+  });
+
+  test('returns true when given matching Float64Array', () => {
+    const a = Float64Array.from(Array.from({length: 10}));
+    const b = Float64Array.from(Array.from({length: 10}));
+    expect(arrayBufferEquality(a, b)).toBe(true);
+  });
+
+  test('returns false when given non-matching Float64Array', () => {
+    const a = Float64Array.from(Array.from({length: 10}));
+    const b = Float64Array.from(Array.from({length: 100}));
+    expect(arrayBufferEquality(a, b)).toBe(false);
   });
 
   test('returns true when given matching URL', () => {
     const a = new URL('https://jestjs.io/');
     const b = new URL('https://jestjs.io/');
-    expect(equals(a, b)).toBeTruthy();
+    expect(equals(a, b)).toBe(true);
   });
 
   test('returns false when given non-matching URL', () => {
     const a = new URL('https://jestjs.io/docs/getting-started');
     const b = new URL('https://jestjs.io/docs/getting-started#using-babel');
-    expect(equals(a, b)).toBeFalsy();
+    expect(equals(a, b)).toBe(false);
   });
 });
 

--- a/packages/expect-utils/src/utils.ts
+++ b/packages/expect-utils/src/utils.ts
@@ -183,6 +183,8 @@ export const iterableEquality = (
     typeof b !== 'object' ||
     Array.isArray(a) ||
     Array.isArray(b) ||
+    ArrayBuffer.isView(a) ||
+    ArrayBuffer.isView(b) ||
     !hasIterator(a) ||
     !hasIterator(b)
   ) {
@@ -413,9 +415,12 @@ export const arrayBufferEquality = (
   let dataViewA = a;
   let dataViewB = b;
 
-  if (a instanceof ArrayBuffer && b instanceof ArrayBuffer) {
+  if (isArrayBuffer(a) && isArrayBuffer(b)) {
     dataViewA = new DataView(a);
     dataViewB = new DataView(b);
+  } else if (ArrayBuffer.isView(a) && ArrayBuffer.isView(b)) {
+    dataViewA = new DataView(a.buffer, a.byteOffset, a.byteLength);
+    dataViewB = new DataView(b.buffer, b.byteOffset, b.byteLength);
   }
 
   if (!(dataViewA instanceof DataView && dataViewB instanceof DataView)) {
@@ -436,6 +441,10 @@ export const arrayBufferEquality = (
 
   return true;
 };
+
+function isArrayBuffer(obj: unknown): obj is ArrayBuffer {
+  return Object.prototype.toString.call(obj) === '[object ArrayBuffer]';
+}
 
 export const sparseArrayEquality = (
   a: unknown,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This partially addresses #15176, in that it

- makes `toEqual` call drop from 500ms to 100ms (due to us not using the iterator, but iterating "normally" which is 5x faster)
- if reproduction is changed to `toStrictEqual` it drops to 3-4 ms, comparable to `lodash` implementation (without the changes in this PR, there is no difference between `toEqual` and `toStrictEqual`)

There might be a case for us to include `arrayBufferEquality` in the custom matchers we use in `toEqual` here: https://github.com/jestjs/jest/blob/76514a8105e94b42a1b810b2b0d200dfeac91ed8/packages/expect/src/matchers.ts#L626-L629

In that case, `toEqual` also drops down to 3-4 ms runtime.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Tests added

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
