### PR TITLE
chore: Replaced links built with Google URL Shortener with full URLs.

### DIFF
--- a/e2e/__tests__/__snapshots__/asyncAndCallback.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/asyncAndCallback.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`errors when a test both returns a promise and takes a callback 1`] = `
 "FAIL __tests__/promise-and-callback.test.js

--- a/e2e/__tests__/__snapshots__/beforeAllFiltered.ts.snap
+++ b/e2e/__tests__/__snapshots__/beforeAllFiltered.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Correct BeforeAll run ensures the BeforeAll of ignored suite is not run 1`] = `
 "  console.log

--- a/e2e/__tests__/__snapshots__/beforeEachQueue.ts.snap
+++ b/e2e/__tests__/__snapshots__/beforeEachQueue.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Correct beforeEach order ensures the correct order for beforeEach 1`] = `
 "  console.log

--- a/e2e/__tests__/__snapshots__/callDoneTwice.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/callDoneTwice.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`\`done()\` should not be called more than once 1`] = `
 "FAIL __tests__/index.test.js

--- a/e2e/__tests__/__snapshots__/chaiAssertionLibrary.ts.snap
+++ b/e2e/__tests__/__snapshots__/chaiAssertionLibrary.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`chai assertion errors should display properly 1`] = `
 "FAIL __tests__/chai_assertion.js

--- a/e2e/__tests__/__snapshots__/circusDeclarationErrors.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/circusDeclarationErrors.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`defining tests and hooks asynchronously throws 1`] = `
 "FAIL __tests__/asyncDefinition.test.js

--- a/e2e/__tests__/__snapshots__/cliHandlesExactFilenames.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/cliHandlesExactFilenames.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`CLI accepts exact file names if matchers matched 1`] = `
 "PASS foo/bar.spec.js

--- a/e2e/__tests__/__snapshots__/complexItemsInErrors.ts.snap
+++ b/e2e/__tests__/__snapshots__/complexItemsInErrors.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`handles errors with BigInt 1`] = `
 "FAIL __tests__/test-1.js

--- a/e2e/__tests__/__snapshots__/console.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/console.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`console printing 1`] = `
 "PASS __tests__/console.test.js

--- a/e2e/__tests__/__snapshots__/consoleAfterTeardown.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/consoleAfterTeardown.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`console printing 1`] = `
 "PASS __tests__/console.test.js

--- a/e2e/__tests__/__snapshots__/consoleDebugging.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/consoleDebugging.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`console debugging with --verbose 1`] = `
 "  console.log

--- a/e2e/__tests__/__snapshots__/consoleLogOutputWhenRunInBand.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/consoleLogOutputWhenRunInBand.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`prints console.logs when run with forceExit 1`] = `
 "PASS __tests__/a-banana.js

--- a/e2e/__tests__/__snapshots__/coverageHandlebars.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/coverageHandlebars.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`code coverage for Handlebars 1`] = `
 "-----------|---------|----------|---------|---------|-------------------

--- a/e2e/__tests__/__snapshots__/coverageProviderV8.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/coverageProviderV8.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`prints correct coverage report, if a CJS module is put under test without transformation 1`] = `
 "  console.log

--- a/e2e/__tests__/__snapshots__/coverageRemapping.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/coverageRemapping.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`maps code coverage against original source 1`] = `
 Object {

--- a/e2e/__tests__/__snapshots__/coverageReport.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/coverageReport.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`collects coverage from duplicate files avoiding shared cache 1`] = `
 "---------------|---------|----------|---------|---------|-------------------

--- a/e2e/__tests__/__snapshots__/coverageThreshold.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/coverageThreshold.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`excludes tests matched by path threshold groups from global group 1`] = `
 "PASS __tests__/banana.test.js

--- a/e2e/__tests__/__snapshots__/coverageTransformInstrumented.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/coverageTransformInstrumented.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`code coverage for transform instrumented code 1`] = `
 Object {

--- a/e2e/__tests__/__snapshots__/coverageWithoutTransform.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/coverageWithoutTransform.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`produces code coverage for uncovered files without transformer 1`] = `
 "---------------------|---------|----------|---------|---------|-------------------

--- a/e2e/__tests__/__snapshots__/customInlineSnapshotMatchers.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/customInlineSnapshotMatchers.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`can bail with a custom inline snapshot matcher 1`] = `
 "FAIL __tests__/bail.test.js

--- a/e2e/__tests__/__snapshots__/customMatcherStackTrace.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/customMatcherStackTrace.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`custom async matchers 1`] = `
 "FAIL __tests__/asynchronous.test.js

--- a/e2e/__tests__/__snapshots__/customReporters.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/customReporters.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Custom Reporters Integration IncompleteReporter for flexibility 1`] = `
 "onRunComplete is called

