### PR TITLE
Add One Double Zero as coverage provider

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -170,7 +170,7 @@ The directory where Jest should output its coverage files.
 
 ### `--coverageProvider=<provider>`
 
-Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default) or `v8`.
+Indicates which provider should be used to instrument code for coverage. Allowed values are `babel` (default), `v8` or `odz`.
 
 ### `--debug`
 

--- a/e2e/__tests__/__snapshots__/coverageProviderODZ.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/coverageProviderODZ.test.ts.snap
@@ -1,0 +1,116 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`prints correct coverage report, if a CJS module is put under test without transformation 1`] = `
+"  console.log
+    this will print
+
+      at covered (module.js:11:11)
+
+--------------|---------|----------|---------|---------|-------------------
+File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+--------------|---------|----------|---------|---------|-------------------
+All files     |      60 |       50 |      50 |      60 |                   
+ module.js    |   66.66 |       50 |      50 |   66.66 | 14-15,19          
+ uncovered.js |       0 |      100 |     100 |       0 | 8                 
+--------------|---------|----------|---------|---------|-------------------"
+`;
+
+exports[`prints correct coverage report, if a TS module is transpiled by Babel to CJS and put under test 1`] = `
+"  console.log
+    this will print
+
+      at log (module.ts:13:11)
+
+--------------|---------|----------|---------|---------|-------------------
+File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+--------------|---------|----------|---------|---------|-------------------
+All files     |    62.5 |       50 |      50 |    62.5 |                   
+ module.ts    |    62.5 |       50 |      50 |    62.5 | 16-17,21          
+ types.ts     |       0 |        0 |       0 |       0 |                   
+ uncovered.ts |       0 |        0 |       0 |       0 |                   
+--------------|---------|----------|---------|---------|-------------------"
+`;
+
+exports[`prints correct coverage report, if a TS module is transpiled by custom transformer to ESM put under test 1`] = `
+"  console.log
+    this will print
+
+      at covered (module.ts:13:11)
+
+--------------|---------|----------|---------|---------|-------------------
+File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+--------------|---------|----------|---------|---------|-------------------
+All files     |    62.5 |       50 |      50 |    62.5 |                   
+ module.ts    |    62.5 |       50 |      50 |    62.5 | 16-17,21          
+ types.ts     |       0 |        0 |       0 |       0 |                   
+ uncovered.ts |       0 |        0 |       0 |       0 |                   
+--------------|---------|----------|---------|---------|-------------------"
+`;
+
+exports[`prints correct coverage report, if an ESM module is put under test without transformation 1`] = `
+"  console.log
+    this will print
+
+      at covered (module.js:11:11)
+
+--------------|---------|----------|---------|---------|-------------------
+File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+--------------|---------|----------|---------|---------|-------------------
+All files     |    62.5 |       50 |      50 |    62.5 |                   
+ module.js    |    62.5 |       50 |      50 |    62.5 | 14-15,19          
+ uncovered.js |       0 |        0 |       0 |       0 |                   
+--------------|---------|----------|---------|---------|-------------------"
+`;
+
+exports[`prints coverage with empty sourcemaps 1`] = `
+"----------|---------|----------|---------|---------|-------------------
+File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+----------|---------|----------|---------|---------|-------------------
+All files |       0 |        0 |       0 |       0 |                   
+ types.ts |       0 |        0 |       0 |       0 |                   
+----------|---------|----------|---------|---------|-------------------"
+`;
+
+exports[`prints coverage with missing sourcemaps 1`] = `
+"  console.log
+    42
+
+      at Object.log (__tests__/Thing.test.js:10:9)
+
+----------|---------|----------|---------|---------|-------------------
+File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+----------|---------|----------|---------|---------|-------------------
+All files |     100 |      100 |     100 |     100 |                   
+ Thing.js |     100 |      100 |     100 |     100 |                   
+ x.css    |       0 |        0 |       0 |       0 |                   
+----------|---------|----------|---------|---------|-------------------"
+`;
+
+exports[`reports coverage with \`resetModules\` 1`] = `
+"  console.log
+    this will print
+
+      at log (module.js:11:11)
+
+  console.log
+    this will print
+
+      at log (module.js:11:11)
+
+--------------|---------|----------|---------|---------|-------------------
+File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+--------------|---------|----------|---------|---------|-------------------
+All files     |      60 |       50 |      50 |      60 |                   
+ module.js    |   66.66 |       50 |      50 |   66.66 | 14-15,19          
+ uncovered.js |       0 |      100 |     100 |       0 | 8                 
+--------------|---------|----------|---------|---------|-------------------"
+`;
+
+exports[`vm script coverage generator 1`] = `
+"-------------|---------|----------|---------|---------|-------------------
+File         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+-------------|---------|----------|---------|---------|-------------------
+All files    |      80 |       75 |   66.66 |      80 |                   
+ vmscript.js |      80 |       75 |   66.66 |      80 | 20-21             
+-------------|---------|----------|---------|---------|-------------------"
+`;

