### PR TITLE
docs(CLI): add details for disabling --silent

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -447,9 +447,9 @@ Prints the seed value in the test report summary. See [`--seed=<num>`](#--seednu
 
 Can also be set in configuration. See [`showSeed`](Configuration.md#showseed-boolean).
 
-### `--silent`
+### `--silent[=<boolean>]`
 
-Prevent tests from printing messages through the console.
+Prevent tests from printing messages through the console. Defaults to true. Disable using `--no-silent` or `--silent=false`.
 
 ### `--testEnvironmentOptions=<json string>`
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This change clarifies in the documentation that the `--silent` flag can be overridden with `--no-silent` or `--silent=false`. It can be useful in situations when silent is enabled in a package.json script and the user want to explicitly disable it like this:

```sh
npm run test -- --no-silent
```

## Test plan

I built the website locally and verified that the changes were displayed correctly. See screenshot below:
![Screenshot 2024-10-10 at 18 43 52](https://github.com/user-attachments/assets/42700da1-9758-4383-bcbb-3af97f7409a0)