--- a/e2e/__tests__/__snapshots__/customReportersOnCircus.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/customReportersOnCircus.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Custom Reporters Integration on jest-circus valid failing assertion counts for adding reporters 1`] = `
 "onTestCaseResult: adds fail, started: today, status: failed, numExpectations: 0

--- a/e2e/__tests__/__snapshots__/declarationErrors.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/declarationErrors.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`errors if describe returns a Promise 1`] = `
 "    Returning a Promise from "describe" is not supported. Tests must be defined synchronously.

--- a/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
+++ b/e2e/__tests__/__snapshots__/detectOpenHandles.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`does not print info about open handlers for a server that is already closed 1`] = `""`;
 

--- a/e2e/__tests__/__snapshots__/domDiffing.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/domDiffing.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`should work without error 1`] = `
 "FAIL __tests__/dom.test.js

--- a/e2e/__tests__/__snapshots__/each.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/each.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`allows nullable or undefined args when templating object each args 1`] = `
 "PASS __tests__/eachTemplate.test.js

--- a/e2e/__tests__/__snapshots__/emptyDescribeWithHooks.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/emptyDescribeWithHooks.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`hook in describe with skipped test 1`] = `
 Object {

--- a/e2e/__tests__/__snapshots__/environmentAfterTeardown.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/environmentAfterTeardown.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`prints useful error for environment methods after test is done w/ \`waitNextEventLoopTurnForUnhandledRejectionEvents\` 1`] = `
 "    ReferenceError: You are trying to access a property or method of the Jest environment outside of the scope of the test code.

--- a/e2e/__tests__/__snapshots__/environmentAfterTeardownJasmine.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/environmentAfterTeardownJasmine.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`prints useful error for environment methods after test is done 1`] = `
 "ReferenceError: You are trying to access a property or method of the Jest environment after it has been torn down. From __tests__/afterTeardown.test.js.

--- a/e2e/__tests__/__snapshots__/errorOnDeprecated.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/errorOnDeprecated.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`defaultTimeoutInterval.test.js errors in errorOnDeprecated mode 1`] = `
 "FAIL __tests__/defaultTimeoutInterval.test.js

--- a/e2e/__tests__/__snapshots__/executeTestsOnceInMpr.ts.snap
+++ b/e2e/__tests__/__snapshots__/executeTestsOnceInMpr.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Tests are executed only once even in an MPR 1`] = `
 "PASS foo/folder/my-test-bar.js

--- a/e2e/__tests__/__snapshots__/expectAsyncMatcher.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/expectAsyncMatcher.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`shows the correct errors in stderr when failing tests 1`] = `
 "FAIL __tests__/failure.test.js

--- a/e2e/__tests__/__snapshots__/failures.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/failures.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`not throwing Error objects 1`] = `
 "FAIL __tests__/throwNumber.test.js

--- a/e2e/__tests__/__snapshots__/findRelatedFiles.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/findRelatedFiles.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`--findRelatedTests flag coverage configuration is applied correctly 1`] = `
 "Test Suites: 1 passed, 1 total

--- a/e2e/__tests__/__snapshots__/globals.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/globals.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`basic test constructs 1`] = `
 "PASS __tests__/basic.testConstructs.test.js

--- a/e2e/__tests__/__snapshots__/injectGlobals.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/injectGlobals.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`globals are undefined if passed \`false\` from CLI 1`] = `
 "PASS __tests__/test.js

--- a/e2e/__tests__/__snapshots__/isolateModulesAsync.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/isolateModulesAsync.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`runs test with isolate modules async import 1`] = `
 "Test Suites: 1 passed, 1 total

--- a/e2e/__tests__/__snapshots__/jest.config.js.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/jest.config.js.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`traverses directory tree up until it finds jest.config 1`] = `
 "  console.log

--- a/e2e/__tests__/__snapshots__/jest.config.ts.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/jest.config.ts.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`traverses directory tree up until it finds jest.config 1`] = `
 "  console.log

--- a/e2e/__tests__/__snapshots__/listTests.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/listTests.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`--listTests flag --outputFile flag causes tests to be saved in the file as JSON 1`] = `"["/MOCK_ABSOLUTE_PATH/e2e/list-tests/__tests__/dummy.test.js","/MOCK_ABSOLUTE_PATH/e2e/list-tests/__tests__/other.test.js"]"`;
 

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`moduleNameMapper correct configuration 1`] = `
 "PASS __tests__/index.js

--- a/e2e/__tests__/__snapshots__/multiProjectRunner.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/multiProjectRunner.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`can pass projects or global config 1`] = `
 "Test Suites: 3 failed, 3 total

--- a/e2e/__tests__/__snapshots__/multipleConfigs.ts.snap
+++ b/e2e/__tests__/__snapshots__/multipleConfigs.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`multiple configs will throw error 1`] = `
 "● Multiple configurations found:

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`does not enforce import assertions 1`] = `
 "Test Suites: 1 passed, 1 total

