### PR TITLE
Added arrayEqualsWithoutOrder

### DIFF
--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -12,7 +12,9 @@ import {
   any,
   anything,
   arrayContaining,
+  arrayEqualsWithoutOrder,
   arrayNotContaining,
+  arrayNotEqualsWithoutOrder,
   closeTo,
   notCloseTo,
   objectContaining,
@@ -135,6 +137,50 @@ test('Anything does not match null and undefined', () => {
 
 test('Anything.toAsymmetricMatcher()', () => {
   jestExpect(anything().toAsymmetricMatcher()).toBe('Anything');
+});
+
+test('ArrayEqualsWithoutOrder matches', () => {
+  for (const test of [
+    arrayEqualsWithoutOrder([]).asymmetricMatch('jest'),
+    arrayEqualsWithoutOrder(['foo']).asymmetricMatch(['foo']),
+    arrayEqualsWithoutOrder(['foo']).asymmetricMatch(['foo', 'bar']),
+    arrayEqualsWithoutOrder([]).asymmetricMatch({}),
+  ]) {
+    jestExpect(test).toEqual(true);
+  }
+});
+
+test('ArrayEqualsWithoutOrder does not match', () => {
+  jestExpect(arrayEqualsWithoutOrder(['foo']).asymmetricMatch(['bar'])).toBe(false);
+});
+
+test('ArrayEqualsWithoutOrder throws for non-arrays', () => {
+  jestExpect(() => {
+    // @ts-expect-error: Testing runtime error
+    arrayEqualsWithoutOrder('foo').asymmetricMatch([]);
+  }).toThrow("You must provide an array to ArrayEqualsWithoutOrder, not 'string'.");
+});
+
+test('ArrayNotEqualsWithoutOrder matches', () => {
+  jestExpect(arrayNotEqualsWithoutOrder(['foo']).asymmetricMatch(['bar'])).toBe(true);
+});
+
+test('ArrayNotEqualsWithoutOrder does not match', () => {
+  for (const test of [
+    arrayNotEqualsWithoutOrder([]).asymmetricMatch('jest'),
+    arrayNotEqualsWithoutOrder(['foo']).asymmetricMatch(['foo']),
+    arrayNotEqualsWithoutOrder(['foo']).asymmetricMatch(['foo', 'bar']),
+    arrayNotEqualsWithoutOrder([]).asymmetricMatch({}),
+  ]) {
+    jestExpect(test).toEqual(false);
+  }
+});
+
+test('ArrayNotEqualsWithoutOrder throws for non-arrays', () => {
+  jestExpect(() => {
+    // @ts-expect-error: Testing runtime error
+    arrayNotEqualsWithoutOrder('foo').asymmetricMatch([]);
+  }).toThrow("You must provide an array to ArrayNotEqualsWithoutOrder, not 'string'.");
 });
 
 test('ArrayContaining matches', () => {

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -219,6 +219,46 @@ class ArrayContaining extends AsymmetricMatcher<Array<unknown>> {
   }
 }
 
+class ArrayEqualsWithoutOrder extends AsymmetricMatcher<Array<unknown>> {
+  constructor(sample: Array<unknown>, inverse = false) {
+    super(sample, inverse);
+  }
+
+  asymmetricMatch(other: unknown) {
+    if (!Array.isArray(this.sample)) {
+      throw new TypeError(
+        `You must provide an array to ${this.toString()}, not '${typeof this
+          .sample}'.`,
+      );
+    }
+
+    const matcherContext = this.getMatcherContext();
+    const result =
+      this.sample.length === 0 ||
+      (Array.isArray(other) && 
+        this.sample.every(item =>
+          other.some(another =>
+            equals(item, another, matcherContext.customTesters),
+          ),
+        ) && 
+        other.every(item => 
+          this.sample.some(another => 
+            equals(item, another, matcherContext.customTesters),
+          ),
+        ));
+
+    return this.inverse ? !result : result;
+  }
+
+  toString() {
+    return `Array${this.inverse ? 'Not' : ''}Containing`;
+  }
+
+  override getExpectedType() {
+    return 'array';
+  }
+}
+
 class ObjectContaining extends AsymmetricMatcher<
   Record<string | symbol, unknown>
 > {
@@ -377,6 +417,10 @@ export const arrayContaining = (sample: Array<unknown>): ArrayContaining =>
   new ArrayContaining(sample);
 export const arrayNotContaining = (sample: Array<unknown>): ArrayContaining =>
   new ArrayContaining(sample, true);
+export const arrayEqualsWithoutOrder = (sample: Array<unknown>): ArrayEqualsWithoutOrder => 
+  new ArrayEqualsWithoutOrder(sample);
+export const arrayNotEqualsWithoutOrder = (sample: Array<unknown>): ArrayEqualsWithoutOrder => 
+  new ArrayEqualsWithoutOrder(sample, true);
 export const objectContaining = (
   sample: Record<string, unknown>,
 ): ObjectContaining => new ObjectContaining(sample);

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -117,6 +117,7 @@ export interface AsymmetricMatchers {
   any(sample: unknown): AsymmetricMatcher;
   anything(): AsymmetricMatcher;
   arrayContaining(sample: Array<unknown>): AsymmetricMatcher;
+  arrayEqualsWithoutOrder(sample: Array<unknown>): AsymmetricMatcher;
   closeTo(sample: number, precision?: number): AsymmetricMatcher;
   objectContaining(sample: Record<string, unknown>): AsymmetricMatcher;
   stringContaining(sample: string): AsymmetricMatcher;


### PR DESCRIPTION
## Summary

At my company, we have had cases where we want to compare arrays.   We wanted to be able to compare two arrays, regardless of order, but we wanted to make sure they were of the same size.   

## Test plan

asymmetricMatchers.test contain the tests for these matchers under "ArrayEqualsWithoutOrder."
