### PR TITLE
fix type of `testFailureExitCode` config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@
 
 ### Fixes
 
+- `[jest-schemas,jest-types]` fix type of `testFailureExitCode` config option([#15232](https://github.com/jestjs/jest/pull/15232))
 - `[babel-plugin-jest-hoist]` Use `denylist` instead of the deprecated `blacklist` for Babel 8 support ([#14109](https://github.com/jestjs/jest/pull/14109))
 - `[expect]` Check error instance type for `toThrow/toThrowError` ([#14576](https://github.com/jestjs/jest/pull/14576))
 - `[expect]` Improve diff for failing `expect.objectContaining` ([#15038](https://github.com/jestjs/jest/pull/15038))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,7 +49,6 @@
 
 ### Fixes
 
-- `[jest-schemas,jest-types]` fix type of `testFailureExitCode` config option([#15232](https://github.com/jestjs/jest/pull/15232))
 - `[babel-plugin-jest-hoist]` Use `denylist` instead of the deprecated `blacklist` for Babel 8 support ([#14109](https://github.com/jestjs/jest/pull/14109))
 - `[expect]` Check error instance type for `toThrow/toThrowError` ([#14576](https://github.com/jestjs/jest/pull/14576))
 - `[expect]` Improve diff for failing `expect.objectContaining` ([#15038](https://github.com/jestjs/jest/pull/15038))
@@ -76,6 +75,7 @@
 - `[@jest/expect-utils]` Fix not addressing to Sets and Maps as objects without keys ([#14873](https://github.com/jestjs/jest/pull/14873))
 - `[jest-leak-detector]` Make leak-detector more aggressive when running GC ([#14526](https://github.com/jestjs/jest/pull/14526))
 - `[jest-runtime]` Properly handle re-exported native modules in ESM via CJS ([#14589](https://github.com/jestjs/jest/pull/14589))
+- `[jest-schemas, jest-types]` [**BREAKING**] Fix type of `testFailureExitCode` config option([#15232](https://github.com/jestjs/jest/pull/15232))
 - `[jest-util]` Make sure `isInteractive` works in a browser ([#14552](https://github.com/jestjs/jest/pull/14552))
 - `[pretty-format]` [**BREAKING**] Print `ArrayBuffer` and `DataView` correctly ([#14290](https://github.com/jestjs/jest/pull/14290))
 - `[pretty-format]` Fixed a bug where "anonymous custom elements" were not being printed as expected. ([#15138](https://github.com/jestjs/jest/pull/15138))

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -2023,7 +2023,7 @@ test('use jsdom and set the URL in this test file', () => {
 });
 ```
 
-### `testFailureExitCode` \[number | string]
+### `testFailureExitCode` \[number]
 
 Default: `1`
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -2023,7 +2023,7 @@ test('use jsdom and set the URL in this test file', () => {
 });
 ```
 
-### `testFailureExitCode` \[number]
+### `testFailureExitCode` \[number | string]
 
 Default: `1`
 

--- a/packages/jest-schemas/src/raw-types.ts
+++ b/packages/jest-schemas/src/raw-types.ts
@@ -321,7 +321,7 @@ export const RawInitialOptions = Type.Partial(
     errorOnDeprecated: Type.Boolean(),
     testEnvironment: Type.String(),
     testEnvironmentOptions: Type.Record(Type.String(), Type.Unknown()),
-    testFailureExitCode: Type.Union([Type.String(), Type.Integer()]),
+    testFailureExitCode: Type.Integer(),
     testLocationInResults: Type.Boolean(),
     testMatch: Type.Array(Type.String()),
     testNamePattern: Type.String(),

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -198,7 +198,7 @@ export type DefaultOptions = {
   snapshotSerializers: Array<string>;
   testEnvironment: string;
   testEnvironmentOptions: Record<string, unknown>;
-  testFailureExitCode: string | number;
+  testFailureExitCode: number;
   testLocationInResults: boolean;
   testMatch: Array<string>;
   testPathIgnorePatterns: Array<string>;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
According to [types](https://github.com/k-rajat19/jest/blob/main/packages/jest-schemas/src/raw-types.ts#L324) `testFailureExitCode` can also take string values.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Green CI
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
