### PR TITLE
fix: fixed incorrect assertion in jest-worker unit tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,7 +93,6 @@
 - `[jest-util]` Always load `mjs` files with `import` ([#15447](https://github.com/jestjs/jest/pull/15447))
 - `[jest-worker]` Properly handle a circular reference error when worker tries to send an assertion fails where either the expected or actual value is circular ([#15191](https://github.com/jestjs/jest/pull/15191))
 - `[jest-worker]` Properly handle a BigInt when worker tries to send an assertion fails where either the expected or actual value is BigInt ([#15191](https://github.com/jestjs/jest/pull/15191))
-- `[jest-worker]` Resolved an incorrect assertion in the unit tests of the `jest-worker` package. ([#15467](https://github.com/jestjs/jest/pull/15467))
 
 ### Performance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,6 +93,7 @@
 - `[jest-util]` Always load `mjs` files with `import` ([#15447](https://github.com/jestjs/jest/pull/15447))
 - `[jest-worker]` Properly handle a circular reference error when worker tries to send an assertion fails where either the expected or actual value is circular ([#15191](https://github.com/jestjs/jest/pull/15191))
 - `[jest-worker]` Properly handle a BigInt when worker tries to send an assertion fails where either the expected or actual value is BigInt ([#15191](https://github.com/jestjs/jest/pull/15191))
+- `[jest-worker]` Resolved an incorrect assertion in the unit tests of the `jest-worker` package. ([#15467](https://github.com/jestjs/jest/pull/15467))
 
 ### Performance
 

--- a/packages/jest-worker/src/__tests__/index.test.ts
+++ b/packages/jest-worker/src/__tests__/index.test.ts
@@ -140,7 +140,7 @@ it('works with minimal options', () => {
   expect(WorkerPool).toHaveBeenCalledTimes(1);
   expect(typeof farm1.methodA).toBe('function');
   expect(typeof farm1.methodB).toBe('function');
-  expect(typeof farm1).toEqual(
+  expect(farm1).toEqual(
     expect.not.objectContaining({
       _shouldNotExist: expect.anything,
     }),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
The unit test in `jest-workers` package had an incorrect assertion as show below:

Failing Test:
![image](https://github.com/user-attachments/assets/764b74b3-9f3e-49d7-8fd2-d19860ca9721)

The source code for the above test can be found [here](https://github.com/jestjs/jest/blob/main/packages/jest-worker/src/__tests__/index.test.ts#L143)

As we can see, the assertion in the above linked file is incorrect. We need to compare the actual `object` and not the `type` of it. Removing the `typeof` operator and passing the object is the correct assertion.

This PR fixes this issue by removing the `typeof` operator:
```js
expect(farm1).toEqual(
    expect.not.objectContaining({
      _shouldNotExist: expect.anything,
    }),
);
```

```
Note: I've found out that, in PR requests, this very test case/check fails due to the incorrect assertion.
```

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

The test passes after removing the `typeof` operator.
![image](https://github.com/user-attachments/assets/29e97f06-9e58-42e1-b329-b398eed8f364)

The commands I ran are:
```bash
yarn jest /packages/jest-worker/src/__tests__/index.test.ts
```
