### PR TITLE
docs: return promise in async test example

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1100,7 +1100,7 @@ test('doAsync calls both callbacks', () => {
     expect(data).toBeTruthy();
   }
 
-  doAsync(callback1, callback2);
+  return doAsync(callback1, callback2);
 });
 ```
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The callback of the test example for [`expect.assertions()`](https://jestjs.io/docs/expect#expectassertionsnumber) is failing because it does not return a promise.

Alternatively, the description below the test could say:

  > The `expect.assertions(2)` call ensures that both callbacks actually get called. **It will fail in the example above, because the promise is not returned therefore Jest will not wait for `doAsync()` to run the callbacks.**

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
