### PR TITLE
added reference material for expressJS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@
 - `[docs]` Link NestJS documentation on testing with Jest ([#14940](https://github.com/jestjs/jest/pull/14940))
 - `[docs]` `Revised documentation for .toHaveBeenCalled()` to accurately depict its functionality. ([#14853](https://github.com/jestjs/jest/pull/14853))
 - `[docs]` Removed ExpressJS reference link from documentation due to dead link ([#15270](https://github.com/jestjs/jest/pull/15270))
+- `[docs]` Added reference link for ExpressJS to documentation ([#15436](https://github.com/jestjs/jest/pull/15436))
 
 ## 29.7.0
 

--- a/docs/TestingFrameworks.md
+++ b/docs/TestingFrameworks.md
@@ -32,6 +32,10 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 
 - [Writing Tests](https://redux.js.org/recipes/writing-tests) by Redux docs
 
+## Express.js
+
+- [How to test Express.js with Jest and Supertest](http://www.albertgao.com/2017/05/24/how-to-test-expressjs-with-jest-and-supertest/) by Albert Gao ([@albertgao](https://x.com/albertgao))
+
 ## GatsbyJS
 
 - [Unit Testing](https://www.gatsbyjs.org/docs/unit-testing/) by GatsbyJS docs

--- a/website/versioned_docs/version-29.4/TestingFrameworks.md
+++ b/website/versioned_docs/version-29.4/TestingFrameworks.md
@@ -32,6 +32,10 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 
 - [Writing Tests](https://redux.js.org/recipes/writing-tests) by Redux docs
 
+## Express.js
+
+- [How to test Express.js with Jest and Supertest](http://www.albertgao.com/2017/05/24/how-to-test-expressjs-with-jest-and-supertest/) by Albert Gao ([@albertgao](https://x.com/albertgao))
+
 ## GatsbyJS
 
 - [Unit Testing](https://www.gatsbyjs.org/docs/unit-testing/) by GatsbyJS docs

--- a/website/versioned_docs/version-29.5/TestingFrameworks.md
+++ b/website/versioned_docs/version-29.5/TestingFrameworks.md
@@ -32,6 +32,10 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 
 - [Writing Tests](https://redux.js.org/recipes/writing-tests) by Redux docs
 
+## Express.js
+
+- [How to test Express.js with Jest and Supertest](http://www.albertgao.com/2017/05/24/how-to-test-expressjs-with-jest-and-supertest/) by Albert Gao ([@albertgao](https://x.com/albertgao))
+
 ## GatsbyJS
 
 - [Unit Testing](https://www.gatsbyjs.org/docs/unit-testing/) by GatsbyJS docs

--- a/website/versioned_docs/version-29.6/TestingFrameworks.md
+++ b/website/versioned_docs/version-29.6/TestingFrameworks.md
@@ -32,6 +32,10 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 
 - [Writing Tests](https://redux.js.org/recipes/writing-tests) by Redux docs
 
+## Express.js
+
+- [How to test Express.js with Jest and Supertest](http://www.albertgao.com/2017/05/24/how-to-test-expressjs-with-jest-and-supertest/) by Albert Gao ([@albertgao](https://x.com/albertgao))
+
 ## GatsbyJS
 
 - [Unit Testing](https://www.gatsbyjs.org/docs/unit-testing/) by GatsbyJS docs

--- a/website/versioned_docs/version-29.7/TestingFrameworks.md
+++ b/website/versioned_docs/version-29.7/TestingFrameworks.md
@@ -32,6 +32,10 @@ Jest is a universal testing platform, with the ability to adapt to any JavaScrip
 
 - [Writing Tests](https://redux.js.org/recipes/writing-tests) by Redux docs
 
+## Express.js
+
+- [How to test Express.js with Jest and Supertest](http://www.albertgao.com/2017/05/24/how-to-test-expressjs-with-jest-and-supertest/) by Albert Gao ([@albertgao](https://x.com/albertgao))
+
 ## GatsbyJS
 
 - [Unit Testing](https://www.gatsbyjs.org/docs/unit-testing/) by GatsbyJS docs


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
ExpressJs is a popular NodeJs library. The Jest documentation used to have good reference material that provided a concise overview of how to start using Jest with ExpressJS. This reference was removed in [PR-15270](https://github.com/jestjs/jest/pull/15270) because of issues with the domain. The reference material domain changed, and it should be included back in the documentation. 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
- The following commands should be ran in sequence to test these changes

```sh
yarn install

cd website

node fetchSupporters.js

yarn start
```
- Navigating to http://localhost:3000/docs/testing-frameworks on your preferred browser should load up the Jest Documentation with reference material for ExpressJS

![Screenshot 2025-01-03 at 04 17 54](https://github.com/user-attachments/assets/0438f57f-7999-44dd-a05b-ccdf14d7faac)



