### PR TITLE
fix: Removed redundant iterator in sort map

### DIFF
--- a/packages/jest-diff/src/index.ts
+++ b/packages/jest-diff/src/index.ts
@@ -122,11 +122,11 @@ function comparePrimitive(
 }
 
 function sortMap(map: Map<unknown, unknown>) {
-  return new Map([...map.entries()].sort());
+  return new Map([...map].sort());
 }
 
 function sortSet(set: Set<unknown>) {
-  return new Set([...set.values()].sort());
+  return new Set([...set].sort());
 }
 
 function compareObjects(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Calling `entries` and `values` is not required before spreading, because those instances are iterable themselves.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
