### PR TITLE
feat: allow passing TS config loader options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[jest-config]` allow passing TS config loader options via docblock comment ([#15234](https://github.com/jestjs/jest/pull/15234))
 - `[babel-jest]` Add option `excludeJestPreset` to allow opting out of `babel-preset-jest` ([#15164](https://github.com/jestjs/jest/pull/15164))
 - `[jest-circus, jest-cli, jest-config]` Add `waitNextEventLoopTurnForUnhandledRejectionEvents` flag to minimise performance impact of correct detection of unhandled promise rejections introduced in [#14315](https://github.com/jestjs/jest/pull/14315) ([#14681](https://github.com/jestjs/jest/pull/14681))
 - `[jest-circus]` Add a `waitBeforeRetry` option to `jest.retryTimes` ([#14738](https://github.com/jestjs/jest/pull/14738))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### Features
 
-- `[jest-config]` allow passing TS config loader options via docblock comment ([#15234](https://github.com/jestjs/jest/pull/15234))
 - `[babel-jest]` Add option `excludeJestPreset` to allow opting out of `babel-preset-jest` ([#15164](https://github.com/jestjs/jest/pull/15164))
 - `[jest-circus, jest-cli, jest-config]` Add `waitNextEventLoopTurnForUnhandledRejectionEvents` flag to minimise performance impact of correct detection of unhandled promise rejections introduced in [#14315](https://github.com/jestjs/jest/pull/14315) ([#14681](https://github.com/jestjs/jest/pull/14681))
 - `[jest-circus]` Add a `waitBeforeRetry` option to `jest.retryTimes` ([#14738](https://github.com/jestjs/jest/pull/14738))
@@ -13,9 +12,9 @@
 - `[jest-config]` [**BREAKING**] Update `testMatch` and `testRegex` default option for supporting `mjs`, `cjs`, `mts`, and `cts` ([#14584](https://github.com/jestjs/jest/pull/14584))
 - `[jest-config]` Loads config file from provided path in `package.json` ([#14044](https://github.com/facebook/jest/pull/14044))
 - `[jest-config]` Allow loading `jest.config.cts` files ([#14070](https://github.com/facebook/jest/pull/14070))
-- `[jest-config]` Added an option to disable `ts-node` typechecking ([#15161](https://github.com/jestjs/jest/pull/15161))
 - `[jest-config]` Show `rootDir` in error message when a `preset` fails to load ([#15194](https://github.com/jestjs/jest/pull/15194))
 - `[jest-config]` Support loading TS config files using `esbuild-register` via docblock loader ([#15190](https://github.com/jestjs/jest/pull/15190))
+- `[jest-config]` allow passing TS config loader options via docblock comment ([#15234](https://github.com/jestjs/jest/pull/15234))
 - `[@jest/core]` Group together open handles with the same stack trace ([#13417](https://github.com/jestjs/jest/pull/13417), & [#14789](https://github.com/jestjs/jest/pull/14789))
 - `[@jest/core]` Add `perfStats` to surface test setup overhead ([#14622](https://github.com/jestjs/jest/pull/14622))
 - `[@jest/core]` [**BREAKING**] Changed `--filter` to accept an object with shape `{ filtered: Array<string> }` to match [documentation](https://jestjs.io/docs/cli#--filterfile) ([#13319](https://github.com/jestjs/jest/pull/13319))

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -73,7 +73,20 @@ const config: Config = {
 export default config;
 ```
 
-If you are using `ts-node`, you can set `JEST_CONFIG_TRANSPILE_ONLY` environment variable to `true` (case insensitive) to read configuration files without typechecking.
+You can also pass options to the loader, for instance to enable `transpileOnly`.
+
+```ts title="jest.config.ts"
+/** @jest-config-loader ts-node */
+/** @jest-config-loader-options {"transpileOnly": true} */
+
+import type {Config} from 'jest';
+
+const config: Config = {
+  verbose: true,
+};
+
+export default config;
+```
 
 :::
 

--- a/e2e/__tests__/jest.config.ts.test.ts
+++ b/e2e/__tests__/jest.config.ts.test.ts
@@ -84,6 +84,7 @@ const jestTypesExists = fs.existsSync(jestTypesPath);
     writeFiles(DIR, {
       '__tests__/a-giraffe.js': "test('giraffe', () => expect(1).toBe(1));",
       'jest.config.ts': `
+      /**@jest-config-loader-options {"transpileOnly":${!!skipTypeCheck}}*/
       import {Config} from 'jest';
       const config: Config = { testTimeout: "10000" };
       export default config;
@@ -95,11 +96,7 @@ const jestTypesExists = fs.existsSync(jestTypesPath);
       "TS2322: Type 'string' is not assignable to type 'number'.";
     const runtimeErrorString = 'Option "testTimeout" must be of type:';
 
-    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false'], {
-      env: {
-        JEST_CONFIG_TRANSPILE_ONLY: skipTypeCheck ? 'true' : undefined,
-      },
-    });
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false']);
 
     if (skipTypeCheck) {
       expect(stderr).not.toMatch(typeErrorString);

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -10,7 +10,6 @@ import {isNativeError} from 'util/types';
 import * as fs from 'graceful-fs';
 import parseJson = require('parse-json');
 import stripJsonComments = require('strip-json-comments');
-import type {RegisterOptions} from 'ts-node';
 import type {Config} from '@jest/types';
 import {extract, parse} from 'jest-docblock';
 import {interopRequireDefault, requireOrImportModule} from 'jest-util';
@@ -90,7 +89,7 @@ export default async function readConfigFileAndSetRootDir(
 }
 
 // Load the TypeScript configuration
-let extraTSLoaderOptions: RegisterOptions;
+let extraTSLoaderOptions: Record<string, unknown>;
 
 const loadTSConfigFile = async (
   configPath: string,
@@ -150,8 +149,7 @@ async function registerTsLoader(loader: TsLoaderModule): Promise<TsLoader> {
         moduleTypes: {
           '**': 'cjs',
         },
-        swc: extraTSLoaderOptions?.swc,
-        transpileOnly: extraTSLoaderOptions?.transpileOnly,
+        ...extraTSLoaderOptions,
       });
     } else if (loader === 'esbuild-register') {
       const tsLoader = await import(
@@ -165,6 +163,7 @@ async function registerTsLoader(loader: TsLoaderModule): Promise<TsLoader> {
           if (bool) {
             instance = tsLoader.register({
               target: `node${process.version.slice(1)}`,
+              ...extraTSLoaderOptions,
             });
           } else {
             instance?.unregister();


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
Follow up #15190
this will allow us to pass config loader options in a docblock comment.
Currently, valid options are `swc` and `transpileOnly`, these options are useful if someone is using `ts-node` for loading ts config files.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Added e2e test
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
