### PR TITLE
docs: added link to assertion count section in assertion page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@
 - `[docs]` Link NestJS documentation on testing with Jest ([#14940](https://github.com/jestjs/jest/pull/14940))
 - `[docs]` `Revised documentation for .toHaveBeenCalled()` to accurately depict its functionality. ([#14853](https://github.com/jestjs/jest/pull/14853))
 - `[docs]` Removed ExpressJS reference link from documentation due to dead link ([#15270](https://github.com/jestjs/jest/pull/15270))
+- `[docs]` Added link to assertion count section in assertion page ([#15281](https://github.com/jestjs/jest/pull/15281))
 
 ## 29.7.0
 

--- a/docs/TestingAsyncCode.md
+++ b/docs/TestingAsyncCode.md
@@ -21,7 +21,7 @@ test('the data is peanut butter', () => {
 
 ## Async/Await
 
-Alternatively, you can use `async` and `await` in your tests. To write an async test, use the `async` keyword in front of the function passed to `test`. For example, the same `fetchData` scenario can be tested with:
+If you expect a promise to be rejected, use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of [assertions](ExpectAPI.md#assertion-count) are called. Otherwise, a fulfilled promise would not fail the test.
 
 ```js
 test('the data is peanut butter', async () => {
@@ -59,7 +59,7 @@ Be sure to return (or `await`) the promise - if you omit the `return`/`await` st
 
 :::
 
-If you expect a promise to be rejected, use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of assertions are called. Otherwise, a fulfilled promise would not fail the test.
+If you expect a promise to be rejected, use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of [assertions](ExpectAPI.md#assertion-count) are called. Otherwise, a fulfilled promise would not fail the test.
 
 ```js
 test('the fetch fails with an error', () => {

--- a/website/versioned_docs/version-29.4/TestingAsyncCode.md
+++ b/website/versioned_docs/version-29.4/TestingAsyncCode.md
@@ -59,7 +59,7 @@ Be sure to return (or `await`) the promise - if you omit the `return`/`await` st
 
 :::
 
-If you expect a promise to be rejected, use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of assertions are called. Otherwise, a fulfilled promise would not fail the test.
+If you expect a promise to be rejected, use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of [assertions](ExpectAPI.md#assertion-count) are called. Otherwise, a fulfilled promise would not fail the test.
 
 ```js
 test('the fetch fails with an error', () => {

--- a/website/versioned_docs/version-29.5/TestingAsyncCode.md
+++ b/website/versioned_docs/version-29.5/TestingAsyncCode.md
@@ -59,7 +59,7 @@ Be sure to return (or `await`) the promise - if you omit the `return`/`await` st
 
 :::
 
-If you expect a promise to be rejected, use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of assertions are called. Otherwise, a fulfilled promise would not fail the test.
+If you expect a promise to be rejected, use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of [assertions](ExpectAPI.md#assertion-count) are called. Otherwise, a fulfilled promise would not fail the test.
 
 ```js
 test('the fetch fails with an error', () => {

--- a/website/versioned_docs/version-29.6/TestingAsyncCode.md
+++ b/website/versioned_docs/version-29.6/TestingAsyncCode.md
@@ -59,7 +59,7 @@ Be sure to return (or `await`) the promise - if you omit the `return`/`await` st
 
 :::
 
-If you expect a promise to be rejected, use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of assertions are called. Otherwise, a fulfilled promise would not fail the test.
+If you expect a promise to be rejected, use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of [assertions](ExpectAPI.md#assertion-count) are called. Otherwise, a fulfilled promise would not fail the test.
 
 ```js
 test('the fetch fails with an error', () => {

--- a/website/versioned_docs/version-29.7/TestingAsyncCode.md
+++ b/website/versioned_docs/version-29.7/TestingAsyncCode.md
@@ -59,7 +59,7 @@ Be sure to return (or `await`) the promise - if you omit the `return`/`await` st
 
 :::
 
-If you expect a promise to be rejected, use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of assertions are called. Otherwise, a fulfilled promise would not fail the test.
+If you expect a promise to be rejected, use the `.catch` method. Make sure to add `expect.assertions` to verify that a certain number of [assertions](ExpectAPI.md#assertion-count) are called. Otherwise, a fulfilled promise would not fail the test.
 
 ```js
 test('the fetch fails with an error', () => {


### PR DESCRIPTION
## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
It was my first time to read the documntation and i found something called ```assertion.count()``` so instead of serching for it i found it will be great if it was a link to click on it to navigate directly to its documentation so i decided to do it by myself 
added a link to ```assertion.count()``` where it is mentioned to make it easy for the reader to get more info about it
