### PR TITLE
Cache interruptedKeys list in watch keypress event

### DIFF
--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -344,6 +344,18 @@ export default async function watch(
     }
   };
 
+  const pluginKeys = getSortedUsageRows(watchPlugins, globalConfig).map(usage =>
+    Number(usage.key).toString(16),
+  );
+  const interruptedKeys = new Set([
+    'q',
+    KEYS.ENTER,
+    'a',
+    'o',
+    'f',
+    ...pluginKeys,
+  ]);
+
   const onKeypress = (key: string) => {
     if (key === KEYS.CONTROL_C || key === KEYS.CONTROL_D) {
       if (typeof stdin.setRawMode === 'function') {
@@ -362,14 +374,7 @@ export default async function watch(
     }
 
     // Abort test run
-    const pluginKeys = getSortedUsageRows(watchPlugins, globalConfig).map(
-      usage => Number(usage.key).toString(16),
-    );
-    if (
-      isRunning &&
-      testWatcher &&
-      ['q', KEYS.ENTER, 'a', 'o', 'f', ...pluginKeys].includes(key)
-    ) {
+    if (isRunning && testWatcher && interruptedKeys.has(key)) {
       testWatcher.setState({interrupted: true});
       return;
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I cached `interruptedKeys` to avoid creating a new collection and calling `getSortedUsageRows` on each keypress.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
