### PR TITLE
fix: pass modulePath instead of moduleName to onGenerateMock callback (#15429)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@
 - `[jest-runtime]` Support `import.meta.resolve` ([#14930](https://github.com/jestjs/jest/pull/14930))
 - `[jest-runtime]` [**BREAKING**] Make it mandatory to pass `globalConfig` to the `Runtime` constructor ([#15044](https://github.com/jestjs/jest/pull/15044))
 - `[jest-runtime]` Add `unstable_unmockModule` ([#15080](https://github.com/jestjs/jest/pull/15080))
-- `[jest-runtime]` Add `onGenerateMock` transformer callback for auto generated callbacks ([#15433](https://github.com/jestjs/jest/pull/15433))
+- `[jest-runtime]` Add `onGenerateMock` transformer callback for auto generated callbacks ([#15433](https://github.com/jestjs/jest/pull/15433) & [#15482](https://github.com/jestjs/jest/pull/15482))
 - `[@jest/schemas]` Upgrade `@sinclair/typebox` to v0.34 ([#15450](https://github.com/jestjs/jest/pull/15450))
 - `[@jest/types]` `test.each()`: Accept a readonly (`as const`) table properly ([#14565](https://github.com/jestjs/jest/pull/14565))
 - `[@jest/types]` Improve argument type inference passed to `test` and `describe` callback functions from `each` tables ([#14920](https://github.com/jestjs/jest/pull/14920))

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -534,7 +534,7 @@ Registers a callback function that is invoked whenever Jest generates a mock for
 
 Parameters for callback:
 
-1. `moduleName: string` - The name of the module that is being mocked.
+1. `modulePath: string` - The absolute path to the module that is being mocked.
 2. `moduleMock: T` - The mock object that Jest has generated for the module. This object can be modified or replaced before returning.
 
 Behaviour:
@@ -543,9 +543,9 @@ Behaviour:
 - Each callback receives the output of the previous callback as its `moduleMock`. This makes it possible to apply multiple layers of transformations to the same mock.
 
 ```js
-jest.onGenerateMock((moduleName, moduleMock) => {
+jest.onGenerateMock((modulePath, moduleMock) => {
   // Inspect the module name and decide how to transform the mock
-  if (moduleName.includes('Database')) {
+  if (modulePath.includes('Database')) {
     // For demonstration, let's replace a method with our own custom mock
     moduleMock.connect = jest.fn().mockImplementation(() => {
       console.log('Connected to mock DB');

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -227,14 +227,14 @@ export interface Jest {
   now(): number;
   /**
    * Registers a callback function that is invoked whenever a mock is generated for a module.
-   * This callback is passed the module name and the newly created mock object, and must return
+   * This callback is passed the module path and the newly created mock object, and must return
    * the (potentially modified) mock object.
    *
    * If multiple callbacks are registered, they will be called in the order they were added.
    * Each callback receives the result of the previous callback as the `moduleMock` parameter,
    * making it possible to apply sequential transformations.
    */
-  onGenerateMock<T>(cb: (moduleName: string, moduleMock: T) => T): Jest;
+  onGenerateMock<T>(cb: (modulePath: string, moduleMock: T) => T): Jest;
   /**
    * Replaces property on an object with another value.
    *

--- a/packages/jest-runtime/src/__tests__/runtime_mock.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_mock.test.js
@@ -155,7 +155,7 @@ describe('Runtime', () => {
         runtime.requireModuleOrMock(runtime.__mockRootPath, 'RegularModule'),
       ).toEqual(mockReference);
       expect(onGenerateMock).toHaveBeenCalledWith(
-        'RegularModule',
+        expect.stringMatching(/[/\\]test_root[/\\]RegularModule\.js$/),
         expect.anything(),
       );
 
@@ -201,17 +201,23 @@ describe('Runtime', () => {
         value: 4,
       });
       expect(onGenerateMock1).toHaveBeenCalledWith(
-        'RegularModule',
+        expect.stringMatching(/[/\\]test_root[/\\]RegularModule\.js$/),
         expect.anything(),
       );
-      expect(onGenerateMock2).toHaveBeenCalledWith('RegularModule', {
-        isMock: true,
-        value: 1,
-      });
-      expect(onGenerateMock3).toHaveBeenCalledWith('RegularModule', {
-        isMock: true,
-        value: 2,
-      });
+      expect(onGenerateMock2).toHaveBeenCalledWith(
+        expect.stringMatching(/[/\\]test_root[/\\]RegularModule\.js$/),
+        {
+          isMock: true,
+          value: 1,
+        },
+      );
+      expect(onGenerateMock3).toHaveBeenCalledWith(
+        expect.stringMatching(/[/\\]test_root[/\\]RegularModule\.js$/),
+        {
+          isMock: true,
+          value: 2,
+        },
+      );
     });
   });
 });

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -1952,7 +1952,7 @@ export default class Runtime {
     );
 
     for (const onGenerateMock of this._onGenerateMock) {
-      moduleMock = onGenerateMock(moduleName, moduleMock);
+      moduleMock = onGenerateMock(modulePath, moduleMock);
     }
 
     return moduleMock;


### PR DESCRIPTION
## Summary

There is no way to require the actual module for the currently mocked module inside the onGenerateMock callback. I think it would be better to replace the relative module name with the absolute module path.