### PR TITLE
Stringify Errors properly with --json flag

### DIFF
--- a/packages/jest-core/src/lib/__tests__/serializeToJSON.test.ts
+++ b/packages/jest-core/src/lib/__tests__/serializeToJSON.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import serializeToJSON from '../serializeToJSON';
+
+// populate an object with all basic JavaScript datatypes
+const object = {
+  species: 'capybara',
+  ok: true,
+  i: ['pull up'],
+  hopOut: {
+    atThe: 'after party',
+    when: new Date('2000-07-14'),
+  },
+  chillness: 100,
+  weight: 9.5,
+  flaws: null,
+  location: undefined,
+};
+
+it('serializes regular objects like JSON.stringify', () => {
+  expect(serializeToJSON(object)).toEqual(JSON.stringify(object));
+});
+
+it('serializes errors', () => {
+  const objectWithError = {
+    ...object,
+    error: new Error('too cool'),
+  };
+  const withError = serializeToJSON(objectWithError);
+  const withoutError = JSON.stringify(objectWithError);
+
+  expect(withoutError).not.toEqual(withError);
+
+  expect(withError).toContain(`"message":"too cool"`);
+  expect(withError).toContain(`"name":"Error"`);
+  expect(withError).toContain(`"stack":"Error:`);
+
+  expect(JSON.parse(withError)).toMatchObject({
+    error: {
+      message: 'too cool',
+      name: 'Error',
+    },
+  });
+});

--- a/packages/jest-core/src/lib/serializeToJSON.ts
+++ b/packages/jest-core/src/lib/serializeToJSON.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * When we're asked to give a JSON output with the --json flag or otherwise,
+ * some data we need to return don't serialize well with a basic
+ * `JSON.stringify`, particularly Errors returned in `.openHandles`.
+ *
+ * This function handles the extended serialization wanted above.
+ */
+export default function serializeToJSON(
+  value: any,
+  space?: string | number,
+): string {
+  return JSON.stringify(
+    value,
+    (_, value) => {
+      // There might be more in Error, but pulling out just the message, name,
+      // and stack should be good enough
+      if (value instanceof Error) {
+        return {
+          message: value.message,
+          name: value.name,
+          stack: value.stack,
+        };
+      }
+      return value;
+    },
+    space,
+  );
+}

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -35,6 +35,7 @@ import collectNodeHandles, {
 import getNoTestsFoundMessage from './getNoTestsFoundMessage';
 import runGlobalHook from './runGlobalHook';
 import type {Filter, TestRunData} from './types';
+import serializeToJSON from './lib/serializeToJSON';
 
 const getTestPaths = async (
   globalConfig: Config.GlobalConfig,
@@ -111,20 +112,21 @@ const processResults = async (
     runResults = await processor(runResults);
   }
   if (isJSON) {
+    const jsonString = serializeToJSON(formatTestResults(runResults));
     if (outputFile) {
       const cwd = tryRealpath(process.cwd());
       const filePath = path.resolve(cwd, outputFile);
 
       fs.writeFileSync(
         filePath,
-        `${JSON.stringify(formatTestResults(runResults))}\n`,
+        `${jsonString}\n`,
       );
       outputStream.write(
         `Test results written to: ${path.relative(cwd, filePath)}\n`,
       );
     } else {
       process.stdout.write(
-        `${JSON.stringify(formatTestResults(runResults))}\n`,
+        `${jsonString}\n`,
       );
     }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When running `jest` with the `--json` flag, the `Error`s from `collectHandles` in `jest-core/src/runJest.ts` is all passed into a `JSON.stringify`, which turns them into an empty object. 

Users might expect or want the error message, name, and stack from the `--json` output possibly to collect data in the more structured JSON format — as opposed to plain stderr output — to help diagnose the source of the leaky handles.

## Changes

Originally, I just iterated over the `runResults.openHandles` in `runJest.ts:processResults` to grab the error message, name, and stack from the `Error`, but adding a test for that was kind of awkward.

So I decided on adding a very basic `serializeToJSON` function that should replace `JSON.stringify` to handle stringifying `Error`s as well as leaving room to stringify other objects in the future if needed.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

- Added tests for `serializeToJSON`
  - Check that it's the same as `JSON.stringify` for regular objects
  - Check that it extends `JSON.stringify` by stringifying `Error`s properly

For a more e2e test, I added a temporary test to leak a handle, built the project, and ran the test:
![image](https://github.com/user-attachments/assets/b89f704a-c3ba-4cbe-b064-6f2377dfaa40)
