### PR TITLE
perf: avoid spread operator in reduce

### DIFF
--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -756,12 +756,14 @@ export default async function normalize(
                   : [];
               const projectEntry =
                 globMatches.length > 0 ? globMatches : project;
-              return [
-                ...projects,
-                ...(Array.isArray(projectEntry)
-                  ? projectEntry
-                  : [projectEntry]),
-              ];
+
+              if (Array.isArray(projectEntry)) {
+                for (const entry of projectEntry) projects.push(entry);
+              } else {
+                projects.push(projectEntry);
+              }
+
+              return projects;
             },
             [],
           );
@@ -1139,7 +1141,8 @@ export default async function normalize(
         ) {
           return patterns;
         }
-        return [...patterns, filename];
+        patterns.push(filename);
+        return patterns;
       }, newOptions.collectCoverageFrom);
     }
 

--- a/packages/jest-core/src/ReporterDispatcher.ts
+++ b/packages/jest-core/src/ReporterDispatcher.ts
@@ -107,7 +107,8 @@ export default class ReporterDispatcher {
   getErrors(): Array<Error> {
     return this._reporters.reduce<Array<Error>>((list, reporter) => {
       const error = reporter.getLastError?.();
-      return error ? [...list, error] : list;
+      if (error) list.push(error);
+      return list;
     }, []);
   }
 

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -351,14 +351,16 @@ const groupSnapshotsBy =
     snapshots.reduce<Record<string, Array<InlineSnapshot>>>(
       (object, inlineSnapshot) => {
         const key = createKey(inlineSnapshot);
-        return {
-          ...object,
-          [key]: [...(object[key] || []), inlineSnapshot],
-        };
+
+        if (!object[key]) {
+          object[key] = [];
+        }
+
+        object[key].push(inlineSnapshot);
+        return object;
       },
       {},
     );
-
 const groupSnapshotsByFrame = groupSnapshotsBy(({frame: {line, column}}) =>
   typeof line === 'number' && typeof column === 'number'
     ? `${line}:${column - 1}`


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This PR removes the use of the spread operator in the reduce method.

Links related : 
 - https://biomejs.dev/linter/rules/no-accumulating-spread/
 - https://prateeksurana.me/blog/why-using-object-spread-with-reduce-bad-idea/

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
<img width="448" alt="Capture d’écran 2025-01-25 à 10 20 36" src="https://github.com/user-attachments/assets/efa104bf-9ea9-4df8-a401-b7b3f4fe24fb" />

