### PR TITLE
doc(docs.mockFunctions): use SAME JS module system

### DIFF
--- a/docs/MockFunctions.md
+++ b/docs/MockFunctions.md
@@ -12,11 +12,12 @@ There are two ways to mock functions: Either by creating a mock function to use 
 Let's imagine we're testing an implementation of a function `forEach`, which invokes a callback for each item in a supplied array.
 
 ```js title="forEach.js"
-export function forEach(items, callback) {
+function forEach(items, callback) {
   for (const item of items) {
     callback(item);
   }
 }
+module.exports = forEach;
 ```
 
 To test this function, we can use a mock function, and inspect the mock's state to ensure the callback is invoked as expected.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

* In [Using a mock function](https://jestjs.io/docs/mock-functions), you can see that
  * in `js title="forEach.test.js" `, that `require` is used == CommonJS
  * in `js title="forEach.js"`, that `export` is used == ES
* That's why lot of pitfalls you will get, mixin them
* Solution:
  * align to use  CommonJS in both files defined

## Test plan

* Create both 2 files
* Create the minimum set up to make jest work -- see [gettingStarted](https://jestjs.io/docs/getting-started) -- 
* Run it to test
  <img width="211" alt="image" src="https://github.com/user-attachments/assets/30ce77f1-734d-4c03-8533-8a17d0ddb3f3" />
