### PR TITLE
Fix docs typo

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -880,7 +880,7 @@ type HasteConfig = {
   hasteImplModulePath?: string;
   /** All platforms to target, e.g ['ios', 'android']. */
   platforms?: Array<string>;
-  /** Whether to throw on error on module collision. */
+  /** Whether to throw an error on module collision. */
   throwOnModuleCollision?: boolean;
   /** Custom HasteMap module */
   hasteMapModulePath?: string;

--- a/packages/jest-schemas/src/raw-types.ts
+++ b/packages/jest-schemas/src/raw-types.ts
@@ -213,7 +213,7 @@ const RawHasteConfig = Type.Partial(
       description: "All platforms to target, e.g ['ios', 'android'].",
     }),
     throwOnModuleCollision: Type.Boolean({
-      description: 'Whether to throw on error on module collision.',
+      description: 'Whether to throw an error on module collision.',
     }),
     hasteMapModulePath: Type.String({
       description: 'Custom HasteMap module',

--- a/packages/jest-types/src/Config.ts
+++ b/packages/jest-types/src/Config.ts
@@ -121,7 +121,7 @@ export type HasteConfig = {
   hasteImplModulePath?: string;
   /** All platforms to target, e.g ['ios', 'android']. */
   platforms?: Array<string>;
-  /** Whether to throw on error on module collision. */
+  /** Whether to throw an error on module collision. */
   throwOnModuleCollision?: boolean;
   /** Custom HasteMap module */
   hasteMapModulePath?: string;

--- a/website/versioned_docs/version-29.4/Configuration.md
+++ b/website/versioned_docs/version-29.4/Configuration.md
@@ -842,7 +842,7 @@ type HasteConfig = {
   hasteImplModulePath?: string;
   /** All platforms to target, e.g ['ios', 'android']. */
   platforms?: Array<string>;
-  /** Whether to throw on error on module collision. */
+  /** Whether to throw an error on module collision. */
   throwOnModuleCollision?: boolean;
   /** Custom HasteMap module */
   hasteMapModulePath?: string;

--- a/website/versioned_docs/version-29.5/Configuration.md
+++ b/website/versioned_docs/version-29.5/Configuration.md
@@ -842,7 +842,7 @@ type HasteConfig = {
   hasteImplModulePath?: string;
   /** All platforms to target, e.g ['ios', 'android']. */
   platforms?: Array<string>;
-  /** Whether to throw on error on module collision. */
+  /** Whether to throw an error on module collision. */
   throwOnModuleCollision?: boolean;
   /** Custom HasteMap module */
   hasteMapModulePath?: string;

--- a/website/versioned_docs/version-29.6/Configuration.md
+++ b/website/versioned_docs/version-29.6/Configuration.md
@@ -842,7 +842,7 @@ type HasteConfig = {
   hasteImplModulePath?: string;
   /** All platforms to target, e.g ['ios', 'android']. */
   platforms?: Array<string>;
-  /** Whether to throw on error on module collision. */
+  /** Whether to throw an error on module collision. */
   throwOnModuleCollision?: boolean;
   /** Custom HasteMap module */
   hasteMapModulePath?: string;

--- a/website/versioned_docs/version-29.7/Configuration.md
+++ b/website/versioned_docs/version-29.7/Configuration.md
@@ -842,7 +842,7 @@ type HasteConfig = {
   hasteImplModulePath?: string;
   /** All platforms to target, e.g ['ios', 'android']. */
   platforms?: Array<string>;
-  /** Whether to throw on error on module collision. */
+  /** Whether to throw an error on module collision. */
   throwOnModuleCollision?: boolean;
   /** Custom HasteMap module */
   hasteMapModulePath?: string;


### PR DESCRIPTION
## Summary

Was looking at the documentation for `jest.config.json` [to create a JSON Schema](https://github.com/SchemaStore/schemastore/pull/4307), and found a typo. This fixes that typo.
