### PR TITLE
Reports returned values on received function not throw when expect `.toThrow()`

### DIFF
--- a/e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts
+++ b/e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts
@@ -45,6 +45,24 @@ test("throws the error if tested function didn't throw error", () => {
     writeFiles(TESTS_DIR, {[filename]: template()});
     const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).toMatch('Received function did not throw');
+    expect(stderr).toMatch('Returned: undefined');
+    expect(exitCode).toBe(1);
+  }
+});
+
+test("reports stringified returned value if tested function didn't throw error", () => {
+  const filename = 'throws-if-tested-function-did-not-throw.test.js';
+  const template =
+    makeTemplate(`test('throws the error if tested function did not throw error', () => {
+      expect(() => { return { foo: 1, bar: { baz: "2", } };}).toThrowErrorMatchingSnapshot();
+    });
+    `);
+
+  {
+    writeFiles(TESTS_DIR, {[filename]: template()});
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    expect(stderr).toMatch('Received function did not throw');
+    expect(stderr).toMatch('Returned: {"bar": {"baz": "2"}, "foo": 1}');
     expect(exitCode).toBe(1);
   }
 });

--- a/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.ts.snap
@@ -92,6 +92,7 @@ exports[`toThrow error class did not throw at all 1`] = `
 Expected constructor: <g>Err</>
 
 Received function did not throw
+Returned: undefined
 `;
 
 exports[`toThrow error class threw, but class did not match (error) 1`] = `
@@ -230,6 +231,7 @@ exports[`toThrow regexp did not throw at all 1`] = `
 Expected pattern: <g>/apple/</>
 
 Received function did not throw
+Returned: undefined
 `;
 
 exports[`toThrow regexp threw, but message did not match (error) 1`] = `
@@ -271,7 +273,8 @@ exports[`toThrow substring did not throw at all 1`] = `
 
 Expected substring: <g>"apple"</>
 
-Received function did not throw
+Received function did not throw 
+Returned: undefined
 `;
 
 exports[`toThrow substring threw, but message did not match (error) 1`] = `

--- a/packages/expect/src/__tests__/toThrowMatchers.test.ts
+++ b/packages/expect/src/__tests__/toThrowMatchers.test.ts
@@ -50,6 +50,10 @@ describe('toThrow', () => {
       ).toThrowErrorMatchingSnapshot();
     });
 
+    test('did not throw with a promise', async () => {
+      await jestExpect(Promise.resolve('banana')).resolves.not.toThrow('apple')
+    });
+
     test('threw, but message did not match (error)', () => {
       expect(() => {
         jestExpect(() => {
@@ -106,6 +110,10 @@ describe('toThrow', () => {
       expect(() =>
         jestExpect(() => {}).toThrow(/apple/),
       ).toThrowErrorMatchingSnapshot();
+    });
+
+    test('did not throw at all with a promise', async () => {
+      await jestExpect(Promise.resolve('banana')).resolves.not.toThrow(/apple/)
     });
 
     test('threw, but message did not match (error)', () => {
@@ -185,6 +193,10 @@ describe('toThrow', () => {
       expect(() =>
         expect(() => {}).toThrow(Err),
       ).toThrowErrorMatchingSnapshot();
+    });
+
+    test('did not throw at all with a promise', async () => {
+      await jestExpect(Promise.resolve()).resolves.not.toThrow(Err)
     });
 
     test('threw, but class did not match (error)', () => {

--- a/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
+++ b/packages/jest-snapshot/src/__tests__/__snapshots__/printSnapshot.test.ts.snap
@@ -120,6 +120,7 @@ exports[`other error toThrowErrorMatchingSnapshot Received function did not thro
 <d>expect(</><r>received</><d>).</>toThrowErrorMatchingSnapshot<d>()</>
 
 Received function did not throw
+Returned: undefined
 `;
 
 exports[`pass false toMatchInlineSnapshot with properties equals false with snapshot 1`] = `

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -509,12 +509,13 @@ const _toThrowErrorMatchingSnapshot = (
   }
 
   let error;
+  let returnedValueOnNotThrow;
 
   if (fromPromise) {
     error = received;
   } else {
     try {
-      received();
+      returnedValueOnNotThrow = received();
     } catch (receivedError) {
       error = receivedError;
     }
@@ -523,7 +524,11 @@ const _toThrowErrorMatchingSnapshot = (
   if (error === undefined) {
     // Because the received value is a function, this is not a matcher error.
     throw new Error(
-      `${matcherHintFromConfig(config, false)}\n\n${DID_NOT_THROW}`,
+      `${matcherHintFromConfig(config, false)}\n\n${DID_NOT_THROW}${
+        typeof received === 'function'
+          ? `\nReturned: ${stringify(returnedValueOnNotThrow)}`
+          : ''
+      }`,
     );
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Implement #15525, to reports returned value of received function when that function call not throw with `.toThrow()` / `.toThrowErrorMatchingSnapshot()`.

To check the format, see the test case in `e2e/__tests__/toThrowErrorMatchingSnapshot.test.ts` .

### Changed Scope

- `expect`: in `toThrowMatchers.ts` for each `toThrowExpectedClass/Message/Regex` function, pass `received` and `returnedValueOnNotThrow` to compose the error message.
- `jest-snapshot`: do the same thing but for `toThrowErrorMatchingSnapshot`.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

- Updated the snapshot of unit test in `toThrowMatchers.test.ts` to make sure it contained returned value message
- Add test case for `toThrowErrorMatchingSnapshot.test.ts` e2e case to ensure it can report the stringified returned object values, not `[Object Object]`.
