### PR TITLE
Add ability to define export conditions per modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[jest-runtime][jest-environment][jest-environment-jsdom-abstract][jest-environment-node]` Allow more granular custom export conditions in test environment options; conditions can be defined both globally and for a set of modules (TBA)
+- `[jest-runtime][jest-environment][jest-environment-jsdom-abstract][jest-environment-node]` Allow more granular custom export conditions in test environment options; conditions can be defined both globally and for a set of modules ([#15340](https://github.com/jestjs/jest/pull/15340))
 - `[babel-jest]` Add option `excludeJestPreset` to allow opting out of `babel-preset-jest` ([#15164](https://github.com/jestjs/jest/pull/15164))
 - `[jest-circus, jest-cli, jest-config]` Add `waitNextEventLoopTurnForUnhandledRejectionEvents` flag to minimise performance impact of correct detection of unhandled promise rejections introduced in [#14315](https://github.com/jestjs/jest/pull/14315) ([#14681](https://github.com/jestjs/jest/pull/14681))
 - `[jest-circus]` Add a `waitBeforeRetry` option to `jest.retryTimes` ([#14738](https://github.com/jestjs/jest/pull/14738))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Features
 
+- `[jest-runtime][jest-environment][jest-environment-jsdom-abstract][jest-environment-node]` Allow more granular custom export conditions in test environment options; conditions can be defined both globally and for a set of modules (TBA)
 - `[babel-jest]` Add option `excludeJestPreset` to allow opting out of `babel-preset-jest` ([#15164](https://github.com/jestjs/jest/pull/15164))
 - `[jest-circus, jest-cli, jest-config]` Add `waitNextEventLoopTurnForUnhandledRejectionEvents` flag to minimise performance impact of correct detection of unhandled promise rejections introduced in [#14315](https://github.com/jestjs/jest/pull/14315) ([#14681](https://github.com/jestjs/jest/pull/14681))
 - `[jest-circus]` Add a `waitBeforeRetry` option to `jest.retryTimes` ([#14738](https://github.com/jestjs/jest/pull/14738))

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -2030,10 +2030,12 @@ In case you need get specific `exports` for a library or set of libraries, you c
 const config = {
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {
-    customExportConditions: [{
-      modules: ['msw', 'msw/node', '@mswjs/interceptors/*'],
-      conditions: [], // use only basic conditions depending on if it's in CJS/ESM context
-    }],
+    customExportConditions: [
+      {
+        modules: ['msw', 'msw/node', '@mswjs/interceptors/*'],
+        conditions: [], // use only basic conditions depending on if it's in CJS/ESM context
+      },
+    ],
   },
 };
 
@@ -2046,10 +2048,12 @@ import type {Config} from 'jest';
 const config: Config = {
   testEnvironment: 'jsdom',
   testEnvironmentOptions: {
-    customExportConditions: [{
-      modules: ['msw', 'msw/node', '@mswjs/interceptors/*'],
-      conditions: [], // use only basic conditions depending on if it's in CJS/ESM context
-    }],
+    customExportConditions: [
+      {
+        modules: ['msw', 'msw/node', '@mswjs/interceptors/*'],
+        conditions: [], // use only basic conditions depending on if it's in CJS/ESM context
+      },
+    ],
   },
 };
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -2023,6 +2023,39 @@ const config: Config = {
 export default config;
 ```
 
+In case you need get specific `exports` for a library or set of libraries, you can define it this way:
+
+```js tab
+/** @type {import('jest').Config} */
+const config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: [{
+      modules: ['msw', 'msw/node', '@mswjs/interceptors/*'],
+      conditions: [], // use only basic conditions depending on if it's in CJS/ESM context
+    }],
+  },
+};
+
+module.exports = config;
+```
+
+```ts tab
+import type {Config} from 'jest';
+
+const config: Config = {
+  testEnvironment: 'jsdom',
+  testEnvironmentOptions: {
+    customExportConditions: [{
+      modules: ['msw', 'msw/node', '@mswjs/interceptors/*'],
+      conditions: [], // use only basic conditions depending on if it's in CJS/ESM context
+    }],
+  },
+};
+
+export default config;
+```
+
 These options can also be passed in a docblock, similar to `testEnvironment`. The string with options must be parseable by `JSON.parse`:
 
 ```js

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -37,6 +37,37 @@ export interface JestEnvironmentConfig {
   globalConfig: Config.GlobalConfig;
 }
 
+export type JestExportConditionsPerModules = {
+  modules: Array<string>;
+  conditions: Array<string>;
+};
+
+export function isSimpleExportConditionsItem(
+  item: string | JestExportConditionsPerModules,
+): item is string {
+  return typeof item === 'string';
+}
+
+export function isExportConditionsItemPerModules(
+  item: string | JestExportConditionsPerModules,
+): item is JestExportConditionsPerModules {
+  return typeof item !== 'string';
+}
+
+export function isExportConditions(
+  item: unknown,
+): item is string | JestExportConditionsPerModules {
+  return (
+    typeof item === 'string' ||
+    (typeof item === 'object' &&
+      item !== null &&
+      'modules' in item &&
+      'conditions' in item &&
+      Array.isArray((item as JestExportConditionsPerModules).modules) &&
+      Array.isArray((item as JestExportConditionsPerModules).conditions))
+  );
+}
+
 export declare class JestEnvironment<Timer = unknown> {
   constructor(config: JestEnvironmentConfig, context: EnvironmentContext);
   global: Global.Global;
@@ -47,7 +78,7 @@ export declare class JestEnvironment<Timer = unknown> {
   setup(): Promise<void>;
   teardown(): Promise<void>;
   handleTestEvent?: Circus.EventHandler;
-  exportConditions?: () => Array<string>;
+  exportConditions?: () => Array<string | JestExportConditionsPerModules>;
 }
 
 export type Module = NodeModule;


### PR DESCRIPTION
## Summary

When migrating to MSW v2, we bumped into the problem described here: https://mswjs.io/docs/migrations/1.x-to-2.x/#cannot-find-module-mswnode-jsdom

Unfortunately the solution didn't work for us fully because we also have some other dependencies and the suggested solution was breaking another things.

For now we patched `jest-runtime` locally in our project to remove `browser` condition from `customExportConditions` only when resolving `msw` and `@mswjs/interceptors` modules and it works.

This PR is an attempt to make the logic configurable and more general.

It's my first contribution to Jest but I tried to update all relevant parts. The only thing I struggled with was testing. As far as I can see, `customExportConditions` are not tested right now and I wasn't sure how to prepare test env for it. If you want, I can look into it too but I'd welcome some guidance.

I hope this change make sense and could be accepted. I'm open to any feedback and adjustments.

Once it's in place, MSW could update their docs and hopefully it could help the community with adopting their new version in Jest.

## Test plan

I created small demo repo: https://github.com/jiri-prokop-pb/jest-custom-export-conditions-demo-repo

You can test the logic by cloning it and running:
```
pnpm install
pnpm --filter main test
```

Tests should pass while respecting exports of `different-exports` sub-package and `msw`-related packages.