### PR TITLE
feat: Show `rootDir` in error message when a `preset` fails to load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[jest-config]` Loads config file from provided path in `package.json` ([#14044](https://github.com/facebook/jest/pull/14044))
 - `[jest-config]` Allow loading `jest.config.cts` files ([#14070](https://github.com/facebook/jest/pull/14070))
 - `[jest-config]` Added an option to disable `ts-node` typechecking ([#15161](https://github.com/jestjs/jest/pull/15161))
+- `[jest-config]` Show `rootDir` in error message when a `preset` fails to load ([#15194](https://github.com/jestjs/jest/pull/15194))
 - `[@jest/core]` Group together open handles with the same stack trace ([#13417](https://github.com/jestjs/jest/pull/13417), & [#14789](https://github.com/jestjs/jest/pull/14789))
 - `[@jest/core]` Add `perfStats` to surface test setup overhead ([#14622](https://github.com/jestjs/jest/pull/14622))
 - `[@jest/core]` [**BREAKING**] Changed `--filter` to accept an object with shape `{ filtered: Array<string> }` to match [documentation](https://jestjs.io/docs/cli#--filterfile) ([#13319](https://github.com/jestjs/jest/pull/13319))

--- a/packages/jest-config/src/__tests__/__snapshots__/normalize.test.ts.snap
+++ b/packages/jest-config/src/__tests__/__snapshots__/normalize.test.ts.snap
@@ -367,7 +367,7 @@ exports[`preset throws when module was found but no "jest-preset.js" or "jest-pr
 exports[`preset throws when preset not found 1`] = `
 "<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
 <red></color>
-<red>  Preset <bold>doesnt-exist</intensity> not found.</color>
+<red>  Preset <bold>doesnt-exist</intensity> not found relative to rootDir <bold>/root/path/foo</intensity>.</color>
 <red></color>
 <red>  <bold>Configuration Documentation:</intensity></color>
 <red>  https://jestjs.io/docs/configuration</color>

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -169,7 +169,7 @@ const setupPreset = async (
           );
         }
         throw createConfigError(
-          `  Preset ${chalk.bold(presetPath)} not found.`,
+          `  Preset ${chalk.bold(presetPath)} not found relative to rootDir ${chalk.bold(options.rootDir)}.`,
         );
       }
       throw createConfigError(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Resolves #15193.

This change provides context to the user about where the preset is being resolved from. Happy to iterate on the error message wording if necessary.

We won't always have the project name/path in `options`, but I _think_ `rootDir` will always be present in `options`, so I chose to add that to the error message.

## Test plan

Updated snapshots with `yarn jest -u`