### PR TITLE
fix(jest-mock): improved `MockedClass` type

### DIFF
--- a/packages/jest-mock/__typetests__/Mocked.test.ts
+++ b/packages/jest-mock/__typetests__/Mocked.test.ts
@@ -6,7 +6,7 @@
  */
 
 import {describe, expect, test} from 'tstyche';
-import type {MockInstance, Mocked} from 'jest-mock';
+import type {MockInstance, Mocked} from '../src/index';
 
 describe('Mocked', () => {
   test('wraps a class type with type definitions of the Jest mock function', () => {

--- a/packages/jest-mock/__typetests__/ModuleMocker.test.ts
+++ b/packages/jest-mock/__typetests__/ModuleMocker.test.ts
@@ -6,7 +6,7 @@
  */
 
 import {expect, test} from 'tstyche';
-import {type MockMetadata, type Mocked, ModuleMocker} from 'jest-mock';
+import {type MockMetadata, type Mocked, ModuleMocker} from '../src/index';
 
 class ExampleClass {
   memberA: Array<number>;
@@ -46,6 +46,7 @@ const exampleModule = {
 const moduleMocker = new ModuleMocker(globalThis);
 
 const exampleMetadata = moduleMocker.getMetadata(exampleModule);
+const mockMetadata = moduleMocker.getMetadata(ExampleClass);
 
 test('getMetadata', () => {
   expect(exampleMetadata).type.toBe<MockMetadata<
@@ -56,6 +57,8 @@ test('getMetadata', () => {
 test('generateFromMetadata', () => {
   const exampleMock = moduleMocker.generateFromMetadata(exampleMetadata!);
 
+  const mockClass = moduleMocker.generateFromMetadata(mockMetadata!);
+  const mockedInstance = new mockClass();
   expect(exampleMock).type.toBe<Mocked<typeof exampleModule>>();
 
   expect(exampleMock.methodA.mock.calls).type.toBe<
@@ -67,6 +70,9 @@ test('generateFromMetadata', () => {
 
   expect(exampleMock.instance.memberA).type.toBe<Array<number>>();
   expect(exampleMock.instance.memberB.mock.calls).type.toBe<Array<[]>>();
+
+  expect(mockedInstance.memberB.mock.calls).type.toBe<Array<[]>>();
+  expect(mockedInstance.memberA).type.toBe<Array<number>>();
 
   expect(exampleMock.propertyA.one).type.toBeString();
   expect(exampleMock.propertyA.two.mock.calls).type.toBe<Array<[]>>();

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -18,7 +18,7 @@ import {
   fn,
   replaceProperty,
   spyOn,
-} from 'jest-mock';
+} from '../src/index';
 
 describe('jest.fn()', () => {
   const mockFnImpl: (this: Date, a: string, b?: number) => boolean = (a, b) =>

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -242,7 +242,6 @@ describe('moduleMocker', () => {
       );
       const foo = new ClassFooMock();
       expect(typeof foo.foo).toBe('function');
-      expect(typeof foo.foo).toBe('function');
       expect(foo.foo.mock).toBeDefined();
 
       expect(foo.toString.mock).toBeDefined();

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -238,20 +238,14 @@ describe('moduleMocker', () => {
       }
 
       const ClassFooMock = moduleMocker.generateFromMetadata(
-        moduleMocker.getMetadata(ClassFoo),
+        moduleMocker.getMetadata(ClassFoo)!,
       );
       const foo = new ClassFooMock();
-
-      const instanceFoo = new ClassFoo();
-      const instanceFooMock = moduleMocker.generateFromMetadata(
-        moduleMocker.getMetadata(instanceFoo),
-      );
-
       expect(typeof foo.foo).toBe('function');
-      expect(typeof instanceFooMock.foo).toBe('function');
-      expect(instanceFooMock.foo.mock).toBeDefined();
+      expect(typeof foo.foo).toBe('function');
+      expect(foo.foo.mock).toBeDefined();
 
-      expect(instanceFooMock.toString.mock).toBeDefined();
+      expect(foo.toString.mock).toBeDefined();
     });
 
     it('mocks ES2015 non-enumerable static properties and methods', () => {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -51,6 +51,7 @@ export type PropertyLikeKeys<T> = Exclude<
 export type MockedClass<T extends ClassLike> = MockInstance<
   (...args: ConstructorParameters<T>) => Mocked<InstanceType<T>>
 > &
+  (new (...args: ConstructorParameters<T>) => Mocked<InstanceType<T>>) &
   MockedObject<T>;
 
 export type MockedFunction<T extends FunctionLike> = MockInstance<T> &


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
Fixes #14458

added constructor signature in `MockedClass` type so that it returns
mocked Instance (of type `Mocked<InstanceType<typeof original class>>`) instead of returning the instance typed with original class type.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Tests added
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
