### PR TITLE
grant access to original process

### DIFF
--- a/packages/jest-util/src/createProcessObject.ts
+++ b/packages/jest-util/src/createProcessObject.ts
@@ -117,5 +117,11 @@ export default function createProcessObject(): typeof Process {
     },
   });
 
+  Object.defineProperty(newProcess, 'original', {
+    get() {
+      return process;
+    },
+  });
+
   return newProcess;
 }


### PR DESCRIPTION
Tested projects might require access to the original process object. This patch might fix both #5620 and #11165 .