### PR TITLE
fix(jest-mock): added missing overload call signature

### DIFF
--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -609,6 +609,10 @@ export class ModuleMocker {
     metadata: MockMetadata<T, 'function'>,
     restore?: () => void,
   ): Mock<T>;
+  private _makeComponent<T>(
+    metadata: MockMetadata<T>,
+    restore?: () => void,
+  ): Record<string, any>;
   /* eslint-enable @typescript-eslint/unified-signatures */
   private _makeComponent<T extends UnknownFunction>(
     metadata: MockMetadata<T>,
@@ -927,9 +931,6 @@ export class ModuleMocker {
       Record<string, any> | Array<unknown> | RegExp | T | Mock | undefined
     >,
   ): Mocked<T> {
-    // metadata not compatible but it's the same type, maybe problem with
-    // overloading of _makeComponent and not _generateMock?
-    // @ts-expect-error - unsure why TSC complains here?
     const mock = this._makeComponent(metadata);
     if (metadata.refID != null) {
       refs[metadata.refID] = mock;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
It seems like `_makeComponent` is missing an overload signature, I have added one and removed Typescript error comment.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Green CI
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