--- a/e2e/__tests__/coverageProviderODZ.test.ts
+++ b/e2e/__tests__/coverageProviderODZ.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as path from 'path';
+import runJest from '../runJest';
+
+const DIR = path.resolve(__dirname, '../coverage-provider-v8');
+
+test('prints coverage with missing sourcemaps', () => {
+  const sourcemapDir = path.join(DIR, 'no-sourcemap');
+
+  const {stdout, exitCode} = runJest(
+    sourcemapDir,
+    ['--coverage', '--coverage-provider', 'odz'],
+    {stripAnsi: true},
+  );
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toMatchSnapshot();
+});
+
+test('prints coverage with empty sourcemaps', () => {
+  const sourcemapDir = path.join(DIR, 'empty-sourcemap');
+
+  const {stdout, exitCode} = runJest(
+    sourcemapDir,
+    ['--coverage', '--coverage-provider', 'odz'],
+    {stripAnsi: true},
+  );
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toMatchSnapshot();
+});
+
+test('reports coverage with `resetModules`', () => {
+  const sourcemapDir = path.join(DIR, 'with-resetModules');
+
+  const {stdout, exitCode} = runJest(
+    sourcemapDir,
+    ['--coverage', '--coverage-provider', 'odz'],
+    {stripAnsi: true},
+  );
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toMatchSnapshot();
+});
+
+test('prints correct coverage report, if a CJS module is put under test without transformation', () => {
+  const sourcemapDir = path.join(DIR, 'cjs-native-without-sourcemap');
+
+  const {stdout, exitCode} = runJest(
+    sourcemapDir,
+    ['--coverage', '--coverage-provider', 'odz', '--no-cache'],
+    {stripAnsi: true},
+  );
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toMatchSnapshot();
+});
+
+test('prints correct coverage report, if a TS module is transpiled by Babel to CJS and put under test', () => {
+  const sourcemapDir = path.join(DIR, 'cjs-with-babel-transformer');
+
+  const {stdout, exitCode} = runJest(
+    sourcemapDir,
+    ['--coverage', '--coverage-provider', 'odz', '--no-cache'],
+    {stripAnsi: true},
+  );
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toMatchSnapshot();
+});
+
+test('prints correct coverage report, if an ESM module is put under test without transformation', () => {
+  const sourcemapDir = path.join(DIR, 'esm-native-without-sourcemap');
+
+  const {stdout, exitCode} = runJest(
+    sourcemapDir,
+    ['--coverage', '--coverage-provider', 'odz', '--no-cache'],
+    {
+      nodeOptions: '--experimental-vm-modules --no-warnings',
+      stripAnsi: true,
+    },
+  );
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toMatchSnapshot();
+});
+
+test('prints correct coverage report, if a TS module is transpiled by custom transformer to ESM put under test', () => {
+  const sourcemapDir = path.join(DIR, 'esm-with-custom-transformer');
+
+  const {stdout, exitCode} = runJest(
+    sourcemapDir,
+    ['--coverage', '--coverage-provider', 'odz', '--no-cache'],
+    {
+      nodeOptions: '--experimental-vm-modules --no-warnings',
+      stripAnsi: true,
+    },
+  );
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toMatchSnapshot();
+});
+
+test('vm script coverage generator', () => {
+  const dir = path.resolve(__dirname, '../vmscript-coverage');
+  const {stdout, exitCode} = runJest(
+    dir,
+    ['--coverage', '--coverage-provider', 'odz'],
+    {stripAnsi: true},
+  );
+
+  expect(exitCode).toBe(0);
+  expect(stdout).toMatchSnapshot();
+});