--- a/e2e/__tests__/__snapshots__/nestedTestDefinitions.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nestedTestDefinitions.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`print correct error message with nested test definitions inside describe 1`] = `
 "FAIL __tests__/nestedTestWithinDescribe.js

--- a/e2e/__tests__/__snapshots__/nonSerializableStructuresInequality.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nonSerializableStructuresInequality.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`processChild handles \`BigInt\` 1`] = `
 "FAIL __tests__/test-1.js

--- a/e2e/__tests__/__snapshots__/processExit.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/processExit.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`prints stack trace pointing to process.exit call 1`] = `
 "  ●  process.exit called with "1"

--- a/e2e/__tests__/__snapshots__/promiseAsyncHandling.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/promiseAsyncHandling.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`fails because of unhandled promise rejection in afterAll hook 1`] = `
 Object {

--- a/e2e/__tests__/__snapshots__/randomize.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/randomize.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`works with each 1`] = `
 "  ✓ test1

--- a/e2e/__tests__/__snapshots__/requireAfterTeardown.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/requireAfterTeardown.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`prints useful error for requires after test is done w/ \`waitNextEventLoopTurnForUnhandledRejectionEvents\` 1`] = `
 "    ReferenceError: You are trying to \`import\` a file outside of the scope of the test code.

--- a/e2e/__tests__/__snapshots__/requireAfterTeardownJasmine.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/requireAfterTeardownJasmine.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`prints useful error for requires after test is done 1`] = `
 "ReferenceError: You are trying to \`import\` a file after the Jest environment has been torn down. From __tests__/lateRequire.test.js.

--- a/e2e/__tests__/__snapshots__/requireMissingExt.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/requireMissingExt.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`shows a proper error from deep requires 1`] = `
 "FAIL __tests__/test.js

--- a/e2e/__tests__/__snapshots__/resolveAsync.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/resolveAsync.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`runs test with native ESM 1`] = `
 "Test Suites: 1 passed, 1 total

--- a/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`show error message when no js moduleFileExtensions 1`] = `
 "● Validation Error:

--- a/e2e/__tests__/__snapshots__/runProgrammaticallyMultipleProjects.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/runProgrammaticallyMultipleProjects.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`run programmatically with multiple projects: summary 1`] = `
 "Test Suites: 2 passed, 2 total

--- a/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/showConfig.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`--showConfig outputs config info and exits 1`] = `
 "{

--- a/e2e/__tests__/__snapshots__/snapshot.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/snapshot.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Snapshot Validation deletes a snapshot when a test does removes all the snapshots 1`] = `
 "Test Suites: 3 passed, 3 total

--- a/e2e/__tests__/__snapshots__/snapshotMockFs.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/snapshotMockFs.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`store snapshot even if fs is mocked 1`] = `
 "Test Suites: 1 passed, 1 total

--- a/e2e/__tests__/__snapshots__/snapshotSerializers.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/snapshotSerializers.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Snapshot serializers renders snapshot 1`] = `
 Object {

--- a/e2e/__tests__/__snapshots__/stackTrace.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/stackTrace.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Stack Trace does not print a stack trace for errors when --noStackTrace is given 1`] = `
 "Test Suites: 1 failed, 1 total

--- a/e2e/__tests__/__snapshots__/stackTraceSourceMapsWithCoverage.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/stackTraceSourceMapsWithCoverage.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`processes stack traces and code frames with source maps with coverage 1`] = `
 "FAIL __tests__/fails.ts

--- a/e2e/__tests__/__snapshots__/testEnvironmentRunScript.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testEnvironmentRunScript.test.ts.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`throw error if test env does not have getVmContext 1`] = `"Test environment found at "<rootDir>/EnvUsingRunScript.js" does not export a "getVmContext" method, which is mandatory from Jest 27. This method is a replacement for "runScript"."`;

--- a/e2e/__tests__/__snapshots__/testFailing.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testFailing.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`works with all statuses 1`] = `
 "FAIL __tests__/statuses.test.js

--- a/e2e/__tests__/__snapshots__/testFailingJasmine.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testFailingJasmine.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`throws an error about unsupported modifier 1`] = `
 "FAIL __tests__/statuses.test.js

--- a/e2e/__tests__/__snapshots__/testFailingSnapshot.test.js.snap
+++ b/e2e/__tests__/__snapshots__/testFailingSnapshot.test.js.snap
@@ -1,7 +1,7 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`test.failing doesnt update or remove snapshots 1`] = `
-"// Jest Snapshot v1, https://goo.gl/fbAQLP
+"// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[\`snapshots not updated nor removed 1\`] = \`"1"\`;
 

