### PR TITLE
remove expressjs reference material as domain has expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@
 - `[docs]` Updated `.toHaveBeenCalled()` documentation to correctly reflect its functionality ([#14842](https://github.com/jestjs/jest/pull/14842))
 - `[docs]` Link NestJS documentation on testing with Jest ([#14940](https://github.com/jestjs/jest/pull/14940))
 - `[docs]` `Revised documentation for .toHaveBeenCalled()` to accurately depict its functionality. ([#14853](https://github.com/jestjs/jest/pull/14853))
+- `[docs]` Removed ExpressJS reference link from documentation due to dead link ([#15270](https://github.com/jestjs/jest/pull/15270))
 
 ## 29.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@
 - `[docs]` Updated `.toHaveBeenCalled()` documentation to correctly reflect its functionality ([#14842](https://github.com/jestjs/jest/pull/14842))
 - `[docs]` Link NestJS documentation on testing with Jest ([#14940](https://github.com/jestjs/jest/pull/14940))
 - `[docs]` `Revised documentation for .toHaveBeenCalled()` to accurately depict its functionality. ([#14853](https://github.com/jestjs/jest/pull/14853))
-- `[docs]` Removed ExpressJS reference link from documentation due to dead link ([#15270](https://github.com/jestjs/jest/pull/15270))
+- `[docs]` Removed ExpressJS reference link from documentation due to dead link ([#15271](https://github.com/jestjs/jest/pull/15271))
 
 ## 29.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@
 - `[docs]` Updated `.toHaveBeenCalled()` documentation to correctly reflect its functionality ([#14842](https://github.com/jestjs/jest/pull/14842))
 - `[docs]` Link NestJS documentation on testing with Jest ([#14940](https://github.com/jestjs/jest/pull/14940))
 - `[docs]` `Revised documentation for .toHaveBeenCalled()` to accurately depict its functionality. ([#14853](https://github.com/jestjs/jest/pull/14853))
-- `[docs]` Removed ExpressJS reference link from documentation due to dead link ([#15271](https://github.com/jestjs/jest/pull/15271))
+- `[docs]` Removed ExpressJS reference link from documentation due to dead link ([#15270](https://github.com/jestjs/jest/pull/15270))
 
 ## 29.7.0
 

--- a/docs/TestingFrameworks.md
+++ b/docs/TestingFrameworks.md
@@ -32,10 +32,6 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 
 - [Writing Tests](https://redux.js.org/recipes/writing-tests) by Redux docs
 
-## Express.js
-
-- [How to test Express.js with Jest and Supertest](http://www.albertgao.xyz/2017/05/24/how-to-test-expressjs-with-jest-and-supertest/) by Albert Gao ([@albertgao](https://twitter.com/albertgao))
-
 ## GatsbyJS
 
 - [Unit Testing](https://www.gatsbyjs.org/docs/unit-testing/) by GatsbyJS docs

--- a/website/versioned_docs/version-29.4/TestingFrameworks.md
+++ b/website/versioned_docs/version-29.4/TestingFrameworks.md
@@ -32,10 +32,6 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 
 - [Writing Tests](https://redux.js.org/recipes/writing-tests) by Redux docs
 
-## Express.js
-
-- [How to test Express.js with Jest and Supertest](http://www.albertgao.xyz/2017/05/24/how-to-test-expressjs-with-jest-and-supertest/) by Albert Gao ([@albertgao](https://twitter.com/albertgao))
-
 ## GatsbyJS
 
 - [Unit Testing](https://www.gatsbyjs.org/docs/unit-testing/) by GatsbyJS docs

--- a/website/versioned_docs/version-29.5/TestingFrameworks.md
+++ b/website/versioned_docs/version-29.5/TestingFrameworks.md
@@ -32,10 +32,6 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 
 - [Writing Tests](https://redux.js.org/recipes/writing-tests) by Redux docs
 
-## Express.js
-
-- [How to test Express.js with Jest and Supertest](http://www.albertgao.xyz/2017/05/24/how-to-test-expressjs-with-jest-and-supertest/) by Albert Gao ([@albertgao](https://twitter.com/albertgao))
-
 ## GatsbyJS
 
 - [Unit Testing](https://www.gatsbyjs.org/docs/unit-testing/) by GatsbyJS docs

--- a/website/versioned_docs/version-29.6/TestingFrameworks.md
+++ b/website/versioned_docs/version-29.6/TestingFrameworks.md
@@ -32,10 +32,6 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 
 - [Writing Tests](https://redux.js.org/recipes/writing-tests) by Redux docs
 
-## Express.js
-
-- [How to test Express.js with Jest and Supertest](http://www.albertgao.xyz/2017/05/24/how-to-test-expressjs-with-jest-and-supertest/) by Albert Gao ([@albertgao](https://twitter.com/albertgao))
-
 ## GatsbyJS
 
 - [Unit Testing](https://www.gatsbyjs.org/docs/unit-testing/) by GatsbyJS docs

--- a/website/versioned_docs/version-29.7/TestingFrameworks.md
+++ b/website/versioned_docs/version-29.7/TestingFrameworks.md
@@ -32,10 +32,6 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 
 - [Writing Tests](https://redux.js.org/recipes/writing-tests) by Redux docs
 
-## Express.js
-
-- [How to test Express.js with Jest and Supertest](http://www.albertgao.xyz/2017/05/24/how-to-test-expressjs-with-jest-and-supertest/) by Albert Gao ([@albertgao](https://twitter.com/albertgao))
-
 ## GatsbyJS
 
 - [Unit Testing](https://www.gatsbyjs.org/docs/unit-testing/) by GatsbyJS docs


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

👉😎👉

might make a guide after I get it working and learn more for my TS Express app I am adding jest to. Just something I discovered

existing page: https://jestjs.io/docs/testing-frameworks#expressjs

✅ changelog

## Summary

After attempting to look at the material for Express.JS someone had linked to their personal guide you are greeted by a parked domain / domain expirey leading you no where.

Current link: http://www.albertgao.xyz/2017/05/24/how-to-test-expressjs-with-jest-and-supertest/

## Test plan

`yarn install`
`cd website`
`node fetchSupporters.js`
`yarn start`
<img width="1509" alt="Screenshot 2024-08-22 at 6 34 40 PM" src="https://github.com/user-attachments/assets/e50beed0-ddb5-494f-b9f6-536a79182ea1">