--- a/e2e/coverage-provider-v8/empty-sourcemap/package.json
+++ b/e2e/coverage-provider-v8/empty-sourcemap/package.json
@@ -2,6 +2,9 @@
   "name": "empty-sourcemap",
   "version": "1.0.0",
   "jest": {
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "collectCoverageFrom": [
+      "<rootDir>/types.ts"
+    ]
   }
 }

--- a/e2e/coverage-provider-v8/no-sourcemap/package.json
+++ b/e2e/coverage-provider-v8/no-sourcemap/package.json
@@ -6,6 +6,14 @@
     "transform": {
       "\\.[jt]sx?$": "babel-jest",
       "\\.css$": "<rootDir>/cssTransform.js"
-    }
+    },
+    "moduleFileExtensions": [
+      "js",
+      "css"
+    ],
+    "collectCoverageFrom": [
+      "<rootDir>/Thing.js",
+      "<rootDir>/x.css"
+    ]
   }
 }

--- a/packages/jest-cli/src/args.ts
+++ b/packages/jest-cli/src/args.ts
@@ -213,8 +213,9 @@ export const options: {[key: string]: Options} = {
     type: 'array',
   },
   coverageProvider: {
-    choices: ['babel', 'v8'],
-    description: 'Select between Babel and V8 to collect coverage',
+    choices: ['babel', 'v8', 'odz'],
+    description:
+      'Select between Babel, V8 and One Double Zero to collect coverage',
     requiresArg: true,
   },
   coverageReporters: {

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -34,7 +34,7 @@
     "jest-message-util": "workspace:*",
     "jest-util": "workspace:*",
     "jest-worker": "workspace:*",
-    "one-double-zero": "1.0.0-beta.14",
+    "one-double-zero-core": "^1.0.0",
     "slash": "^3.0.0",
     "string-length": "^4.0.1",
     "strip-ansi": "^6.0.0",

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -34,6 +34,7 @@
     "jest-message-util": "workspace:*",
     "jest-util": "workspace:*",
     "jest-worker": "workspace:*",
+    "one-double-zero": "1.0.0-beta.14",
     "slash": "^3.0.0",
     "string-length": "^4.0.1",
     "strip-ansi": "^6.0.0",

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -20,7 +20,7 @@ import {
   type ProcessCoverage,
   type SourceMap,
   createOneDoubleZero,
-} from 'one-double-zero';
+} from 'one-double-zero-core';
 import v8toIstanbul = require('v8-to-istanbul');
 import type {
   AggregatedResult,

--- a/packages/jest-reporters/src/generateEmptyCoverage.ts
+++ b/packages/jest-reporters/src/generateEmptyCoverage.ts
@@ -41,7 +41,10 @@ export default async function generateEmptyCoverage(
   };
   let coverageWorkerResult: CoverageWorkerResult | null = null;
   if (shouldInstrument(filename, coverageOptions, config)) {
-    if (coverageOptions.coverageProvider === 'v8') {
+    if (
+      coverageOptions.coverageProvider === 'v8' ||
+      coverageOptions.coverageProvider === 'odz'
+    ) {
       const stat = fs.statSync(filename);
       return {
         kind: 'V8Coverage',

--- a/packages/jest-runner/src/runTest.ts
+++ b/packages/jest-runner/src/runTest.ts
@@ -297,7 +297,8 @@ async function runTestInternal(
   // if we don't have `getVmContext` on the env skip coverage
   const collectV8Coverage =
     globalConfig.collectCoverage &&
-    globalConfig.coverageProvider === 'v8' &&
+    (globalConfig.coverageProvider === 'v8' ||
+      globalConfig.coverageProvider === 'odz') &&
     typeof environment.getVmContext === 'function';
 
   // Node's error-message stack size is limited at 10, but it's pretty useful

--- a/packages/jest-schemas/src/raw-types.ts
+++ b/packages/jest-schemas/src/raw-types.ts
@@ -37,6 +37,7 @@ export const SnapshotFormat = Type.Partial(
 const CoverageProvider = Type.Union([
   Type.Literal('babel'),
   Type.Literal('v8'),
+  Type.Literal('odz'),
 ]);
 
 const CoverageThresholdValue = Type.Partial(

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -13,7 +13,7 @@ import type {InitialOptions, SnapshotFormat} from '@jest/schemas';
 
 export type {InitialOptions} from '@jest/schemas';
 
-type CoverageProvider = 'babel' | 'v8';
+type CoverageProvider = 'babel' | 'v8' | 'odz';
 
 export type FakeableAPI =
   | 'Date'

--- a/yarn.lock
+++ b/yarn.lock
@@ -3862,6 +3862,7 @@ __metadata:
     jest-worker: "workspace:*"
     mock-fs: ^5.1.2
     node-notifier: ^10.0.0
+    one-double-zero-core: ^1.0.0
     slash: ^3.0.0
     string-length: ^4.0.1
     strip-ansi: ^6.0.0
@@ -13389,7 +13390,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0":
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.0, istanbul-lib-coverage@npm:^3.2.2":
   version: 3.2.2
   resolution: "istanbul-lib-coverage@npm:3.2.2"
   checksum: 2367407a8d13982d8f7a859a35e7f8dd5d8f75aae4bb5484ede3a9ea1b426dc245aff28b976a2af48ee759fdd9be374ce2bd2669b644f31e76c5f46a2e29a831
@@ -17004,6 +17005,16 @@ __metadata:
   dependencies:
     wrappy: 1
   checksum: cd0a88501333edd640d95f0d2700fbde6bff20b3d4d9bdc521bdd31af0656b5706570d6c6afe532045a20bb8dc0849f8332d6f2a416e0ba6d3d3b98806c7db68
+  languageName: node
+  linkType: hard
+
+"one-double-zero-core@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "one-double-zero-core@npm:1.0.0"
+  dependencies:
+    "@jridgewell/trace-mapping": ^0.3.25
+    istanbul-lib-coverage: ^3.2.2
+  checksum: 71c8b1d007cd6400efd4f19aa41ad725abec80eb9eb84cf76d7815e3787fa6aa718f6990a4689a289de886ff1c44da1d1983f70d8bd76a76ca8fd2b133b5c22b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

As explained in the [issue](https://github.com/jestjs/jest/issues/11188), `v8` coverage provider comes with some important tradeoffs compared to the babel/istanbul one. [One Double Zero](https://one-double-zero.nightlycommit.com/) is a code coverage tool and API that consumes V8 coverage data and targets the accuracy and correctness of istanbul. It does this by operating at the AST level.

This PR adds One Double Zero as a coverage provider.

It also updates the documentation, and explains the tradeoffs of the `v8` coverage provider.

## Test plan

The plan is to execute `odz` on each e2e test executed by the `v8` coverage provider test suite, and use the output result as the snapshot for `e2e/__tests__/coverageProviderODZ.test.ts`. The test script of each `e2e` has to be changed to be executable wth either node or ts-node, which does not impact the coverage result.

* e2e/coverage-provider-v8/cjs-native-without-sourcemap

```shell
e2e/coverage-provider-v8/cjs-native-without-sourcemap$ odz --sources=module.js --sources=uncovered.js node __tests__/test.js

this will print
--------------|---------|----------|---------|---------|-------------------
File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------|---------|----------|---------|---------|-------------------
All files     |      60 |       50 |      50 |      60 |                   
 module.js    |   66.66 |       50 |      50 |   66.66 | 14-15,19          
 uncovered.js |       0 |      100 |     100 |       0 | 8                 
--------------|---------|----------|---------|---------|-------------------
```

* e2e/coverage-provider-v8/cjs-with-babel-transformer

```shell
e2e/coverage-provider-v8/cjs-with-babel-transformer$ odz --sources=module.ts --sources=uncovered.ts --sources=types.ts ts-node -T __tests__/test.ts

this will print
--------------|---------|----------|---------|---------|-------------------
File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------|---------|----------|---------|---------|-------------------
All files     |    62.5 |       50 |      50 |    62.5 |                   
 module.ts    |    62.5 |       50 |      50 |    62.5 | 16-17,21          
 types.ts     |       0 |        0 |       0 |       0 |                   
 uncovered.ts |       0 |        0 |       0 |       0 |                   
--------------|---------|----------|---------|---------|-------------------
```

* e2e/coverage-provider-v8/empty-sourcemap

```shell
e2e/coverage-provider-v8/empty-sourcemap$ odz  --sources=types.ts ts-node -T __tests__/test.ts

----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |       0 |        0 |       0 |       0 |                   
 types.ts |       0 |        0 |       0 |       0 |                   
----------|---------|----------|---------|---------|-------------------
```

* e2e/coverage-provider-v8/esm-native-without-sourcemap

```shell
e2e/coverage-provider-v8/esm-native-without-sourcemap$ odz --sources=module.js node __tests__/test.js 

--------------|---------|----------|---------|---------|-------------------
File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------|---------|----------|---------|---------|-------------------
All files     |    62.5 |       50 |      50 |    62.5 |                   
 module.js    |    62.5 |       50 |      50 |    62.5 | 14-15,19          
 uncovered.js |       0 |        0 |       0 |       0 |                   
--------------|---------|----------|---------|---------|-------------------
```

* e2e/coverage-provider-v8/esm-with-custom-transformer

```shell
e2e/coverage-provider-v8/esm-with-custom-transformer$ odz --sources=module.ts --sources=uncovered.ts --sources=types.ts ts-node -T __tests__/test.ts

--------------|---------|----------|---------|---------|-------------------
File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------|---------|----------|---------|---------|-------------------
All files     |    62.5 |       50 |      50 |    62.5 |                   
 module.ts    |    62.5 |       50 |      50 |    62.5 | 16-17,21          
 types.ts     |       0 |        0 |       0 |       0 |                   
 uncovered.ts |       0 |        0 |       0 |       0 |                   
--------------|---------|----------|---------|---------|-------------------
```

* e2e/coverage-provider-v8/no-sourcemap

```shell\
e2e/coverage-provider-v8/no-sourcemap$ odz --sources=Thing.js --sources=x.css node __tests__/Thing.test.js

42
----------|---------|----------|---------|---------|-------------------
File      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
----------|---------|----------|---------|---------|-------------------
All files |     100 |      100 |     100 |     100 |                   
 Thing.js |     100 |      100 |     100 |     100 |                   
 x.css    |       0 |        0 |       0 |       0 |                   
----------|---------|----------|---------|---------|-------------------
```

* e2e/coverage-provider-v8/with-resetModules

```shell
e2e/coverage-provider-v8/with-resetModules$ odz --sources=module.js --sources=uncovered.js node __tests__/test.js

this will print
--------------|---------|----------|---------|---------|-------------------
File          | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------|---------|----------|---------|---------|-------------------
All files     |      60 |       50 |      50 |      60 |                   
 module.js    |   66.66 |       50 |      50 |   66.66 | 14-15,19          
 uncovered.js |       0 |      100 |     100 |       0 | 8                 
--------------|---------|----------|---------|---------|-------------------
```

* e2e/vmscript-coverage

```shell
e2e/vmscript-coverage$ odz --sources=module.js --sources=package/vmscript.js node __tests__/extract-coverage.test.js

-------------|---------|----------|---------|---------|-------------------
File         | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
-------------|---------|----------|---------|---------|-------------------
All files    |      80 |       75 |   66.66 |      80 |                   
 vmscript.js |      80 |       75 |   66.66 |      80 | 20-21             
-------------|---------|----------|---------|---------|-------------------
```

A few changes had to be made, like passing the list of files to cover to the `_getCoverageResult` method, but globally the changes required to add `odz` were minimal.