### PR TITLE
fix: projects should use collectCoverageFrom option

### DIFF
--- a/e2e/__tests__/multiProjectRunner.test.ts
+++ b/e2e/__tests__/multiProjectRunner.test.ts
@@ -14,8 +14,8 @@ const DIR = path.resolve(tmpdir(), 'multi-project-runner-test');
 
 const SAMPLE_FILE_CONTENT = 'module.exports = {};';
 
-beforeEach(() => cleanup(DIR));
-afterEach(() => cleanup(DIR));
+// beforeEach(() => cleanup(DIR));
+// afterEach(() => cleanup(DIR));
 
 test("--listTests doesn't duplicate the test files", () => {
   writeFiles(DIR, {
@@ -128,6 +128,631 @@ test('can pass projects or global config', () => {
   // make sure different ways of passing projects work exactly the same
   expect(result1.summary).toBe(result2.summary);
   expect(sortLines(result1.rest)).toBe(sortLines(result2.rest));
+});
+
+describe.only('correctly handle coverage reporting', () => {
+  const dir = path.join(__dirname, '../../multi-project-runner-test');
+  const getJestConfig = cfg => `module.exports = ${JSON.stringify(cfg)};`;
+  const setupDirectory = () => {
+    writeFiles(dir, {
+      'package.json': JSON.stringify(
+        {
+          scripts: {
+            start: 'node ./src/index.js',
+            test: '../node_modules/.bin/jest -c ./jest.config.js',
+          },
+        },
+        null,
+        '    ',
+      ),
+      '.nvmrc': `20`,
+      'src/index.js': `
+      const express = require('express');
+      const fruitController = require('./controllers/fruit');
+      const colorsController = require('./controllers/colors');
+      const validateMiddleware = require('./middleware/validate');
+      const errorsMiddleware = require('./middleware/errors');
+      const app = express();
+      const router = express.Router();
+
+      router.use(validateMiddleware);
+      router.get('/fruit', fruitController);
+      router.get('/colors', colorsController);
+      router.use(errorsMiddleware);
+
+      app.use('/', router);
+
+      app.listen(8443, function onListen() {
+          console.log('Sample service running on %s:%d', this.address().address, this.address().port);
+      });
+    `,
+      'src/controllers/fruit.js': `
+      module.exports = function (req, res, next){
+        switch(req.query.color) {
+           case 'red':
+             return res.send('apple');
+           case 'yellow':
+             return res.send('lemon');
+           case 'green':
+             return res.send('lime');
+           case 'blue':
+             return res.send('blueberry');
+           default:
+             return next(new Error('invalid color'))
+         }
+      }
+    `,
+      'src/controllers/colors.js': `
+      module.exports = function (req, res, next) {
+        res.send('["red","yellow","green","blue"]');
+      }
+    `,
+      'src/middleware/validate.js': `
+      module.exports = function (req, res, next){
+        if (req.url.startsWith('/fruit')) {
+          if (typeof req.query.color !== 'string') {
+            return next(new Error('color should be a string'));
+          }
+          if (!['red', 'yellow', 'green', 'blue'].includes(req.query.color)) {
+            return res.send('valid colors are ["red","yellow","green","blue"]');
+          }
+        }
+        next();
+      }
+    `,
+      'src/middleware/errors.js': `
+      module.exports = function (err, req, res, next){
+        res.status(500).send(\`ERROR: \${err.message}\`);
+      }
+    `,
+      'test/utils.js': `
+      module.exports = function getContext ({ params, url, query } = {}) {
+        const req = {
+          params, 
+          url: url ?? '/fruit',
+          query: {
+            color: 'red',
+            ...query
+          }
+        };
+        const res = {
+          status: jest.fn(() => res),
+          send: jest.fn(() => res)
+        };
+        const next = jest.fn();
+        const initialReq = JSON.parse(JSON.stringify(req));
+        const clear = () => {
+          Object.assign(req, initialReq);
+          res.status.mockClear();
+          res.send.mockClear();
+          next.mockClear();
+        }
+        return {
+          req,
+          res, 
+          next,
+          clear
+        }
+      }
+    `,
+      'src/controllers/__tests__/fruit.test.js': `
+      const getContext = require('../../../test/utils');
+      const fruitController = require('../fruit');
+      const { req, res, next, clear } = getContext({ url: '/fruit', query: {color:'red'} });
+      afterEach(()=>{
+        clear();
+      })
+      describe('fruit controller', () => {
+        test('does not throw', () => {
+          expect(() => {
+            fruitController(req, res, next);
+          }).not.toThrow();
+        })
+        test('sends a fruit', () => {
+          req.query.color = 'yellow'
+          fruitController(req, res, next);
+          expect(res.send).toHaveBeenCalledWith(expect.stringMatching(/apple|lemon|lime|blueberry/));
+        })
+      })
+    `,
+      'src/controllers/__tests__/colors.test.js': `
+      const getContext = require('../../../test/utils');
+      const colorsController = require('../colors');
+      const { req, res, next, clear } = getContext({ url: '/colors' });
+      afterEach(()=>{
+        clear();
+      })
+      describe('colors controller', () => {
+        test('does not throw', () => {
+          expect(() => {
+            colorsController(req, res, next);
+          }).not.toThrow();
+        })
+      })
+    `,
+      'src/middleware/__tests__/validate.test.js': `
+      const getContext = require('../../../test/utils');
+      const validateMiddleware = require('../validate');
+      const { req, res, next, clear } = getContext();
+      afterEach(()=>{
+        clear();
+      })
+      describe('validate middleware', () => {
+        test('does not throw', () => {
+          expect(() => {
+            validateMiddleware(req, res, next);
+          }).not.toThrow();
+        })
+      })
+    `,
+      'src/middleware/__tests__/errors.test.js': `
+      const getContext = require('../../../test/utils');
+      const errorsMiddleware = require('../errors');
+      const err = new Error('something bad');
+      const { req, res, next, clear } = getContext();
+      afterEach(()=>{
+        clear();
+      })
+      describe('errors middleware', () => {
+        test('does not throw', () => {
+          expect(() => {
+            errorsMiddleware(err, req, res, next);
+          }).not.toThrow();
+        })
+      })
+    `,
+      'jest.config.js': getJestConfig(baseConfig),
+    });
+  };
+
+  // put the patterns into an objects,so we can try plugging
+  // identical values into different locations (global config, project config, cli arg)
+  const COLLECT_COVERAGE_FROM_PATTERNS = {
+    ALL: ['src/**/*.js', '!src/**/*.test.js'],
+    CONTROLLERS: ['**/controllers/*.js'],
+    MIDDLEWARE: ['**/middleware/*.js'],
+  };
+  const TEST_MATCH_PATTERNS = {
+    ALL: ['**/+(*.)+(spec|test).+(ts|js)?(x)'],
+    CONTROLLERS: ['**/controllers/__tests__/*'],
+    MIDDLEWARE: ['**/middleware/__tests__/*'],
+  };
+  const TEST_PATH_PATTERNS = {
+    CONTROLLERS: 'controllers',
+    MIDDLEWARE: 'middleware',
+  };
+
+  // have one config that does not use the projects option
+  const baseConfig = {
+    collectCoverage: true,
+    collectCoverageFrom: COLLECT_COVERAGE_FROM_PATTERNS.ALL,
+    coveragePathIgnorePatterns: ['/node_modules/', 'tests'],
+    coverageReporters: ['text', 'text-summary'],
+    coverageThreshold: {
+      global: {
+        // arbitrary thresholds; picked values that would:
+        // - pass when running the all test files
+        // - pass when running the middleware test files
+        // - fails when running the controller test files
+        branches: 45,
+        functions: 60,
+        lines: 40,
+      },
+    },
+    testMatch: TEST_MATCH_PATTERNS.all,
+    transformIgnorePatterns: ['/node_modules/'],
+    reporters: ['default'],
+  };
+
+  // have another config that does not use the projects option
+  const projectsConfig = {
+    ...baseConfig,
+    projects: [
+      {
+        displayName: 'controllers',
+        collectCoverageFrom: COLLECT_COVERAGE_FROM_PATTERNS.CONTROLLERS,
+        testMatch: TEST_MATCH_PATTERNS.CONTROLLERS,
+      },
+      {
+        displayName: 'middleware',
+        collectCoverageFrom: COLLECT_COVERAGE_FROM_PATTERNS.MIDDLEWARE,
+        testMatch: TEST_MATCH_PATTERNS.MIDDLEWARE,
+      },
+    ],
+  };
+
+  /**
+   * Provide a function that can be thrown into a test to manually view everything
+   * the command returned
+   */
+  const report = ({stdout, stderr, exitCode, args}) => {
+    console.log('command', `../node_modules/.bin/jest ${args.join(' ')}`);
+    console.log(`stdout\n${stdout}`);
+    console.log(`stderr\n${stderr}`);
+    console.log('exitCode', exitCode);
+  };
+
+  // breaking up repeated expect statements into reusable functions
+
+  /**
+   * Confirm the jest command ran the controller test files
+   */
+  const ranControllerTests = (stderr, expected) => {
+    if (expected) {
+      // it ran the controller tests
+      expect(stderr).toMatch(/PASS.+?colors.test.js/);
+      expect(stderr).toMatch(/PASS.+?fruit.test.js/);
+    } else {
+      // it avoided the controller tests
+      expect(stderr).not.toMatch(/PASS.+?colors.test.js/);
+      expect(stderr).not.toMatch(/PASS.+?fruit.test.js/);
+    }
+  };
+
+  /**
+   * Confirm the jest command ran the middleware test files
+   */
+  const ranMiddlewareTests = (stderr, expected) => {
+    if (expected) {
+      // it ran the middleware tests
+      expect(stderr).toMatch(/PASS.+?errors.test.js/);
+      expect(stderr).toMatch(/PASS.+?validate.test.js/);
+    } else {
+      // it avoided the middleware tests
+      expect(stderr).not.toMatch(/PASS.+?errors.test.js/);
+      expect(stderr).not.toMatch(/PASS.+?validate.test.js/);
+    }
+  };
+
+  /**
+   * Confirm the jest command ran the correct test files
+   */
+  const checkTested = (
+    stderr,
+    {controller: controllerExpected, middleware: middlewareExpected},
+  ) => {
+    ranControllerTests(stderr, controllerExpected);
+    ranMiddlewareTests(stderr, middlewareExpected);
+  };
+
+  /**
+   * Confirm the jest command included the controller src files in
+   * the coverage report
+   */
+  const coveredController = (stdout, expected) => {
+    if (expected) {
+      // it covered controller files
+      expect(stdout).toMatch(/colors\.js/);
+      expect(stdout).toMatch(/fruit\.js/);
+    } else {
+      // it avoided controller files
+      expect(stdout).not.toMatch(/colors\.js/);
+      expect(stdout).not.toMatch(/fruit\.js/);
+    }
+  };
+
+  /**
+   * Confirm the jest command included the middleware src files in
+   * the coverage report
+   */
+  const coveredMiddleware = (stdout, expected) => {
+    if (expected) {
+      // it covered middleware files
+      expect(stdout).toMatch(/errors\.js/);
+      expect(stdout).toMatch(/validate\.js/);
+    } else {
+      // it avoided middleware files
+      expect(stdout).not.toMatch(/errors\.js/);
+      expect(stdout).not.toMatch(/validate\.js/);
+    }
+  };
+
+  /**
+   * Confirm the jest command included the correct src files in
+   * the coverage report
+   */
+  const checkCovered = (
+    stdout,
+    {controller: controllerExpected, middleware: middlewareExpected},
+  ) => {
+    coveredController(stdout, controllerExpected);
+    coveredMiddleware(stdout, middlewareExpected);
+    // should never include test utils in coverage
+    expect(stdout).not.toMatch(/utils\.js/);
+  };
+
+  beforeAll(() => {
+    setupDirectory();
+  });
+  describe('no projects option', () => {
+    // baseline sets up the directory and
+    // - runs all the test files in the directory
+    // - reports coverage for the source code
+    // giving us something to compare against in the later tests
+    test('baseline', () => {
+      const args = ['--config', 'jest.config.js'];
+      const {stderr, stdout, exitCode} = runJest(dir, args);
+      // report({stderr, stdout, exitCode, args});
+
+      // should run all tests
+      checkTested(stderr, {controller: true, middleware: true});
+
+      // should cover all files
+      checkCovered(stdout, {controller: true, middleware: true});
+
+      // has sufficient test coverage
+      expect(exitCode).toBe(0);
+    });
+
+    describe('middleware with testNamePatterns', () => {
+      test('without collectCoverageFrom within cli args', () => {
+        writeFiles(dir, {
+          'jest.config.js': getJestConfig(baseConfig),
+        });
+        const args = [
+          '--config',
+          'jest.config.js',
+          '--testNamePattern',
+          TEST_PATH_PATTERNS.MIDDLEWARE,
+        ];
+
+        const {stderr, stdout, exitCode} = runJest(dir, args);
+        // report({stderr, stdout, exitCode, args});
+
+        // tested and passed only middleware files
+        checkTested(stderr, {controller: false, middleware: true});
+
+        // should cover all files
+        checkCovered(stdout, {controller: true, middleware: true});
+
+        // has insufficient test coverage
+        // middleware/__tests__/* does cover the all the src files
+        expect(exitCode).toBe(1);
+      });
+
+      test('with collectCoverageFrom within cli args', () => {
+        writeFiles(dir, {
+          'jest.config.js': getJestConfig(baseConfig),
+        });
+        const args = [
+          '--config',
+          'jest.config.js',
+          '--testNamePattern',
+          TEST_PATH_PATTERNS.MIDDLEWARE,
+          ...COLLECT_COVERAGE_FROM_PATTERNS.MIDDLEWARE.flatMap(pattern => [
+            '--collectCoverageFrom',
+            pattern,
+          ]),
+        ];
+
+        const {stderr, stdout, exitCode} = runJest(dir, args);
+        // report({stderr, stdout, exitCode, args});
+
+        // tested and passed only middleware files
+        checkTested(stderr, {controller: false, middleware: true});
+
+        // included only middleware src files in code coverage
+        checkCovered(stdout, {controller: false, middleware: true});
+
+        // has sufficient test coverage
+        // middleware/__tests__/* does cover the middleware src files
+        expect(exitCode).toBe(0);
+      });
+    });
+
+    describe('controllers with testNamePatterns', () => {
+      test('without collectCoverageFrom within cli args', () => {
+        writeFiles(dir, {
+          'jest.config.js': getJestConfig(baseConfig),
+        });
+        const args = [
+          '--config',
+          'jest.config.js',
+          '--testNamePattern',
+          TEST_PATH_PATTERNS.CONTROLLERS,
+        ];
+
+        const {stderr, stdout, exitCode} = runJest(dir, args);
+        // report({stderr, stdout, exitCode, args});
+
+        /**
+         * POSSIBLE_BUG_NOTE
+         * This example fails the coverage check, causing these lines
+         *    ```
+         *    PASS   controllers  src/controllers/__tests__/fruit.test.js
+         *    PASS   controllers  src/controllers/__tests__/colors.test.js
+         *    ```
+         * not to appear in the stderr.
+         *
+         * Unclear if this is a bug.
+         *
+         * Creating this test directory as jest/multi-project-runner-test
+         * and cd into it and running
+         * ```sh
+         *    ../packages/jest-cli/bin/jest.js \
+         *        --config jest.config.js \
+         *        --testPathPatterns controllers
+         * ```
+         * does appear to show the text in the terminal.
+         */
+
+        // // tested and passed only controllers files
+        // checkTested(stderr, {
+        //   controller: true,
+        //   middleware: false,
+        // });
+
+        // included only controllers src files in code coverage
+        checkCovered(stdout, {controller: true, middleware: true});
+
+        // has insufficient test coverage
+        // controllers/__tests__/* does cover the controllers src files
+        expect(exitCode).toBe(1);
+      });
+
+      test('with collectCoverageFrom within cli args', () => {
+        writeFiles(dir, {
+          'jest.config.js': getJestConfig(baseConfig),
+        });
+
+        const args = [
+          '--config',
+          'jest.config.js',
+          '--testNamePattern',
+          TEST_PATH_PATTERNS.CONTROLLERS,
+          ...COLLECT_COVERAGE_FROM_PATTERNS.CONTROLLERS.flatMap(pattern => [
+            '--collectCoverageFrom',
+            pattern,
+          ]),
+        ];
+        const {stderr, stdout, exitCode} = runJest(dir, args);
+        // report({stderr, stdout, exitCode, args});
+
+        // See POSSIBLE_BUG_NOTE above why this is commented out
+        // // tested and passed only controllers files
+        // checkTested(stderr, {
+        //   controller: true,
+        //   middleware: false,
+        // });
+
+        // included only controllers src files in code coverage
+        checkCovered(stdout, {controller: true, middleware: false});
+
+        // has sufficient test coverage; controllers/__tests__/*
+        // does cover the controllers src files
+        expect(exitCode).toBe(1);
+      });
+    });
+  });
+
+  describe('with projects option', () => {
+    test('test all src code', () => {
+      writeFiles(dir, {
+        'jest.config.js': getJestConfig(projectsConfig),
+      });
+      const args = ['--config', 'jest.config.js'];
+      const {stderr, stdout, exitCode} = runJest(dir, args);
+      // report({stderr, stdout, exitCode, args});
+
+      // tested and passed all files
+      checkTested(stderr, {controller: true, middleware: true});
+
+      // included all src files in code coverage
+      checkCovered(stdout, {controller: true, middleware: true});
+
+      // has sufficient test coverage
+      expect(exitCode).toBe(0);
+    });
+    describe('test middleware project', () => {
+      test('without collectCoverageFrom within cli args', () => {
+        writeFiles(dir, {
+          'jest.config.js': getJestConfig(projectsConfig),
+        });
+        const args = [
+          '--config',
+          'jest.config.js',
+          '--selectProjects',
+          'middleware',
+        ];
+        const {stderr, stdout, exitCode} = runJest(dir, args);
+        // report({stderr, stdout, exitCode, args});
+
+        // tested and passed middleware files
+        checkTested(stderr, {controller: false, middleware: true});
+
+        // PROJECT_COVERAGE_BUG_NOTE
+        // included only middleware src files in code coverage because
+        // the middleware project in projectsConfig.projects defines collectCoverageFrom
+        checkCovered(stdout, {controller: false, middleware: true});
+
+        // has sufficient test coverage
+        expect(exitCode).toBe(0);
+      });
+      test('with collectCoverageFrom within cli args', () => {
+        writeFiles(dir, {
+          'jest.config.js': getJestConfig(projectsConfig),
+        });
+
+        const args = [
+          '--config',
+          'jest.config.js',
+          '--selectProjects',
+          'middleware',
+          ...COLLECT_COVERAGE_FROM_PATTERNS.MIDDLEWARE.flatMap(pattern => [
+            '--collectCoverageFrom',
+            pattern,
+          ]),
+        ];
+        const {stderr, stdout, exitCode} = runJest(dir, args);
+        // report({stderr, stdout, exitCode, args});
+
+        // tested and passed middleware files
+        checkTested(stderr, {controller: false, middleware: true});
+
+        // included only middleware src files in code coverage because
+        // collectCoverageFrom added to the cli arguments
+        checkCovered(stdout, {controller: false, middleware: true});
+
+        // has sufficient test coverage
+        expect(exitCode).toBe(0);
+      });
+    });
+    describe('test controllers project', () => {
+      test('without collectCoverageFrom within cli args', () => {
+        writeFiles(dir, {
+          'jest.config.js': getJestConfig(projectsConfig),
+        });
+        const args = [
+          '--config',
+          'jest.config.js',
+          '--selectProjects',
+          'controllers',
+        ];
+        const {stderr, stdout, exitCode} = runJest(dir, args);
+        // report({stderr, stdout, exitCode, args});
+
+        // See POSSIBLE_BUG_NOTE above why this is commented out
+        // // tested and passed controller files
+        // checkTested(stderr, {controller: true, middleware: false});
+
+        // included only controller src files in code coverage because
+        // the controller project in projectsConfig.projects defines collectCoverageFrom
+        checkCovered(stdout, {controller: true, middleware: false});
+
+        // has insufficient test coverage
+        expect(exitCode).toBe(1);
+      });
+      test('with collectCoverageFrom within cli args', () => {
+        writeFiles(dir, {
+          'jest.config.js': getJestConfig(projectsConfig),
+        });
+
+        const args = [
+          '--config',
+          'jest.config.js',
+          '--selectProjects',
+          'controllers',
+          ...COLLECT_COVERAGE_FROM_PATTERNS.CONTROLLERS.flatMap(pattern => [
+            '--collectCoverageFrom',
+            pattern,
+          ]),
+        ];
+        const {stderr, stdout, exitCode} = runJest(dir, args);
+        // report({stderr, stdout, exitCode, args});
+
+        // tested and passed controller files
+        checkTested(stderr, {controller: true, middleware: false});
+
+        // PROJECT_COVERAGE_BUG_NOTE
+        // included only controller src files in code coverage because
+        // collectCoverageFrom added to the cli arguments
+        checkCovered(stdout, {controller: true, middleware: false});
+
+        // has insufficient test coverage
+        expect(exitCode).toBe(1);
+      });
+    });
+  });
 });
 
 test('"No tests found" message for projects', () => {


### PR DESCRIPTION
TL;DR; running a single project defined in the `projects` config option fails to correctly use the `collectCoverageFrom` config option for that project.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I upgraded my `nx` repo to 19 and attempted to migrate from groups of tests defined as configurations in `project.json`, to using jest `projects`.
However, when I would run a single `jest` project, it would report the code coverage for the whole `nx` project instead of only the source code files being tested. This resulted in a non-zero exit code, causing `nx` to not cache the results (even when all the tests that ran passed).

I tried again with a non-mono repo and got the same result. 
From what I can tell, a project config is meant to be nearly identical to the overall config, [including using collectCoverageFrom](https://github.com/jestjs/jest/blob/68dca2a321b9887660d641c160ff6b94552c9dac/packages/jest-types/src/Config.ts#L334).

I wrote up some tests to illustrate this behavior. 
```
 FAIL  e2e/__tests__/multiProjectRunner.test.ts (9.321 s)
  correctly handle coverage reporting
    no projects option
      ✓ baseline (1044 ms)
      middleware with testNamePatterns
        ✓ without collectCoverageFrom within cli args (969 ms)
        ✓ with collectCoverageFrom within cli args (951 ms)
      controllers with testNamePatterns
        ✓ without collectCoverageFrom within cli args (942 ms)
        ✓ with collectCoverageFrom within cli args (727 ms)
    with projects option
      ✓ test all src code (998 ms)
      test middleware project
        ✕ without collectCoverageFrom within cli args (934 ms)
        ✓ with collectCoverageFrom within cli args (792 ms)
      test controllers project
        ✕ without collectCoverageFrom within cli args (907 ms)
        ✓ with collectCoverageFrom within cli args (670 ms)
```

I left comments in the test file `PROJECT_COVERAGE_BUG_NOTE` where the tests are failing, but ought to be passing. 

While writing these tests, I came across some unexpected behavior. The stderr was missing some text I'd have expected, and when I ran it manually the text was present. I commented those out and left a `POSSIBLE_BUG_NOTE` comment.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

I wrote tests to check combinations of 
- meets code coverage threshold vs not
- defines projects in the `jest` config vs not
- uses `testPathPattern` in the cli arguments vs not
- uses `collectCoverageFrom` in the cli arguments vs not (Contrasts how when the option is defined in a single project it is ignored)

Those tests can be run by
```sh
yarn jest e2e/__tests__/multiProjectRunner.test.ts
```

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

## TODO

This is a draft, providing tests to check if all works as expected. What remains: 

- write a fix
- update CHANGELOG.md 
- clean up test file after fix is written
    - remove `describe.only`
    - change from using `dir` to `DIR`
- remove unused code
- lint

