### PR TITLE
Fix: Remove broken link for "Running AngularJS Tests with Jest"

### DIFF
--- a/docs/TestingFrameworks.md
+++ b/docs/TestingFrameworks.md
@@ -17,7 +17,6 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 ## AngularJS
 
 - [Testing an AngularJS app with Jest](https://medium.com/aya-experience/testing-an-angularjs-app-with-jest-3029a613251) by Matthieu Lux ([@Swiip](https://twitter.com/Swiip))
-- [Running AngularJS Tests with Jest](https://engineering.talentpair.com/running-angularjs-tests-with-jest-49d0cc9c6d26) by Ben Brandt ([@benjaminbrandt](https://twitter.com/benjaminbrandt))
 - [AngularJS Unit Tests with Jest Actions (Traditional Chinese)](https://dwatow.github.io/2019/08-14-angularjs/angular-jest/?fbclid=IwAR2SrqYg_o6uvCQ79FdNPeOxs86dUqB6pPKgd9BgnHt1kuIDRyRM-ch11xg) by Chris Wang ([@dwatow](https://github.com/dwatow))
 
 ## Angular


### PR DESCRIPTION


## Summary
This PR removes the broken link to "Running AngularJS Tests with Jest" in the AngularJS section of the Jest documentation. The link is no longer working, and the relevant content is either outdated or no longer available.

Fixes #15257

## Changes
- Deleted the line of code containing the broken link.

## Reason for the Change
The link was leading to a 404 page, which could confuse users. Removing it improves the documentation's accuracy and user experience.

Thank you for reviewing this change.
