### PR TITLE
chore: Replace `glob` with `tinyglobby` in `@jest/reporters`, `jest-config`, and `jest-runtime`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,7 @@
 - `[docs]` Link NestJS documentation on testing with Jest ([#14940](https://github.com/jestjs/jest/pull/14940))
 - `[docs]` `Revised documentation for .toHaveBeenCalled()` to accurately depict its functionality. ([#14853](https://github.com/jestjs/jest/pull/14853))
 - `[docs]` Removed ExpressJS reference link from documentation due to dead link ([#15270](https://github.com/jestjs/jest/pull/15270))
+- `[jest-config, jest-runtime, @jest/reporters]` Replace `glob` with `tinyglobby` ([#15283](https://github.com/jestjs/jest/pull/15283))
 
 ## 29.7.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,7 +120,7 @@
 - `[docs]` Link NestJS documentation on testing with Jest ([#14940](https://github.com/jestjs/jest/pull/14940))
 - `[docs]` `Revised documentation for .toHaveBeenCalled()` to accurately depict its functionality. ([#14853](https://github.com/jestjs/jest/pull/14853))
 - `[docs]` Removed ExpressJS reference link from documentation due to dead link ([#15270](https://github.com/jestjs/jest/pull/15270))
-- `[jest-config, jest-runtime, @jest/reporters]` Replace `glob` with `tinyglobby` ([#15283](https://github.com/jestjs/jest/pull/15283))
+- `[@jest/reporters, jest-config, jest-runtime]` Replace `glob` with `tinyglobby` ([#15283](https://github.com/jestjs/jest/pull/15283))
 
 ## 29.7.0
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "eslint-plugin-unicorn": "^55.0.0",
     "execa": "^5.0.0",
     "find-process": "^1.4.1",
-    "glob": "^10.3.10",
     "graceful-fs": "^4.2.9",
     "isbinaryfile": "^5.0.0",
     "istanbul-lib-coverage": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "eslint-plugin-unicorn": "^55.0.0",
     "execa": "^5.0.0",
     "find-process": "^1.4.1",
+    "glob": "^10.3.10",
     "graceful-fs": "^4.2.9",
     "isbinaryfile": "^5.0.0",
     "istanbul-lib-coverage": "^3.0.0",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -43,7 +43,6 @@
     "chalk": "^4.0.0",
     "ci-info": "^4.0.0",
     "deepmerge": "^4.2.2",
-    "glob": "^10.3.10",
     "graceful-fs": "^4.2.9",
     "jest-circus": "workspace:*",
     "jest-docblock": "workspace:*",
@@ -58,7 +57,8 @@
     "parse-json": "^5.2.0",
     "pretty-format": "workspace:*",
     "slash": "^3.0.0",
-    "strip-json-comments": "^3.1.1"
+    "strip-json-comments": "^3.1.1",
+    "tinyglobby": "^0.2.5"
   },
   "devDependencies": {
     "@types/graceful-fs": "^4.1.3",

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -10,9 +10,9 @@ import {totalmem} from 'os';
 import * as path from 'path';
 import chalk = require('chalk');
 import merge = require('deepmerge');
-import {glob} from 'glob';
 import {statSync} from 'graceful-fs';
 import micromatch = require('micromatch');
+import {globSync} from 'tinyglobby';
 import {TestPathPatterns} from '@jest/pattern';
 import type {Config} from '@jest/types';
 import {replacePathSepForRegex} from 'jest-regex-util';
@@ -752,7 +752,7 @@ export default async function normalize(
               // for the future resolution.
               const globMatches =
                 typeof project === 'string'
-                  ? glob.sync(project, {windowsPathsNoEscape: true})
+                  ? globSync([project.replaceAll('\\', '/')])
                   : [];
               const projectEntry =
                 globMatches.length > 0 ? globMatches : project;

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -752,7 +752,9 @@ export default async function normalize(
               // for the future resolution.
               const globMatches =
                 typeof project === 'string'
-                  ? globSync([project.replaceAll('\\', '/')])
+                  ? globSync([project.replaceAll('\\', '/')], {
+                      expandDirectories: false,
+                    })
                   : [];
               const projectEntry =
                 globMatches.length > 0 ? globMatches : project;

--- a/packages/jest-config/tsconfig.json
+++ b/packages/jest-config/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "build"
+    "outDir": "build",
+    "lib": ["es2021"]
   },
   "include": ["./src/**/*"],
   "exclude": ["./**/__mocks__/**/*", "./**/__tests__/**/*"],

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -24,7 +24,6 @@
     "chalk": "^4.0.0",
     "collect-v8-coverage": "^1.0.0",
     "exit": "^0.1.2",
-    "glob": "^10.3.10",
     "graceful-fs": "^4.2.9",
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-instrument": "^6.0.0",
@@ -37,6 +36,7 @@
     "slash": "^3.0.0",
     "string-length": "^4.0.1",
     "strip-ansi": "^6.0.0",
+    "tinyglobby": "^0.2.5",
     "v8-to-istanbul": "^9.0.1"
   },
   "devDependencies": {

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -297,9 +297,10 @@ export default class CoverageReporter extends BaseReporter {
           // (rather than recalculating it for each covered file) we save a tonne
           // of execution time.
           if (filesByGlob[absoluteThresholdGroup] === undefined) {
-            filesByGlob[absoluteThresholdGroup] = globSync([
-              absoluteThresholdGroup.replaceAll('\\', '/'),
-            ]).map(filePath => path.resolve(filePath));
+            filesByGlob[absoluteThresholdGroup] = globSync(
+              [absoluteThresholdGroup.replaceAll('\\', '/')],
+              {expandDirectories: false},
+            ).map(filePath => path.resolve(filePath));
           }
 
           if (filesByGlob[absoluteThresholdGroup].includes(file)) {

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -9,12 +9,12 @@ import * as path from 'path';
 import {mergeProcessCovs} from '@bcoe/v8-coverage';
 import type {EncodedSourceMap} from '@jridgewell/trace-mapping';
 import chalk = require('chalk');
-import {glob} from 'glob';
 import * as fs from 'graceful-fs';
 import istanbulCoverage = require('istanbul-lib-coverage');
 import istanbulReport = require('istanbul-lib-report');
 import libSourceMaps = require('istanbul-lib-source-maps');
 import istanbulReports = require('istanbul-reports');
+import {globSync} from 'tinyglobby';
 import v8toIstanbul = require('v8-to-istanbul');
 import type {
   AggregatedResult,
@@ -297,9 +297,9 @@ export default class CoverageReporter extends BaseReporter {
           // (rather than recalculating it for each covered file) we save a tonne
           // of execution time.
           if (filesByGlob[absoluteThresholdGroup] === undefined) {
-            filesByGlob[absoluteThresholdGroup] = glob
-              .sync(absoluteThresholdGroup, {windowsPathsNoEscape: true})
-              .map(filePath => path.resolve(filePath));
+            filesByGlob[absoluteThresholdGroup] = globSync([
+              absoluteThresholdGroup.replaceAll('\\', '/'),
+            ]).map(filePath => path.resolve(filePath));
           }
 
           if (filesByGlob[absoluteThresholdGroup].includes(file)) {

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -30,7 +30,6 @@
     "chalk": "^4.0.0",
     "cjs-module-lexer": "^1.0.0",
     "collect-v8-coverage": "^1.0.0",
-    "glob": "^10.3.10",
     "graceful-fs": "^4.2.9",
     "jest-haste-map": "workspace:*",
     "jest-message-util": "workspace:*",
@@ -40,7 +39,8 @@
     "jest-snapshot": "workspace:*",
     "jest-util": "workspace:*",
     "slash": "^3.0.0",
-    "strip-bom": "^4.0.0"
+    "strip-bom": "^4.0.0",
+    "tinyglobby": "^0.2.5"
   },
   "devDependencies": {
     "@jest/test-utils": "workspace:*",

--- a/packages/jest-runtime/src/helpers.ts
+++ b/packages/jest-runtime/src/helpers.ts
@@ -6,8 +6,8 @@
  */
 
 import * as path from 'path';
-import {glob} from 'glob';
 import slash = require('slash');
+import {globSync} from 'tinyglobby';
 import type {Config} from '@jest/types';
 
 const OUTSIDE_JEST_VM_PROTOCOL = 'jest-main:';
@@ -41,8 +41,7 @@ export const findSiblingsWithFileExtension = (
     try {
       const slashedDirname = slash(dirname);
 
-      const matches = glob
-        .sync(`${pathToModule}.*`, {windowsPathsNoEscape: true})
+      const matches = globSync([`${pathToModule}.*`.replaceAll('\\', '/')])
         .map(match => slash(match))
         .map(match => {
           const relativePath = path.posix.relative(slashedDirname, match);

--- a/packages/jest-runtime/src/helpers.ts
+++ b/packages/jest-runtime/src/helpers.ts
@@ -41,7 +41,9 @@ export const findSiblingsWithFileExtension = (
     try {
       const slashedDirname = slash(dirname);
 
-      const matches = globSync([`${pathToModule}.*`.replaceAll('\\', '/')])
+      const matches = globSync([`${pathToModule}.*`.replaceAll('\\', '/')], {
+        expandDirectories: false,
+      })
         .map(match => slash(match))
         .map(match => {
           const relativePath = path.posix.relative(slashedDirname, match);

--- a/packages/jest-runtime/tsconfig.json
+++ b/packages/jest-runtime/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     // needed for WebAssembly, see https://github.com/microsoft/TypeScript-DOM-lib-generator/issues/826
-    "lib": ["dom"],
+    "lib": ["dom", "es2021"],
     "rootDir": "src",
     "outDir": "build"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,6 +3295,7 @@ __metadata:
     eslint-plugin-unicorn: ^55.0.0
     execa: ^5.0.0
     find-process: ^1.4.1
+    glob: ^10.3.10
     graceful-fs: ^4.2.9
     isbinaryfile: ^5.0.0
     istanbul-lib-coverage: ^3.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -13612,7 +13612,6 @@ __metadata:
     chalk: ^4.0.0
     cjs-module-lexer: ^1.0.0
     collect-v8-coverage: ^1.0.0
-    glob: ^10.3.10
     graceful-fs: ^4.2.9
     jest-environment-node: "workspace:*"
     jest-haste-map: "workspace:*"
@@ -13624,6 +13623,7 @@ __metadata:
     jest-util: "workspace:*"
     slash: ^3.0.0
     strip-bom: ^4.0.0
+    tinyglobby: ^0.2.5
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3295,7 +3295,6 @@ __metadata:
     eslint-plugin-unicorn: ^55.0.0
     execa: ^5.0.0
     find-process: ^1.4.1
-    glob: ^10.3.10
     graceful-fs: ^4.2.9
     isbinaryfile: ^5.0.0
     istanbul-lib-coverage: ^3.0.0

--- a/yarn.lock
+++ b/yarn.lock
@@ -10742,6 +10742,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fdir@npm:^6.2.0":
+  version: 6.3.0
+  resolution: "fdir@npm:6.3.0"
+  peerDependencies:
+    picomatch: ^3 || ^4
+  peerDependenciesMeta:
+    picomatch:
+      optional: true
+  checksum: c0fe6ddd4aa0a315a55401d468974b582b1880908c8f7b1b1c40db4cd2feb2c04402d2fbdbd6ad049f6261e0d7cd6e629cc5ae678f8883f245ebc1f94b6ff9e6
+  languageName: node
+  linkType: hard
+
 "feed@npm:^4.2.2":
   version: 4.2.2
   resolution: "feed@npm:4.2.2"
@@ -13215,7 +13227,6 @@ __metadata:
     deepmerge: ^4.2.2
     esbuild: ^0.23.0
     esbuild-register: ^3.4.0
-    glob: ^10.3.10
     graceful-fs: ^4.2.9
     jest-circus: "workspace:*"
     jest-docblock: "workspace:*"
@@ -13232,6 +13243,7 @@ __metadata:
     semver: ^7.5.3
     slash: ^3.0.0
     strip-json-comments: ^3.1.1
+    tinyglobby: ^0.2.5
     ts-node: ^10.5.0
     typescript: ^5.0.4
   peerDependencies:
@@ -17154,7 +17166,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.0":
+"picomatch@npm:^4.0.0, picomatch@npm:^4.0.2":
   version: 4.0.2
   resolution: "picomatch@npm:4.0.2"
   checksum: a7a5188c954f82c6585720e9143297ccd0e35ad8072231608086ca950bee672d51b0ef676254af0788205e59bd4e4deb4e7708769226bed725bf13370a7d1464
@@ -20421,6 +20433,16 @@ __metadata:
   version: 1.0.3
   resolution: "tiny-warning@npm:1.0.3"
   checksum: da62c4acac565902f0624b123eed6dd3509bc9a8d30c06e017104bedcf5d35810da8ff72864400ad19c5c7806fc0a8323c68baf3e326af7cb7d969f846100d71
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.5":
+  version: 0.2.5
+  resolution: "tinyglobby@npm:0.2.5"
+  dependencies:
+    fdir: ^6.2.0
+    picomatch: ^4.0.2
+  checksum: 04d01bb603c10a94d44045236bab6a5402c59ead6a02a7317f119647d31c250394189cee152fddbf13e80496697987b29d90d75786b12f76358a936cff307d35
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3370,7 +3370,6 @@ __metadata:
     chalk: ^4.0.0
     collect-v8-coverage: ^1.0.0
     exit: ^0.1.2
-    glob: ^10.3.10
     graceful-fs: ^4.2.9
     istanbul-lib-coverage: ^3.0.0
     istanbul-lib-instrument: ^6.0.0
@@ -3386,6 +3385,7 @@ __metadata:
     slash: ^3.0.0
     string-length: ^4.0.1
     strip-ansi: ^6.0.0
+    tinyglobby: ^0.2.5
     v8-to-istanbul: ^9.0.1
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I made this change as a part of the [e18e](https://e18e.dev/) initiative. [`tinyglobby`](https://www.npmjs.com/package/tinyglobby) is a minimalist alternative to various other packages handling `glob` patterns. `.replaceAll('\\', '/')` is exactly what's done by `glob` when the `windowsPathsNoEscape: true` option is passed: https://github.com/isaacs/node-glob/blob/feaf0a85c1d1bcc7c992f45edf51aaab8ed729ac/src/glob.ts#L470-L472.

Initially I also wanted to replace `slash` usages in these three packages, but I decided it'd be better to leave that for another PR as to separate concerns.

## Test plan

Ensure the test suites are passing for the changed files.
