### PR TITLE
Remove dead link from documentation :(

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,7 +119,7 @@
 - `[docs]` Updated `.toHaveBeenCalled()` documentation to correctly reflect its functionality ([#14842](https://github.com/jestjs/jest/pull/14842))
 - `[docs]` Link NestJS documentation on testing with Jest ([#14940](https://github.com/jestjs/jest/pull/14940))
 - `[docs]` `Revised documentation for .toHaveBeenCalled()` to accurately depict its functionality. ([#14853](https://github.com/jestjs/jest/pull/14853))
-- `[docs]` Removed ExpressJS testing-frameworks personal reference guide after domain expired / dead link.
+- `[docs]` Removed ExpressJS from `testing-frameworks` reference pages after domain expired.
 
 ## 29.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,6 +119,7 @@
 - `[docs]` Updated `.toHaveBeenCalled()` documentation to correctly reflect its functionality ([#14842](https://github.com/jestjs/jest/pull/14842))
 - `[docs]` Link NestJS documentation on testing with Jest ([#14940](https://github.com/jestjs/jest/pull/14940))
 - `[docs]` `Revised documentation for .toHaveBeenCalled()` to accurately depict its functionality. ([#14853](https://github.com/jestjs/jest/pull/14853))
+- `[docs]` Removed ExpressJS testing-frameworks personal reference guide after domain expired / dead link.
 
 ## 29.7.0
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

👉😎👉

might make a guide after I get it working and learn more for my TS Express app I am adding jest to. Just something I discovered

existing page: https://jestjs.io/docs/testing-frameworks#expressjs

✅ changelog

## Summary

After attempting to look at the material for Express.JS someone had linked to their personal guide you are greeted by a parked domain / domain expirey leading you no where.

Current link: http://www.albertgao.xyz/2017/05/24/how-to-test-expressjs-with-jest-and-supertest/

## Test plan

`yarn install`
`cd website`
`node fetchSupporters.js`
`yarn start`
<img width="1509" alt="Screenshot 2024-08-22 at 6 34 40 PM" src="https://github.com/user-attachments/assets/e50beed0-ddb5-494f-b9f6-536a79182ea1">
