### PR TITLE
fix failing snapshot test

### DIFF
--- a/e2e/__tests__/jest.config.ts.test.ts
+++ b/e2e/__tests__/jest.config.ts.test.ts
@@ -148,7 +148,7 @@ onNodeVersions('>=23.6', () => {
     expect(
       stderr
         // Remove the stack trace from the error message
-        .slice(0, Math.max(0, stderr.indexOf('Caused by')))
+        .slice(0, Math.max(0, stderr.indexOf('at readConfigFileAndSetRootDir')))
         .trim()
         // Replace the path to the config file with a placeholder
         .replace(


### PR DESCRIPTION
## Summary

This just fixes the test @SimenB noted to be failing here: https://github.com/jestjs/jest/pull/15480#issuecomment-2646307877

It seems that the error output slightly changed in node 23.7 and didn't match the `.indexOf` anymore.

## Test plan

This PR quite literally updates a test ;)