--- a/e2e/__tests__/__snapshots__/testMatch.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testMatch.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`testMatch should able to match file with cjs and mjs extension 1`] = `
 "Test Suites: 2 passed, 2 total

--- a/e2e/__tests__/__snapshots__/testMatchDefault.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testMatchDefault.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`testMatch should able to match file with \`?([mc])[jt]s?(x)\` by default 1`] = `
 "Test Suites: 16 passed, 16 total

--- a/e2e/__tests__/__snapshots__/testMatchTs.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testMatchTs.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`testMatch should able to match file with cts and mts extension 1`] = `
 "Test Suites: 2 passed, 2 total

--- a/e2e/__tests__/__snapshots__/testNamePattern.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testNamePattern.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`testNamePattern 1`] = `
 "Test Suites: 1 passed, 1 total

--- a/e2e/__tests__/__snapshots__/testNamePatternSkipped.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testNamePatternSkipped.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`testNamePattern skipped 1`] = `
 "Test Suites: 1 passed, 1 total

--- a/e2e/__tests__/__snapshots__/testRetries.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testRetries.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Test Retries logs error(s) before retry 1`] = `
 "LOGGING RETRY ERRORS  retryTimes set

--- a/e2e/__tests__/__snapshots__/testTodo.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testTodo.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`counts todo tests when inside of a \`describe.only\` 1`] = `
 "PASS __tests__/only-todo.test.js

--- a/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/timeouts.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`does not exceed the command line testTimeout 1`] = `
 "PASS __tests__/a-banana.js

--- a/e2e/__tests__/__snapshots__/timeoutsLegacy.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/timeoutsLegacy.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`can read and write jasmine.DEFAULT_TIMEOUT_INTERVAL 1`] = `
 "Test Suites: 1 passed, 1 total

--- a/e2e/__tests__/__snapshots__/toMatchInlineSnapshot.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/toMatchInlineSnapshot.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`basic support: initial write 1`] = `
 "test('inline snapshots', () =>

--- a/e2e/__tests__/__snapshots__/toThrowErrorMatchingInlineSnapshot.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/toThrowErrorMatchingInlineSnapshot.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`should support rejecting promises 1`] = `
 "test('should support rejecting promises', async () => {

--- a/e2e/__tests__/__snapshots__/toThrowErrorMatchingSnapshot.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/toThrowErrorMatchingSnapshot.test.ts.snap
@@ -1,7 +1,7 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`should support rejecting promises 1`] = `
-"// Jest Snapshot v1, https://goo.gl/fbAQLP
+"// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[\`should support rejecting promises 1\`] = \`"octopus"\`;
 "

--- a/e2e/__tests__/__snapshots__/transform.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/transform.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`babel-jest ignored tells user to match ignored files 1`] = `
 "FAIL __tests__/ignoredFile.test.js

--- a/e2e/__tests__/__snapshots__/typescriptCoverage.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/typescriptCoverage.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`instruments and collects coverage for typescript files 1`] = `
 "------------|---------|----------|---------|---------|-------------------

--- a/e2e/__tests__/__snapshots__/watchModeOnlyFailed.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/watchModeOnlyFailed.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`can press "f" to run only failed tests: test results 1`] = `
 "FAIL __tests__/bar.spec.js

--- a/e2e/__tests__/__snapshots__/watchModePatterns.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/watchModePatterns.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`can press "p" to filter by file name 1`] = `
 "<hideCursor>

--- a/e2e/__tests__/__snapshots__/watchModeUpdateSnapshot.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/watchModeUpdateSnapshot.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`can press "u" to update snapshots: test results 1`] = `
 "FAIL __tests__/bar.spec.js

--- a/e2e/__tests__/__snapshots__/workerRestartBeforeSend.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/workerRestartBeforeSend.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`all 3 test files should complete 1`] = `
 "Test Suites: 1 failed, 2 passed, 3 total

--- a/e2e/__tests__/__snapshots__/workerRestarting.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/workerRestarting.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`all 3 test files should complete 1`] = `
 "Test Suites: 3 passed, 3 total

--- a/e2e/__tests__/__snapshots__/wrongEnv.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/wrongEnv.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Wrong globals for environment on node <=18 print useful error for navigator 1`] = `
 "FAIL __tests__/node.js

--- a/e2e/__tests__/watchModeUpdateSnapshot.test.ts
+++ b/e2e/__tests__/watchModeUpdateSnapshot.test.ts
@@ -23,7 +23,7 @@ expect.addSnapshotSerializer({
 
 const setupFiles = (input: Array<{keys: Array<string>}>) => {
   writeFiles(DIR, {
-    '__tests__/__snapshots__/bar.spec.js.snap': `// Jest Snapshot v1, https://goo.gl/fbAQLP
+    '__tests__/__snapshots__/bar.spec.js.snap': `// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[\`bar 1\`] = \`"foo"\`;
     `,

--- a/e2e/failures/__tests__/__snapshots__/snapshot.test.js.snap
+++ b/e2e/failures/__tests__/__snapshots__/snapshot.test.js.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`failing snapshot 1`] = `"bar"`;

