### PR TITLE
Add type-only import test case for dependencyExtractor

### DIFF
--- a/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
@@ -87,7 +87,7 @@ describe('dependencyExtractor', () => {
     );
   });
 
-  it('should not extract dependencies from `import type/typeof` statements', () => {
+  it('should not extract dependencies from `import type/typeof` statements, or type-only imports', () => {
     const code = `
       // Bad
       import typeof {foo} from 'inv1';
@@ -108,8 +108,9 @@ describe('dependencyExtractor', () => {
         type foo,
         bar
       } from 'inv8';
+      import TheDefaultExport, {type foo, type bar} from 'inv9';
     `;
-    expect(extractor.extract(code)).toEqual(new Set(['inv5', 'inv6', 'inv7', 'inv8']));
+    expect(extractor.extract(code)).toEqual(new Set(['inv5', 'inv6', 'inv7', 'inv8', 'inv9']));
   });
 
   it('should extract dependencies from `export` statements', () => {

--- a/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
@@ -92,8 +92,12 @@ describe('dependencyExtractor', () => {
       // Bad
       import typeof {foo} from 'inv1';
       import type {foo} from 'inv2';
+      import {type foo, typeof bar} from 'inv3';
+      // Good
+      import {foo, typeof bar} from 'inv4';
+      import {type foo, bar} from 'inv5';
     `;
-    expect(extractor.extract(code)).toEqual(new Set([]));
+    expect(extractor.extract(code)).toEqual(new Set(['inv4', 'inv5']));
   });
 
   it('should extract dependencies from `export` statements', () => {

--- a/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
@@ -93,9 +93,21 @@ describe('dependencyExtractor', () => {
       import typeof {foo} from 'inv1';
       import type {foo} from 'inv2';
       import {type foo, typeof bar} from 'inv3';
+      import {
+        type foo,
+        typeof bar,
+      } from 'inv4'
       // Good
-      import {foo, typeof bar} from 'inv4';
-      import {type foo, bar} from 'inv5';
+      import {foo, typeof bar} from 'inv5';
+      import {type foo, bar} from 'inv6';
+      import {
+        foo,
+        typeof bar
+      } from 'inv7';
+      import {
+        type foo,
+        bar
+      } from 'inv8';
     `;
     expect(extractor.extract(code)).toEqual(new Set(['inv4', 'inv5']));
   });

--- a/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
@@ -111,7 +111,7 @@ describe('dependencyExtractor', () => {
       import TheDefaultExport, {type foo, type bar} from 'inv9';
     `;
     expect(extractor.extract(code)).toEqual(
-      new Set(['inv5', 'inv6', 'inv7', 'inv8', 'inv9'])
+      new Set(['inv5', 'inv6', 'inv7', 'inv8', 'inv9']),
     );
   });
 

--- a/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
@@ -109,7 +109,7 @@ describe('dependencyExtractor', () => {
         bar
       } from 'inv8';
     `;
-    expect(extractor.extract(code)).toEqual(new Set(['inv4', 'inv5']));
+    expect(extractor.extract(code)).toEqual(new Set(['inv5', 'inv6', 'inv7', 'inv8']));
   });
 
   it('should extract dependencies from `export` statements', () => {

--- a/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
+++ b/packages/jest-haste-map/src/lib/__tests__/dependencyExtractor.test.js
@@ -110,7 +110,9 @@ describe('dependencyExtractor', () => {
       } from 'inv8';
       import TheDefaultExport, {type foo, type bar} from 'inv9';
     `;
-    expect(extractor.extract(code)).toEqual(new Set(['inv5', 'inv6', 'inv7', 'inv8', 'inv9']));
+    expect(extractor.extract(code)).toEqual(
+      new Set(['inv5', 'inv6', 'inv7', 'inv8', 'inv9'])
+    );
   });
 
   it('should extract dependencies from `export` statements', () => {


### PR DESCRIPTION
See https://github.com/jestjs/jest/issues/15308

This PR only adds a test case for an open bug report issue, so it can be referenced as a reproduction step.

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I know the problem, but I don't know regex well enough to solve this problem. I could handle this with an if-statement in addDependency to exclude these deps, but I think regex is the proper solution given the rest of the code.

## Test plan

Run this test to reproduce the bug.
