### PR TITLE
feat: Stop using `ts-node` as a default loader for parsing TS configs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -57,7 +57,7 @@ export default async (): Promise<Config> => {
 
 :::tip
 
-To read TypeScript configuration files Jest by default requires [`ts-node`](https://npmjs.com/package/ts-node). You can override this behavior by adding a `@jest-config-loader` docblock at the top of the file. Currently, [`ts-node`](https://npmjs.com/package/ts-node) and [`esbuild-register`](https://npmjs.com/package/esbuild-register) is supported. Make sure `ts-node` or the loader you specify is installed.
+To read TypeScript configuration files Jest requires a Loader. You can define it by adding a `@jest-config-loader` docblock at the top of the file. Currently, [`ts-node`](https://npmjs.com/package/ts-node) and [`esbuild-register`](https://npmjs.com/package/esbuild-register) is supported. Make sure `ts-node` or the loader you specify is installed.
 
 ```ts title="jest.config.ts"
 /** @jest-config-loader ts-node */
@@ -76,8 +76,10 @@ export default config;
 You can also pass options to the loader, for instance to enable `transpileOnly`.
 
 ```ts title="jest.config.ts"
-/** @jest-config-loader ts-node */
-/** @jest-config-loader-options {"transpileOnly": true} */
+/**   
+ * @jest-config-loader ts-node 
+ * @jest-config-loader-options {"transpileOnly":${!!skipTypeCheck}}
+ */
 
 import type {Config} from 'jest';
 

--- a/e2e/__tests__/jest.config.ts.test.ts
+++ b/e2e/__tests__/jest.config.ts.test.ts
@@ -18,8 +18,9 @@ afterAll(() => cleanup(DIR));
 test('works with jest.config.ts', () => {
   writeFiles(DIR, {
     '__tests__/a-giraffe.js': "test('giraffe', () => expect(1).toBe(1));",
-    'jest.config.ts':
-      "export default {testEnvironment: 'jest-environment-node', testRegex: '.*-giraffe.js'};",
+    'jest.config.ts': `
+      /** @jest-config-loader ts-node */
+      export default {testEnvironment: 'jest-environment-node', testRegex: '.*-giraffe.js'};`,
     'package.json': '{}',
   });
 
@@ -33,8 +34,9 @@ test('works with jest.config.ts', () => {
 test('works with tsconfig.json', () => {
   writeFiles(DIR, {
     '__tests__/a-giraffe.js': "test('giraffe', () => expect(1).toBe(1));",
-    'jest.config.ts':
-      "export default {testEnvironment: 'jest-environment-node', testRegex: '.*-giraffe.js'};",
+    'jest.config.ts': `
+      /**@jest-config-loader ts-node */
+      export default {testEnvironment: 'jest-environment-node', testRegex: '.*-giraffe.js'};`,
     'package.json': '{}',
     'tsconfig.json': '{ "compilerOptions": { "module": "esnext" } }',
   });
@@ -53,8 +55,9 @@ test('traverses directory tree up until it finds jest.config', () => {
     test('giraffe', () => expect(1).toBe(1));
     test('abc', () => console.log(slash(process.cwd())));
     `,
-    'jest.config.ts':
-      "export default {testEnvironment: 'jest-environment-node', testRegex: '.*-giraffe.js'};",
+    'jest.config.ts': `
+      /** @jest-config-loader ts-node */
+      export default {testEnvironment: 'jest-environment-node', testRegex: '.*-giraffe.js'};`,
     'package.json': '{}',
     'some/nested/directory/file.js': '// nothing special',
   });
@@ -84,7 +87,10 @@ const jestTypesExists = fs.existsSync(jestTypesPath);
     writeFiles(DIR, {
       '__tests__/a-giraffe.js': "test('giraffe', () => expect(1).toBe(1));",
       'jest.config.ts': `
-      /**@jest-config-loader-options {"transpileOnly":${!!skipTypeCheck}}*/
+      /**
+       * @jest-config-loader ts-node 
+       * @jest-config-loader-options {"transpileOnly":${!!skipTypeCheck}}
+       */
       import {Config} from 'jest';
       const config: Config = { testTimeout: "10000" };
       export default config;
@@ -113,7 +119,9 @@ const jestTypesExists = fs.existsSync(jestTypesPath);
 test('invalid JS in jest.config.ts', () => {
   writeFiles(DIR, {
     '__tests__/a-giraffe.js': "test('giraffe', () => expect(1).toBe(1));",
-    'jest.config.ts': "export default i'll break this file yo",
+    'jest.config.ts': `
+    /**@jest-config-loader ts-node*/ 
+    export default i'll break this file yo`,
     'package.json': '{}',
   });
 

--- a/e2e/__tests__/tsIntegration.test.ts
+++ b/e2e/__tests__/tsIntegration.test.ts
@@ -19,6 +19,7 @@ describe('when `Config` type is imported from "@jest/types"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
+        /**@jest-config-loader ts-node */
         import type {Config} from '@jest/types';
         const config: Config.InitialOptions = {displayName: 'ts-object-config', verbose: true};
         export default config;
@@ -37,6 +38,7 @@ describe('when `Config` type is imported from "@jest/types"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
+        /**@jest-config-loader ts-node */
         import type {Config} from '@jest/types';
         async function getVerbose() {return true;}
         export default async (): Promise<Config.InitialOptions> => {
@@ -97,6 +99,7 @@ describe('when `Config` type is imported from "@jest/types"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
+        /**@jest-config-loader ts-node */
         import type {Config} from '@jest/types';
         const config: Config.InitialOptions = {testTimeout: '10000'};
         export default config;
@@ -116,6 +119,7 @@ describe('when `Config` type is imported from "@jest/types"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
+        /**@jest-config-loader ts-node */
         import type {Config} from '@jest/types';
         const config: Config.InitialOptions = {verbose: true};
         export default get config;
@@ -173,6 +177,7 @@ describe('when `Config` type is imported from "@jest/types"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(12).toBe(12));",
       'jest.config.ts': `
+          /**@jest-config-loader ts-node */
           import type {Config} from '@jest/types';
           const config: Config.InitialOptions = {displayName: 'ts-esm-object-config', verbose: true};
           export default config;
@@ -191,6 +196,7 @@ describe('when `Config` type is imported from "@jest/types"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(12).toBe(12));",
       'jest.config.ts': `
+      /**@jest-config-loader ts-node */ 
       import type {Config} from '@jest/types';
       async function getVerbose() {return true;}
       export default async (): Promise<Config.InitialOptions> => {
@@ -251,6 +257,7 @@ describe('when `Config` type is imported from "@jest/types"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(12).toBe(12));",
       'jest.config.ts': `
+          /**@jest-config-loader ts-node */
           import type {Config} from '@jest/types';
           const config: Config.InitialOptions = {testTimeout: '10000'};
           export default config;
@@ -270,6 +277,7 @@ describe('when `Config` type is imported from "@jest/types"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
+          /**@jest-config-loader ts-node */
           import type {Config} from '@jest/types';
           const config: Config.InitialOptions = {verbose: true};
           export default get config;
@@ -329,6 +337,7 @@ describe('when `Config` type is imported from "jest"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
+        /**@jest-config-loader ts-node */
         import type {Config} from 'jest';
         const config: Config = {displayName: 'ts-object-config', verbose: true};
         export default config;
@@ -347,6 +356,7 @@ describe('when `Config` type is imported from "jest"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
+        /**@jest-config-loader ts-node */
         import type {Config} from 'jest';
         async function getVerbose() {return true;}
         export default async (): Promise<Config> => {
@@ -407,6 +417,7 @@ describe('when `Config` type is imported from "jest"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
+        /**@jest-config-loader ts-node */
         import type {Config} from 'jest';
         const config: Config = {testTimeout: '10000'};
         export default config;
@@ -426,6 +437,7 @@ describe('when `Config` type is imported from "jest"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
+        /**@jest-config-loader ts-node */
         import type {Config} from 'jest';
         const config: Config = {verbose: true};
         export default get config;
@@ -483,6 +495,7 @@ describe('when `Config` type is imported from "jest"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(12).toBe(12));",
       'jest.config.ts': `
+          /**@jest-config-loader ts-node */
           import type {Config} from 'jest';
           const config: Config = {displayName: 'ts-esm-object-config', verbose: true};
           export default config;
@@ -501,6 +514,7 @@ describe('when `Config` type is imported from "jest"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(12).toBe(12));",
       'jest.config.ts': `
+          /**@jest-config-loader ts-node */
           import type {Config} from 'jest';
           async function getVerbose() {return true;}
           export default async (): Promise<Config> => {
@@ -561,6 +575,7 @@ describe('when `Config` type is imported from "jest"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(12).toBe(12));",
       'jest.config.ts': `
+          /**@jest-config-loader ts-node */
           import type {Config} from 'jest';
           const config: Config = {testTimeout: '10000'};
           export default config;
@@ -580,6 +595,7 @@ describe('when `Config` type is imported from "jest"', () => {
     writeFiles(DIR, {
       '__tests__/dummy.test.js': "test('dummy', () => expect(123).toBe(123));",
       'jest.config.ts': `
+          /**@jest-config-loader ts-node */
           import type {Config} from 'jest';
           const config: Config = {verbose: true};
           export default get config;

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -96,11 +96,13 @@ const loadTSConfigFile = async (
 ): Promise<Config.InitialOptions> => {
   // Get registered TypeScript compiler instance
   const docblockPragmas = parse(extract(fs.readFileSync(configPath, 'utf8')));
-  const tsLoader = docblockPragmas['jest-config-loader'] || 'ts-node';
+  const tsLoader = docblockPragmas['jest-config-loader'];
   const docblockTSLoaderOptions = docblockPragmas['jest-config-loader-options'];
 
-  if (typeof docblockTSLoaderOptions === 'string') {
-    extraTSLoaderOptions = JSON.parse(docblockTSLoaderOptions);
+  if (tsLoader === undefined) {
+    throw new Error(
+      'Jest: loader is required for the TypeScript configuration files. See https://jestjs.io/docs/configuration',
+    );
   }
   if (Array.isArray(tsLoader)) {
     throw new TypeError(
@@ -108,6 +110,9 @@ const loadTSConfigFile = async (
         ', ',
       )}"`,
     );
+  }
+  if (typeof docblockTSLoaderOptions === 'string') {
+    extraTSLoaderOptions = JSON.parse(docblockTSLoaderOptions);
   }
 
   const registeredCompiler = await getRegisteredCompiler(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary
Currently `ts-node` is set as a default loader for parsing TS configs, this PR changes that behavior because now there are other good alternatives like `esbuild-register` so it's better to stop doing anything by default and let users specify which module they wanna use in a docblock comment for loading their ts configs.
<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan
Green CI
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