--- a/e2e/failures/__tests__/__snapshots__/snapshotWithHint.test.js.snap
+++ b/e2e/failures/__tests__/__snapshots__/snapshotWithHint.test.js.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`failing snapshot with hint: descriptive hint 1`] = `"bar"`;

--- a/e2e/randomize/__tests__/__snapshots__/snapshots.test.js.snap
+++ b/e2e/randomize/__tests__/__snapshots__/snapshots.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`describe1 test4 1`] = `4`;
 

--- a/e2e/snapshot-concurrent/__tests__/__snapshots__/works.test.js.snap
+++ b/e2e/snapshot-concurrent/__tests__/__snapshots__/works.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`A a 1`] = `"Aa1"`;
 

--- a/e2e/snapshot-formatting-changes/__tests__/__snapshots__/snapshot.test.js.snap
+++ b/e2e/snapshot-formatting-changes/__tests__/__snapshots__/snapshot.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`snapshot serializer uses 8 chars for indent, and shows no prototypes for object and array in a snapshot: no prototypes 1`] = `
 {

--- a/e2e/snapshot-unknown/__tests__/__snapshots__/fails.test.js.snap
+++ b/e2e/snapshot-unknown/__tests__/__snapshots__/fails.test.js.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`snapshot this one makes not toMatchSnapshot assertion, but has a .snap file 1`] = `"normal"`;

--- a/e2e/snapshot-unknown/__tests__/__snapshots__/fails2.test.js.snap
+++ b/e2e/snapshot-unknown/__tests__/__snapshots__/fails2.test.js.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`snapshot this one makes not toMatchSnapshot assertion, but has a .snap file 1`] = `"normal"`;

--- a/e2e/snapshot-unknown/__tests__/__snapshots__/works.test.js.snap
+++ b/e2e/snapshot-unknown/__tests__/__snapshots__/works.test.js.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`snapshot some snapshots exists and are fine 1`] = `"normal"`;

--- a/e2e/test-failing-snapshot-all-pass/__tests__/__snapshots__/snapshot.test.js.snap
+++ b/e2e/test-failing-snapshot-all-pass/__tests__/__snapshots__/snapshot.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`snapshots not updated 1`] = `"1"`;
 

--- a/e2e/test-failing-snapshot/__tests__/__snapshots__/snapshot.test.js.snap
+++ b/e2e/test-failing-snapshot/__tests__/__snapshots__/snapshot.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`snapshots not updated nor removed 1`] = `"1"`;
 

--- a/e2e/transform/multiple-transformers/__tests__/__snapshots__/multipleTransformers.test.js.snap
+++ b/e2e/transform/multiple-transformers/__tests__/__snapshots__/multipleTransformers.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generates a snapshot with correctly transformed dependencies 1`] = `
 <div

--- a/examples/react-native/__tests__/__snapshots__/intro.test.js.snap
+++ b/examples/react-native/__tests__/__snapshots__/intro.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders correctly 1`] = `
 <View

--- a/examples/snapshot/__tests__/__snapshots__/clock.test.js.snap
+++ b/examples/snapshot/__tests__/__snapshots__/clock.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`renders correctly 1`] = `
 <p>

--- a/examples/snapshot/__tests__/__snapshots__/link.test.js.snap
+++ b/examples/snapshot/__tests__/__snapshots__/link.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`changes the class when hovered 1`] = `
 <a

--- a/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`babel-plugin-jest-hoist 1. automatic react runtime: 1. automatic react runtime 1`] = `
 

--- a/packages/create-jest/src/__tests__/__snapshots__/init.test.ts.snap
+++ b/packages/create-jest/src/__tests__/__snapshots__/init.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`init has jest config in package.json should ask the user whether to override config or not 1`] = `
 Object {

--- a/packages/create-jest/src/__tests__/__snapshots__/modifyPackageJson.test.ts.snap
+++ b/packages/create-jest/src/__tests__/__snapshots__/modifyPackageJson.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`should add test script when there are no scripts 1`] = `
 "{

--- a/packages/diff-sequences/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/diff-sequences/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`common substrings regression 1`] = `
 Array [

--- a/packages/expect/src/__tests__/__snapshots__/assertionCounts.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/assertionCounts.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`.hasAssertions() throws if expected is not undefined 1`] = `
 <d>expect(</><r>received</><d>)[.not].hasAssertions()</>

--- a/packages/expect/src/__tests__/__snapshots__/customEqualityTesters.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/customEqualityTesters.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`with custom equality testers toMatchObject error shows Volume objects as equal 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).</intensity>toMatchObject<dim>(</intensity><green>expected</color><dim>)</intensity>

--- a/packages/expect/src/__tests__/__snapshots__/customEqualityTestersRecursive.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/customEqualityTestersRecursive.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`with custom equality testers toMatchObject error shows Book objects as equal 1`] = `
 "<dim>expect(</intensity><red>received</color><dim>).</intensity>toMatchObject<dim>(</intensity><green>expected</color><dim>)</intensity>

