### PR TITLE
fix(jest-config): fix typings in `normalize` 

### DIFF
--- a/packages/jest-config/src/Defaults.ts
+++ b/packages/jest-config/src/Defaults.ts
@@ -43,7 +43,6 @@ const defaultOptions: Config.DefaultOptions = {
   injectGlobals: true,
   listTests: false,
   maxConcurrency: 5,
-  maxWorkers: '50%',
   moduleDirectories: ['node_modules'],
   moduleFileExtensions: [
     'js',
@@ -57,7 +56,7 @@ const defaultOptions: Config.DefaultOptions = {
     'json',
     'node',
   ],
-  moduleNameMapper: {},
+  moduleNameMapper: [], // normalized default value
   modulePathIgnorePatterns: [],
   noStackTrace: false,
   notify: false,

--- a/packages/jest-config/src/Defaults.ts
+++ b/packages/jest-config/src/Defaults.ts
@@ -56,7 +56,6 @@ const defaultOptions: Config.DefaultOptions = {
     'json',
     'node',
   ],
-  moduleNameMapper: [], // normalized default value
   modulePathIgnorePatterns: [],
   noStackTrace: false,
   notify: false,

--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -15,7 +15,7 @@ import type {Config} from '@jest/types';
 function getNumCpus(): number {
   return typeof availableParallelism === 'function'
     ? availableParallelism()
-    : cpus()?.length ?? 1;
+    : (cpus()?.length ?? 1);
 }
 
 export default function getMaxWorkers(

--- a/packages/jest-config/src/getMaxWorkers.ts
+++ b/packages/jest-config/src/getMaxWorkers.ts
@@ -15,7 +15,7 @@ import type {Config} from '@jest/types';
 function getNumCpus(): number {
   return typeof availableParallelism === 'function'
     ? availableParallelism()
-    : (cpus()?.length ?? 1);
+    : cpus()?.length ?? 1;
 }
 
 export default function getMaxWorkers(

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -1067,7 +1067,9 @@ export default async function normalize(
   if (!newOptions.watchAll) {
     newOptions.watchAll = false;
   }
-
+  if (!newOptions.moduleNameMapper) {
+    newOptions.moduleNameMapper = [];
+  }
   if (argv.ci != null) {
     newOptions.ci = argv.ci;
   }

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -556,10 +556,9 @@ export default async function normalize(
   }
 
   setupBabelJest(options);
-  // TODO: Type this properly
-  const newOptions = {
+  const newOptions: Partial<AllOptions> = {
     ...DEFAULT_CONFIG,
-  } as unknown as AllOptions;
+  };
 
   if (options.resolver) {
     newOptions.resolver = resolve(null, {
@@ -983,7 +982,7 @@ export default async function normalize(
     );
   }
 
-  for (const [i, root] of newOptions.roots.entries()) {
+  for (const [i, root] of newOptions.roots!.entries()) {
     verifyDirectoryExists(root, `roots[${i}]`);
   }
 
@@ -1069,13 +1068,6 @@ export default async function normalize(
     newOptions.watchAll = false;
   }
 
-  // as unknown since it can happen. We really need to fix the types here
-  if (
-    newOptions.moduleNameMapper === (DEFAULT_CONFIG.moduleNameMapper as unknown)
-  ) {
-    newOptions.moduleNameMapper = [];
-  }
-
   if (argv.ci != null) {
     newOptions.ci = argv.ci;
   }
@@ -1094,14 +1086,14 @@ export default async function normalize(
   newOptions.maxWorkers = getMaxWorkers(argv, options);
   newOptions.runInBand = argv.runInBand || false;
 
-  if (newOptions.testRegex.length > 0 && options.testMatch) {
+  if (newOptions.testRegex!.length > 0 && options.testMatch) {
     throw createConfigError(
       `  Configuration options ${chalk.bold('testMatch')} and` +
         ` ${chalk.bold('testRegex')} cannot be used together.`,
     );
   }
 
-  if (newOptions.testRegex.length > 0 && !options.testMatch) {
+  if (newOptions.testRegex!.length > 0 && !options.testMatch) {
     // Prevent the default testMatch conflicting with any explicitly
     // configured `testRegex` value
     newOptions.testMatch = [];
@@ -1134,7 +1126,7 @@ export default async function normalize(
         if (
           micromatch(
             [replacePathSepForGlob(path.relative(options.rootDir, filename))],
-            newOptions.collectCoverageFrom,
+            newOptions.collectCoverageFrom!,
           ).length === 0
         ) {
           return patterns;
@@ -1174,6 +1166,6 @@ export default async function normalize(
 
   return {
     hasDeprecationWarnings,
-    options: newOptions,
+    options: newOptions as AllOptions,
   };
 }

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -173,10 +173,9 @@ export type DefaultOptions = {
   injectGlobals: boolean;
   listTests: boolean;
   maxConcurrency: number;
-  maxWorkers: number | string;
   moduleDirectories: Array<string>;
   moduleFileExtensions: Array<string>;
-  moduleNameMapper: Record<string, string | Array<string>>;
+  moduleNameMapper: Array<[string, string]>;
   modulePathIgnorePatterns: Array<string>;
   noStackTrace: boolean;
   notify: boolean;
@@ -198,7 +197,7 @@ export type DefaultOptions = {
   snapshotSerializers: Array<string>;
   testEnvironment: string;
   testEnvironmentOptions: Record<string, unknown>;
-  testFailureExitCode: string | number;
+  testFailureExitCode: number;
   testLocationInResults: boolean;
   testMatch: Array<string>;
   testPathIgnorePatterns: Array<string>;

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -175,7 +175,6 @@ export type DefaultOptions = {
   maxConcurrency: number;
   moduleDirectories: Array<string>;
   moduleFileExtensions: Array<string>;
-  moduleNameMapper: Array<[string, string]>;
   modulePathIgnorePatterns: Array<string>;
   noStackTrace: boolean;
   notify: boolean;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
I was reading the normalize function to know how jest normalizes config options and realized that in the process of normalizing, it also changes the type of some config options.
we are initializing the normalized options with `defaultOptions` and this will cause type conflicts because types will going to change for some config options.
I just removed those types that are causing conflicts
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Green CI
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
