### PR TITLE
fix: add comma to improve error message

### DIFF
--- a/packages/jest-transform/src/enhanceUnexpectedTokenMessage.ts
+++ b/packages/jest-transform/src/enhanceUnexpectedTokenMessage.ts
@@ -50,7 +50,7 @@ ${DOT}If you are trying to use TypeScript, see ${chalk.underline(
 ${DOT}To have some of your "node_modules" files transformed, you can specify a custom ${chalk.bold(
     '"transformIgnorePatterns"',
   )} in your config.
-${DOT}If you need a custom transformation specify a ${chalk.bold(
+${DOT}If you need a custom transformation, specify a ${chalk.bold(
     '"transform"',
   )} option in your config.
 ${DOT}If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the ${chalk.bold(


### PR DESCRIPTION
## Summary

Without a comma, it's somehow hard to understand/distinguish the issue and a possible solution.

## Test plan

_not required_
