### PR TITLE
docs: update link to contributors in `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -211,7 +211,7 @@ See [SECURITY.md](./SECURITY.md) for the safe disclosure of security bugs. With 
 
 This project exists thanks to all the people who [contribute](CONTRIBUTING.md).
 
-<a href="graphs/contributors"><img src="https://opencollective.com/jest/contributors.svg?width=890&button=false" /></a>
+<a href="https://github.com/jestjs/jest/graphs/contributors"><img src="https://opencollective.com/jest/contributors.svg?width=890&button=false" /></a>
 
 ### [Backers](https://opencollective.com/jest#backer)
 


### PR DESCRIPTION
## Summary

The existing link redirects to https://github.com/jestjs/jest/blob/main/graphs/contributors rather than https://github.com/jestjs/jest/graphs/contributors.
