### PR TITLE
fix: remove needless entries for map

### DIFF
--- a/packages/jest-matcher-utils/src/deepCyclicCopyReplaceable.ts
+++ b/packages/jest-matcher-utils/src/deepCyclicCopyReplaceable.ts
@@ -142,7 +142,7 @@ function deepCyclicCopyMap<T>(
 
   cycles.set(map, newMap);
 
-  for (const [key, value] of map.entries()) {
+  for (const [key, value] of map) {
     newMap.set(key, deepCyclicCopyReplaceable(value, cycles));
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Call `entries()` with `for..of` on a `Map` is not required, because `Map` already has its own `Symbol.iterator`.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