--- a/packages/expect/src/__tests__/__snapshots__/extend.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/extend.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`defines asymmetric unary matchers 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`.rejects fails for promise that resolves 1`] = `
 <d>expect(</><r>received</><d>).</>rejects<d>.</>toBe<d>()</>

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`toHaveBeenCalled .not fails with any argument passed 1`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toHaveBeenCalled<d>()</>

--- a/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`toThrow asymmetric any-Class fail isNot false 1`] = `
 <d>expect(</><r>received</><d>).</>toThrow<d>(</><g>expected</><d>)</>

--- a/packages/jest-circus/src/__tests__/__snapshots__/afterAll.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/afterAll.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`child tests marked with only should not run if describe block is skipped 1`] = `
 "start_describe_definition: describe

--- a/packages/jest-circus/src/__tests__/__snapshots__/baseTest.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/baseTest.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`failures 1`] = `
 "start_describe_definition: describe

--- a/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/hooks.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`beforeAll is exectued correctly 1`] = `
 "start_describe_definition: describe 1

--- a/packages/jest-circus/src/__tests__/__snapshots__/randomizeTest.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/randomizeTest.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`failures 1`] = `
 "start_describe_definition: describe

--- a/packages/jest-circus/src/__tests__/__snapshots__/shuffleArray.test.ts.snap
+++ b/packages/jest-circus/src/__tests__/__snapshots__/shuffleArray.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`rngBuilder creates a randomizer given seed 1 1`] = `
 Array [

--- a/packages/jest-config/src/__tests__/__snapshots__/normalize.test.ts.snap
+++ b/packages/jest-config/src/__tests__/__snapshots__/normalize.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`displayName generates a default color for the runner jest-runner 1`] = `"yellow"`;
 

--- a/packages/jest-core/src/__tests__/__snapshots__/SnapshotInteractiveMode.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/SnapshotInteractiveMode.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`SnapshotInteractiveMode skip 1 test, then quit 1`] = `
 "<moveCursorUpBy6Rows>

--- a/packages/jest-core/src/__tests__/__snapshots__/getNoTestsFoundMessage.test.ts.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/getNoTestsFoundMessage.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`getNoTestsFoundMessage returns correct message when monitoring only changed 1`] = `
 Object {

--- a/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watch.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Watch mode flows Runs Jest in a non-interactive environment not showing usage 1`] = `
 Array [

--- a/packages/jest-core/src/__tests__/__snapshots__/watchFilenamePatternMode.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watchFilenamePatternMode.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Watch mode flows Pressing "P" enters pattern mode 1`] = `
 "<eraseLine>

--- a/packages/jest-core/src/__tests__/__snapshots__/watchTestNamePatternMode.test.js.snap
+++ b/packages/jest-core/src/__tests__/__snapshots__/watchTestNamePatternMode.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Watch mode flows Pressing "T" enters pattern mode 1`] = `
 "<eraseLine>

--- a/packages/jest-core/src/lib/__tests__/__snapshots__/logDebugMessages.test.ts.snap
+++ b/packages/jest-core/src/lib/__tests__/__snapshots__/logDebugMessages.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`prints the config object 1`] = `
 "{

--- a/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/diff.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`collapses big diffs to patch format 1`] = `
 <g>- Expected</>

--- a/packages/jest-diff/src/__tests__/__snapshots__/getAlignedDiffs.test.ts.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/getAlignedDiffs.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`getAlignedDiffs lines change preceding and following common 1`] = `
 - delete

--- a/packages/jest-diff/src/__tests__/__snapshots__/joinAlignedDiffs.test.ts.snap
+++ b/packages/jest-diff/src/__tests__/__snapshots__/joinAlignedDiffs.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`joinAlignedDiffsExpand first line is empty common 1`] = `
   ↵

--- a/packages/jest-each/src/__tests__/__snapshots__/array.test.ts.snap
+++ b/packages/jest-each/src/__tests__/__snapshots__/array.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`jest-each .describe throws an error when called with an empty array 1`] = `
 "Error: \`.each\` called with an empty Array of table data.

--- a/packages/jest-each/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/jest-each/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`throws an error when not called with the right number of arguments 1`] = `"\`.each\` must only be called with an Array or Tagged Template Literal."`;

--- a/packages/jest-each/src/__tests__/__snapshots__/template.test.ts.snap
+++ b/packages/jest-each/src/__tests__/__snapshots__/template.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`jest-each .describe throws an error when called with an empty string 1`] = `
 "Error: \`.each\` called with an empty Tagged Template Literal of table data.

--- a/packages/jest-fake-timers/src/__tests__/__snapshots__/legacyFakeTimers.test.ts.snap
+++ b/packages/jest-fake-timers/src/__tests__/__snapshots__/legacyFakeTimers.test.ts.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FakeTimers runAllTimers warns when trying to advance timers while real timers are used 1`] = `"A function to advance timers was called but the timers APIs are not mocked with fake timers. Call \`jest.useFakeTimers({legacyFakeTimers: true})\` in this test file or enable fake timers for all tests by setting {'enableGlobally': true, 'legacyFakeTimers': true} in Jest configuration file."`;

--- a/packages/jest-fake-timers/src/__tests__/__snapshots__/modernFakeTimers.test.ts.snap
+++ b/packages/jest-fake-timers/src/__tests__/__snapshots__/modernFakeTimers.test.ts.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`FakeTimers runAllTimers warns when trying to advance timers while real timers are used 1`] = `"A function to advance timers was called but the timers APIs are not replaced with fake timers. Call \`jest.useFakeTimers()\` in this test file or enable fake timers for all tests by setting 'fakeTimers': {'enableGlobally': true} in Jest configuration file."`;

--- a/packages/jest-haste-map/src/__tests__/__snapshots__/index.test.js.snap
+++ b/packages/jest-haste-map/src/__tests__/__snapshots__/index.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`HasteMap file system changes processing recovery from duplicate module IDs recovers when the most recent duplicate is fixed 1`] = `
 "The name \`Pear\` was looked up in the Haste module map. It cannot be resolved, because there exists several different files, or packages, that provide a module for that particular name and platform. The platform is generic (no extension). You must delete or exclude files until there remains only one of these:

--- a/packages/jest-jasmine2/src/__tests__/__snapshots__/expectationResultFactory.test.ts.snap
+++ b/packages/jest-jasmine2/src/__tests__/__snapshots__/expectationResultFactory.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`expectationResultFactory returns the result if failed (with \`error.stack\` not as a string). 1`] = `
 "thrown: Object {

--- a/packages/jest-leak-detector/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/jest-leak-detector/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`complains if the value is a primitive 1`] = `"Primitives cannot leak memory. You passed a undefined: <undefined>"`;
 

--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/index.test.ts.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/index.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ensureNoExpected() throws error when expected is not undefined with matcherName 1`] = `
 <d>expect(</><r>received</><d>)[.not].toBeDefined()</>

--- a/packages/jest-matcher-utils/src/__tests__/__snapshots__/printDiffOrStringify.test.ts.snap
+++ b/packages/jest-matcher-utils/src/__tests__/__snapshots__/printDiffOrStringify.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`printDiffOrStringify asymmetricMatcher array 1`] = `
 <g>- Expected  - 1</>

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`.formatExecError() 1`] = `
 "  <bold>● </intensity>Test suite failed to run

--- a/packages/jest-pattern/src/__tests__/__snapshots__/TestPathPatterns.test.ts.snap
+++ b/packages/jest-pattern/src/__tests__/__snapshots__/TestPathPatterns.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`TestPathPatterns toPretty renders a human-readable string 1`] = `"a/b|c/d"`;
 

--- a/packages/jest-reporters/src/__tests__/__snapshots__/GitHubActionsReporter.test.ts.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/GitHubActionsReporter.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`annotations logs error annotation when a test has reference error 1`] = `
 Array [

--- a/packages/jest-reporters/src/__tests__/__snapshots__/NotifyReporter.test.ts.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/NotifyReporter.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`test always 1`] = `
 Array [

--- a/packages/jest-reporters/src/__tests__/__snapshots__/SummaryReporter.test.js.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/SummaryReporter.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`snapshots all have results (after update) 1`] = `
 "<bold>Snapshot Summary</intensity>

--- a/packages/jest-reporters/src/__tests__/__snapshots__/generateEmptyCoverage.test.js.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/generateEmptyCoverage.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generateEmptyCoverage generates an empty coverage object for a file without running it 1`] = `
 Object {

--- a/packages/jest-reporters/src/__tests__/__snapshots__/getSnapshotStatus.test.js.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/getSnapshotStatus.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Retrieves the snapshot status 1`] = `
 Array [

--- a/packages/jest-reporters/src/__tests__/__snapshots__/getSnapshotSummary.test.js.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/getSnapshotSummary.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`creates a snapshot summary 1`] = `
 "<bold>Snapshot Summary</intensity>

--- a/packages/jest-reporters/src/__tests__/__snapshots__/getSummary.test.ts.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/getSummary.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`getSummary does not print seed value when showSeed is false 1`] = `
 "<bold>Test Suites: </intensity>0 total

--- a/packages/jest-reporters/src/__tests__/__snapshots__/utils.test.ts.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/utils.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`printDisplayName should correctly print the displayName when color and name are valid values 1`] = `"</><inverse><green> hello </color></inverse></>"`;
 

--- a/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/__snapshots__/related.test.js.snap
+++ b/packages/jest-resolve-dependencies/src/__tests__/__fixtures__/__snapshots__/related.test.js.snap
@@ -1,3 +1,3 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`sample 1`] = `Object {}`;

--- a/packages/jest-runtime/src/__tests__/__snapshots__/runtime_require_module_no_ext.test.js.snap
+++ b/packages/jest-runtime/src/__tests__/__snapshots__/runtime_require_module_no_ext.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Runtime requireModule with no extension throws error pointing out file with extension 1`] = `
 "Cannot find module 'RegularModuleWithWrongExt' from 'root.js'

--- a/packages/jest-runtime/src/__tests__/__snapshots__/runtime_wrap.js.snap
+++ b/packages/jest-runtime/src/__tests__/__snapshots__/runtime_wrap.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Runtime wrapCodeInModuleWrapper generates the correct args for the module wrapper 1`] = `
 "({"Object.<anonymous>":function(module,exports,require,__dirname,__filename,jest){module.exports = "Hello!"

--- a/packages/jest-snapshot-utils/src/utils.ts
+++ b/packages/jest-snapshot-utils/src/utils.ts
@@ -14,7 +14,7 @@ import type {SnapshotData} from './types';
 
 export const SNAPSHOT_VERSION = '1';
 const SNAPSHOT_VERSION_REGEXP = /^\/\/ Jest Snapshot v(.+),/;
-export const SNAPSHOT_GUIDE_LINK = 'https://goo.gl/fbAQLP';
+export const SNAPSHOT_GUIDE_LINK = 'https://jestjs.io/docs/snapshot-testing';
 export const SNAPSHOT_VERSION_WARNING = chalk.yellow(
   `${chalk.bold('Warning')}: Before you upgrade snapshots, ` +
     'we recommend that you revert any local changes to tests or other code, ' +

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/SnapshotResolver.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/SnapshotResolver.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`malformed custom resolver in project config inconsistent functions throws  1`] = `"<bold>Custom snapshot resolver functions must transform paths consistently, i.e. expects resolveTestPath(resolveSnapshotPath('foo/__tests__/bar.test.js')) === foo/__SPECS__/bar.test.js</intensity>"`;
 

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/mockSerializer.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/mockSerializer.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`mock with 0 calls and default name 1`] = `[MockFunction]`;
 

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`matcher error toMatchInlineSnapshot Expected properties must be an object (non-null) without snapshot 1`] = `
 <d>expect(</><r>received</><d>).</>toMatchInlineSnapshot<d>(</><g>properties</><d>)</>

--- a/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
+++ b/packages/jest-transform/src/__tests__/__snapshots__/ScriptTransformer.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ScriptTransformer (in sync mode) throws an error if \`process\` isn't defined 1`] = `
 "<red><bold>● Invalid synchronous transformer module:</intensity></color>

--- a/packages/jest-validate/src/__tests__/__snapshots__/validate.test.ts.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validate.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Repeated types within multiple valid examples are coalesced in error report 1`] = `
 "<red><bold><bold>●</intensity><bold> Validation Error</intensity>:</color>

--- a/packages/jest-validate/src/__tests__/__snapshots__/validateCLIOptions.test.ts.snap
+++ b/packages/jest-validate/src/__tests__/__snapshots__/validateCLIOptions.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`does not show suggestion when unrecognized cli param length <= 1 1`] = `
 "<red><bold><bold>●</intensity><bold> Unrecognized CLI Parameter</intensity>:</color>

--- a/packages/jest-watcher/src/lib/__tests__/__snapshots__/formatTestNameByPattern.test.ts.snap
+++ b/packages/jest-watcher/src/lib/__tests__/__snapshots__/formatTestNameByPattern.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`for multiline test name returns test name with highlighted pattern and replaced line breaks 1`] = `"<dim>should⏎ </intensity></>name</><dim> the ⏎function you at...</intensity>"`;
 

--- a/packages/pretty-format/src/__tests__/__snapshots__/react.test.tsx.snap
+++ b/packages/pretty-format/src/__tests__/__snapshots__/react.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ReactElement plugin highlights syntax 1`] = `
 "<cyan><Mouse</color>

--- a/website/blog/2017-02-21-jest-19-immersive-watch-mode-test-platform-improvements.md
+++ b/website/blog/2017-02-21-jest-19-immersive-watch-mode-test-platform-improvements.md
@@ -38,7 +38,7 @@ exports[`test snap 1`] = `
 After (no “test” prefix, better JSX rendering, version header):
 
 ```js
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`snap 1`] = `
 <header>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
Replaced links built with Google URL Shortener with full URLs. (`https://goo.gl/*`)

Since it was announced that Google URL Shortener will no longer be supported after August 2025

* https://developers.googleblog.com/en/google-url-shortener-links-will-no-longer-be-available/

## Additional
The redirect for https://goo.gl/fbAQLP was to the following link.
*  http://facebook.github.io/jest/docs/snapshot-testing.html.

However, it was further redirected to `jestjs.io` from here, so the URL finally reached is adopted.

## Test plan
None