### PR TITLE
chore: update type tests

### DIFF
--- a/packages/expect-utils/__typetests__/utils.test.ts
+++ b/packages/expect-utils/__typetests__/utils.test.ts
@@ -9,21 +9,21 @@ import {expect, test} from 'tstyche';
 import {isA} from '@jest/expect-utils';
 
 test('isA', () => {
-  expect(isA('String', 'default')).type.toBeBoolean();
-  expect(isA<number>('Number', 123)).type.toBeBoolean();
+  expect(isA('String', 'default')).type.toBe<boolean>();
+  expect(isA<number>('Number', 123)).type.toBe<boolean>();
 
   const sample = {} as unknown;
 
   if (isA('String', sample)) {
-    expect(sample).type.toBeUnknown();
+    expect(sample).type.toBe<unknown>();
   }
 
   if (isA<string>('String', sample)) {
-    expect(sample).type.toBeString();
+    expect(sample).type.toBe<string>();
   }
 
   if (isA<number>('Number', sample)) {
-    expect(sample).type.toBeNumber();
+    expect(sample).type.toBe<number>();
   }
 
   if (isA<Map<unknown, unknown>>('Map', sample)) {

--- a/packages/expect/__typetests__/expect.test.ts
+++ b/packages/expect/__typetests__/expect.test.ts
@@ -41,8 +41,8 @@ describe('Matchers', () => {
 describe('Expect', () => {
   test('.addEqualityTesters()', () => {
     const tester1: Tester = function (a, b, customTesters) {
-      expect(a).type.toBeAny();
-      expect(b).type.toBeAny();
+      expect(a).type.toBe<any>();
+      expect(b).type.toBe<any>();
       expect(customTesters).type.toBe<Array<Tester>>();
       expect(this).type.toBe<TesterContext>();
       expect(this.equals).type.toBe<EqualsFunction>();
@@ -55,17 +55,17 @@ describe('Expect', () => {
         tester1,
 
         (a, b, customTesters) => {
-          expect(a).type.toBeAny();
-          expect(b).type.toBeAny();
+          expect(a).type.toBe<any>();
+          expect(b).type.toBe<any>();
           expect(customTesters).type.toBe<Array<Tester>>();
-          expect(this).type.toBeUndefined();
+          expect(this).type.toBe<undefined>();
 
           return true;
         },
 
         function anotherTester(a, b, customTesters) {
-          expect(a).type.toBeAny();
-          expect(b).type.toBeAny();
+          expect(a).type.toBe<any>();
+          expect(b).type.toBe<any>();
           expect(customTesters).type.toBe<Array<Tester>>();
           expect(this).type.toBe<TesterContext>();
           expect(this.equals).type.toBe<EqualsFunction>();
@@ -73,7 +73,7 @@ describe('Expect', () => {
           return undefined;
         },
       ]),
-    ).type.toBeVoid();
+    ).type.toBe<void>();
   });
 
   test('.extend()', () => {
@@ -86,7 +86,7 @@ describe('Expect', () => {
       jestExpect.extend({
         // TODO `actual` should be allowed to have only `unknown` type
         toBeWithinRange(actual: number, floor: number, ceiling: number) {
-          expect(this.assertionCalls).type.toBeNumber();
+          expect(this.assertionCalls).type.toBe<number>();
           expect(this.currentTestName).type.toBe<string | undefined>();
           expect(this.customTesters).type.toBe<Array<Tester>>();
           expect(this.dontThrow).type.toBe<() => void>();
@@ -97,12 +97,12 @@ describe('Expect', () => {
           expect(this.expectedAssertionsNumberError).type.toBe<
             Error | undefined
           >();
-          expect(this.isExpectingAssertions).type.toBeBoolean();
+          expect(this.isExpectingAssertions).type.toBe<boolean>();
           expect(this.isExpectingAssertionsError).type.toBe<
             Error | undefined
           >();
           expect(this.isNot).type.toBe<boolean | undefined>();
-          expect(this.numPassingAsserts).type.toBeNumber();
+          expect(this.numPassingAsserts).type.toBe<number>();
           expect(this.promise).type.toBe<string | undefined>();
           expect(this.suppressedErrors).type.toBe<Array<Error>>();
           expect(this.testPath).type.toBe<string | undefined>();
@@ -124,17 +124,17 @@ describe('Expect', () => {
           }
         },
       }),
-    ).type.toBeVoid();
+    ).type.toBe<void>();
 
-    expect(jestExpect(100).toBeWithinRange(90, 110)).type.toBeVoid();
-    expect(jestExpect(101).not.toBeWithinRange(0, 100)).type.toBeVoid();
+    expect(jestExpect(100).toBeWithinRange(90, 110)).type.toBe<void>();
+    expect(jestExpect(101).not.toBeWithinRange(0, 100)).type.toBe<void>();
 
     expect(
       jestExpect({apples: 6, bananas: 3}).toEqual({
         apples: jestExpect.toBeWithinRange(1, 10),
         bananas: jestExpect.not.toBeWithinRange(11, 20),
       }),
-    ).type.toBeVoid();
+    ).type.toBe<void>();
   });
 
   test('does not define the `.toMatchSnapshot()` matcher', () => {
@@ -246,7 +246,7 @@ describe('MatcherFunction', () => {
       ...expected: Array<unknown>
     ) {
       expect(this).type.toBe<CustomContext>();
-      expect(this.customMethod()).type.toBeVoid();
+      expect(this.customMethod()).type.toBe<void>();
 
       if (expected.length > 0) {
         throw new Error('This matcher does not take any expected argument.');
@@ -275,7 +275,7 @@ describe('MatcherFunction', () => {
       [count: number]
     > = function (actual: unknown, count: unknown) {
       expect(this).type.toBe<CustomContext>();
-      expect(this.customMethod()).type.toBeVoid();
+      expect(this.customMethod()).type.toBe<void>();
 
       return {
         message: () => `count: ${count}`,

--- a/packages/expect/__typetests__/expectTyped.test.ts
+++ b/packages/expect/__typetests__/expectTyped.test.ts
@@ -16,8 +16,8 @@ declare module 'expect' {
 
 describe('Expect', () => {
   test('allows type inference of the `actual` argument', () => {
-    expect(_expect(100).toTypedEqual(100)).type.toBeVoid();
-    expect(_expect(101).not.toTypedEqual(100)).type.toBeVoid();
+    expect(_expect(100).toTypedEqual(100)).type.toBe<void>();
+    expect(_expect(101).not.toTypedEqual(100)).type.toBe<void>();
 
     expect(_expect(100).toTypedEqual('three')).type.toRaiseError(
       "Argument of type 'string' is not assignable to parameter of type 'number'.",

--- a/packages/jest-expect/__typetests__/jest-expect.test.ts
+++ b/packages/jest-expect/__typetests__/jest-expect.test.ts
@@ -35,8 +35,8 @@ describe('JestExpect', () => {
   });
 
   test('allows type inference of the `actual` argument', () => {
-    expect(jestExpect(100).toTypedEqual(100)).type.toBeVoid();
-    expect(jestExpect(101).not.toTypedEqual(100)).type.toBeVoid();
+    expect(jestExpect(100).toTypedEqual(100)).type.toBe<void>();
+    expect(jestExpect(101).not.toTypedEqual(100)).type.toBe<void>();
 
     expect(jestExpect(100).toTypedEqual('three')).type.toRaiseError(
       "Argument of type 'string' is not assignable to parameter of type 'number'.",

--- a/packages/jest-mock/__typetests__/ModuleMocker.test.ts
+++ b/packages/jest-mock/__typetests__/ModuleMocker.test.ts
@@ -68,14 +68,14 @@ test('generateFromMetadata', () => {
   expect(exampleMock.instance.memberA).type.toBe<Array<number>>();
   expect(exampleMock.instance.memberB.mock.calls).type.toBe<Array<[]>>();
 
-  expect(exampleMock.propertyA.one).type.toBeString();
+  expect(exampleMock.propertyA.one).type.toBe<string>();
   expect(exampleMock.propertyA.two.mock.calls).type.toBe<Array<[]>>();
-  expect(exampleMock.propertyA.three.nine).type.toBeNumber();
+  expect(exampleMock.propertyA.three.nine).type.toBe<number>();
   expect(exampleMock.propertyA.three.ten).type.toBe<Array<number>>();
 
   expect(exampleMock.propertyB).type.toBe<Array<number>>();
-  expect(exampleMock.propertyC).type.toBeNumber();
-  expect(exampleMock.propertyD).type.toBeString();
-  expect(exampleMock.propertyE).type.toBeBoolean();
-  expect(exampleMock.propertyF).type.toBeSymbol();
+  expect(exampleMock.propertyC).type.toBe<number>();
+  expect(exampleMock.propertyD).type.toBe<string>();
+  expect(exampleMock.propertyE).type.toBe<boolean>();
+  expect(exampleMock.propertyF).type.toBe<symbol>();
 });

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -103,7 +103,7 @@ describe('jest.fn()', () => {
   });
 
   test('infers argument and return types of mocked function', () => {
-    expect(mockFn('one', 2)).type.toBeBoolean();
+    expect(mockFn('one', 2)).type.toBe<boolean>();
     expect(mockAsyncFn(false)).type.toBe<Promise<string>>();
 
     expect(mockFn()).type.toRaiseError();
@@ -128,18 +128,18 @@ describe('jest.fn()', () => {
   });
 
   test('.getMockName()', () => {
-    expect(mockFn.getMockName()).type.toBeString();
+    expect(mockFn.getMockName()).type.toBe<string>();
 
     expect(mockFn.getMockName('some-mock')).type.toRaiseError();
   });
 
   test('.mock', () => {
-    expect(mockFn.mock.calls.length).type.toBeNumber();
+    expect(mockFn.mock.calls.length).type.toBe<number>();
 
-    expect(mockFn.mock.calls[0][0]).type.toBeString();
+    expect(mockFn.mock.calls[0][0]).type.toBe<string>();
     expect(mockFn.mock.calls[0][1]).type.toBe<number | undefined>();
 
-    expect(mockFn.mock.calls[1][0]).type.toBeString();
+    expect(mockFn.mock.calls[1][0]).type.toBe<string>();
     expect(mockFn.mock.calls[1][1]).type.toBe<number | undefined>();
 
     expect(mockFn.mock.contexts).type.toBe<Array<Date>>();
@@ -160,18 +160,18 @@ describe('jest.fn()', () => {
     const returnValue = mockFn.mock.results[0];
 
     expect(returnValue.type).type.toBe<'incomplete' | 'return' | 'throw'>();
-    expect(returnValue.value).type.toBeUnknown();
+    expect(returnValue.value).type.toBe<unknown>();
 
     if (returnValue.type === 'incomplete') {
-      expect(returnValue.value).type.toBeUndefined();
+      expect(returnValue.value).type.toBe<undefined>();
     }
 
     if (returnValue.type === 'return') {
-      expect(returnValue.value).type.toBeBoolean();
+      expect(returnValue.value).type.toBe<boolean>();
     }
 
     if (returnValue.type === 'throw') {
-      expect(returnValue.value).type.toBeUnknown();
+      expect(returnValue.value).type.toBe<unknown>();
     }
   });
 
@@ -192,7 +192,7 @@ describe('jest.fn()', () => {
   });
 
   test('.mockRestore()', () => {
-    expect(mockFn.mockRestore()).type.toBeVoid();
+    expect(mockFn.mockRestore()).type.toBe<void>();
 
     expect(mockFn.mockRestore('some-mock')).type.toRaiseError();
   });
@@ -200,7 +200,7 @@ describe('jest.fn()', () => {
   test('.mockImplementation()', () => {
     expect(
       mockFn.mockImplementation((a, b) => {
-        expect(a).type.toBeString();
+        expect(a).type.toBe<string>();
         expect(b).type.toBe<number | undefined>();
         return false;
       }),
@@ -212,7 +212,7 @@ describe('jest.fn()', () => {
 
     expect(
       mockAsyncFn.mockImplementation(async a => {
-        expect(a).type.toBeBoolean();
+        expect(a).type.toBe<boolean>();
         return 'mock value';
       }),
     ).type.toBe<Mock<(p: boolean) => Promise<string>>>();
@@ -225,7 +225,7 @@ describe('jest.fn()', () => {
   test('.mockImplementationOnce()', () => {
     expect(
       mockFn.mockImplementationOnce((a, b) => {
-        expect(a).type.toBeString();
+        expect(a).type.toBe<string>();
         expect(b).type.toBe<number | undefined>();
         return false;
       }),
@@ -239,7 +239,7 @@ describe('jest.fn()', () => {
 
     expect(
       mockAsyncFn.mockImplementationOnce(async a => {
-        expect(a).type.toBeBoolean();
+        expect(a).type.toBe<boolean>();
         return 'mock value';
       }),
     ).type.toBe<Mock<(p: boolean) => Promise<string>>>();
@@ -354,7 +354,7 @@ describe('jest.fn()', () => {
   });
 
   test('.withImplementation()', () => {
-    expect(mockFn.withImplementation(mockFnImpl, () => {})).type.toBeVoid();
+    expect(mockFn.withImplementation(mockFnImpl, () => {})).type.toBe<void>();
     expect(mockFn.withImplementation(mockFnImpl, async () => {})).type.toBe<
       Promise<void>
     >();
@@ -625,7 +625,7 @@ describe('jest.replaceProperty()', () => {
     >();
     expect(
       replaceProperty(replaceObject, 'property', 1).replaceValue(1).restore(),
-    ).type.toBeVoid();
+    ).type.toBe<void>();
 
     expect(replaceProperty(replaceObject, 'invalid', 1)).type.toRaiseError();
     expect(

--- a/packages/jest-reporters/__typetests__/jest-reporters.test.ts
+++ b/packages/jest-reporters/__typetests__/jest-reporters.test.ts
@@ -25,8 +25,8 @@ declare const testResult: TestResult;
 
 // utils.formatTestPath()
 
-expect(utils.formatTestPath(globalConfig, 'some/path')).type.toBeString();
-expect(utils.formatTestPath(projectConfig, 'some/path')).type.toBeString();
+expect(utils.formatTestPath(globalConfig, 'some/path')).type.toBe<string>();
+expect(utils.formatTestPath(projectConfig, 'some/path')).type.toBe<string>();
 expect(utils.formatTestPath()).type.toRaiseError();
 expect(utils.formatTestPath({}, 'some/path')).type.toRaiseError();
 expect(utils.formatTestPath(globalConfig, 123)).type.toRaiseError();
@@ -36,8 +36,8 @@ expect(utils.formatTestPath(projectConfig, 123)).type.toRaiseError();
 
 expect(
   utils.getResultHeader(testResult, globalConfig, projectConfig),
-).type.toBeString();
-expect(utils.getResultHeader(testResult, globalConfig)).type.toBeString();
+).type.toBe<string>();
+expect(utils.getResultHeader(testResult, globalConfig)).type.toBe<string>();
 expect(utils.getResultHeader()).type.toRaiseError();
 expect(utils.getResultHeader({}, globalConfig)).type.toRaiseError();
 expect(
@@ -71,15 +71,15 @@ expect(
 
 // utils.getSummary()
 
-expect(utils.getSummary(aggregatedResults, summaryOptions)).type.toBeString();
-expect(utils.getSummary(aggregatedResults)).type.toBeString();
+expect(utils.getSummary(aggregatedResults, summaryOptions)).type.toBe<string>();
+expect(utils.getSummary(aggregatedResults)).type.toBe<string>();
 expect(utils.getSummary()).type.toRaiseError();
 expect(utils.getSummary({})).type.toRaiseError();
 expect(utils.getSummary(aggregatedResults, true)).type.toRaiseError();
 
 // utils.printDisplayName()
 
-expect(utils.printDisplayName(projectConfig)).type.toBeString();
+expect(utils.printDisplayName(projectConfig)).type.toBe<string>();
 expect(utils.printDisplayName()).type.toRaiseError();
 expect(utils.printDisplayName({})).type.toRaiseError();
 
@@ -101,7 +101,7 @@ expect(utils.relativePath(projectConfig, true)).type.toRaiseError();
 
 expect(
   utils.trimAndFormatPath(2, globalConfig, 'some/path', 4),
-).type.toBeString();
+).type.toBe<string>();
 expect(utils.trimAndFormatPath()).type.toRaiseError();
 expect(
   utils.trimAndFormatPath(true, globalConfig, 'some/path', 4),

--- a/packages/jest-resolve/__typetests__/resolver.test.ts
+++ b/packages/jest-resolve/__typetests__/resolver.test.ts
@@ -61,9 +61,9 @@ expect<AsyncResolver>().type.toBeAssignableWith(customAsyncResolver);
 // AsyncResolver
 
 const asyncResolver: AsyncResolver = async (path, options) => {
-  expect(path).type.toBeString();
+  expect(path).type.toBe<string>();
 
-  expect(options.basedir).type.toBeString();
+  expect(options.basedir).type.toBe<string>();
   expect(options.conditions).type.toBe<Array<string> | undefined>();
   expect(options.defaultResolver).type.toBe<SyncResolver>();
   expect(options.extensions).type.toBe<Array<string> | undefined>();
@@ -84,9 +84,9 @@ expect<AsyncResolver>().type.not.toBeAssignableWith(
 // SyncResolver
 
 const syncResolver: SyncResolver = (path, options) => {
-  expect(path).type.toBeString();
+  expect(path).type.toBe<string>();
 
-  expect(options.basedir).type.toBeString();
+  expect(options.basedir).type.toBe<string>();
   expect(options.conditions).type.toBe<Array<string> | undefined>();
   expect(options.defaultResolver).type.toBe<SyncResolver>();
   expect(options.extensions).type.toBe<Array<string> | undefined>();

--- a/packages/jest-runner/__typetests__/jest-runner.test.ts
+++ b/packages/jest-runner/__typetests__/jest-runner.test.ts
@@ -69,7 +69,7 @@ class CustomCallbackRunner implements CallbackTestRunnerInterface {
     options: TestRunnerOptions,
   ): Promise<void> {
     expect(this.#globalConfig).type.toBe<Config.GlobalConfig>();
-    expect(this.#maxConcurrency).type.toBeNumber();
+    expect(this.#maxConcurrency).type.toBe<number>();
 
     return;
   }
@@ -120,7 +120,7 @@ class CustomEmittingRunner implements EmittingTestRunnerInterface {
     options: TestRunnerOptions,
   ): Promise<void> {
     expect(this.#globalConfig).type.toBe<Config.GlobalConfig>();
-    expect(this.#maxConcurrency).type.toBeNumber();
+    expect(this.#maxConcurrency).type.toBe<number>();
 
     return;
   }

--- a/packages/jest-snapshot/__typetests__/SnapshotResolver.test.ts
+++ b/packages/jest-snapshot/__typetests__/SnapshotResolver.test.ts
@@ -12,13 +12,13 @@ import type {SnapshotResolver} from 'jest-snapshot';
 
 const snapshotResolver: SnapshotResolver = {
   resolveSnapshotPath: (testPath, snapshotExtension) => {
-    expect(testPath).type.toBeString();
+    expect(testPath).type.toBe<string>();
     expect(snapshotExtension).type.toBe<string | undefined>();
     return 'snapshot/path';
   },
 
   resolveTestPath: (snapshotPath, snapshotExtension) => {
-    expect(snapshotPath).type.toBeString();
+    expect(snapshotPath).type.toBe<string>();
     expect(snapshotExtension).type.toBe<string | undefined>();
     return 'test/path';
   },

--- a/packages/jest-types/__typetests__/each.test.ts
+++ b/packages/jest-types/__typetests__/each.test.ts
@@ -29,20 +29,20 @@ const objectTable = [
 
 expect(
   test.each(list)('some test', (a, done) => {
-    expect(a).type.toBeNumber();
+    expect(a).type.toBe<number>();
 
     expect(done).type.toBe<(reason?: string | Error) => void>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each(list)(
     'some test',
     a => {
-      expect(a).type.toBeNumber();
+      expect(a).type.toBe<number>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.each(tupleList)('some test', (b, done) => {
@@ -50,7 +50,7 @@ expect(
 
     expect(done).type.toBe<(reason?: string | Error) => void>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each(tupleList)(
     'some test',
@@ -59,7 +59,7 @@ expect(
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.each([3, 4, 'seven'])('some test', (c, done) => {
@@ -67,7 +67,7 @@ expect(
 
     expect(done).type.toBe<(reason?: string | Error) => void>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each([3, 4, 'seven'])(
     'some test',
@@ -76,7 +76,7 @@ expect(
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.each(table)('some test', (a, b, expected) => {
@@ -84,7 +84,7 @@ expect(
     expect(b).type.toBe<string | number>();
     expect(expected).type.toBe<string | number>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each(table)(
     'some test',
@@ -95,39 +95,39 @@ expect(
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.each(tupleTable)('some test', (a, b, expected, extra) => {
-    expect(a).type.toBeNumber();
-    expect(b).type.toBeNumber();
-    expect(expected).type.toBeString();
+    expect(a).type.toBe<number>();
+    expect(b).type.toBe<number>();
+    expect(expected).type.toBe<string>();
     expect(extra).type.toBe<boolean | undefined>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each(tupleTable)(
     'some test',
     (a, b, expected, extra) => {
-      expect(a).type.toBeNumber();
-      expect(b).type.toBeNumber();
-      expect(expected).type.toBeString();
+      expect(a).type.toBe<number>();
+      expect(b).type.toBe<number>();
+      expect(expected).type.toBe<string>();
       expect(extra).type.toBe<boolean | undefined>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.each([
     [1, 2, 'three'],
     [3, 4, 'seven'],
   ])('some test', (a, b, expected) => {
-    expect(a).type.toBeNumber();
-    expect(b).type.toBeNumber();
-    expect(expected).type.toBeString();
+    expect(a).type.toBe<number>();
+    expect(b).type.toBe<number>();
+    expect(expected).type.toBe<string>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each([
     [1, 2, 'three'],
@@ -135,13 +135,13 @@ expect(
   ])(
     'some test',
     (a, b, expected) => {
-      expect(a).type.toBeNumber();
-      expect(b).type.toBeNumber();
-      expect(expected).type.toBeString();
+      expect(a).type.toBe<number>();
+      expect(b).type.toBe<number>();
+      expect(expected).type.toBe<string>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.each([
@@ -152,7 +152,7 @@ expect(
     expect(b).type.toBe<2 | 4>();
     expect(expected).type.toBe<'three' | 'seven'>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each([
     [1, 2, 'three'],
@@ -166,18 +166,18 @@ expect(
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.each(objectTable)('some test', ({a, b, expected, extra}, done) => {
-    expect(a).type.toBeNumber();
-    expect(b).type.toBeNumber();
-    expect(expected).type.toBeString();
+    expect(a).type.toBe<number>();
+    expect(b).type.toBe<number>();
+    expect(expected).type.toBe<string>();
     expect(extra).type.toBe<boolean | undefined>();
 
     expect(done).type.toBe<(reason?: string | Error) => void>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each([
     {a: 1, b: 2, expected: 'three', extra: true},
@@ -186,16 +186,16 @@ expect(
   ])(
     'some test',
     ({a, b, expected, extra}, done) => {
-      expect(a).type.toBeNumber();
-      expect(b).type.toBeNumber();
-      expect(expected).type.toBeString();
+      expect(a).type.toBe<number>();
+      expect(b).type.toBe<number>();
+      expect(expected).type.toBe<string>();
       expect(extra).type.toBe<boolean | undefined>();
 
       expect(done).type.toBe<(reason?: string | Error) => void>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.each`
@@ -204,13 +204,13 @@ expect(
     ${1} | ${2} | ${3}
     ${2} | ${1} | ${3}
   `('some test', ({a, b, expected}, done) => {
-    expect(a).type.toBeNumber();
-    expect(b).type.toBeNumber();
-    expect(expected).type.toBeNumber();
+    expect(a).type.toBe<number>();
+    expect(b).type.toBe<number>();
+    expect(expected).type.toBe<number>();
 
     expect(done).type.toBe<(reason?: string | Error) => void>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each`
     item   | expected
@@ -220,19 +220,19 @@ expect(
     expect(item).type.toBe<string | boolean>();
     expect(expected).type.toBe<string | boolean>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each<{item: string; expected: boolean}>`
     item   | expected
     ${'a'} | ${true}
     ${'b'} | ${false}
   `('some test', ({item, expected}, done) => {
-    expect(item).type.toBeString();
-    expect(expected).type.toBeBoolean();
+    expect(item).type.toBe<string>();
+    expect(expected).type.toBe<boolean>();
 
     expect(done).type.toBe<(reason?: string | Error) => void>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each`
     a    | b    | expected
@@ -242,13 +242,13 @@ expect(
   `(
     'some test',
     ({a, b, expected}) => {
-      expect(a).type.toBeNumber();
-      expect(b).type.toBeNumber();
-      expect(expected).type.toBeNumber();
+      expect(a).type.toBe<number>();
+      expect(b).type.toBe<number>();
+      expect(expected).type.toBe<number>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each`
     item   | expected
@@ -262,7 +262,7 @@ expect(
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each<{item: string; expected: boolean}>`
     item   | expected
@@ -271,12 +271,12 @@ expect(
   `(
     'some test',
     ({item, expected}) => {
-      expect(item).type.toBeString();
-      expect(expected).type.toBeBoolean();
+      expect(item).type.toBe<string>();
+      expect(expected).type.toBe<boolean>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(test.each()).type.toRaiseError();
 expect(test.each('abc')).type.toRaiseError();
@@ -289,24 +289,24 @@ expect(test.skip.each).type.toBe(test.each);
 
 expect(
   test.concurrent.each(list)('some test', async a => {
-    expect(a).type.toBeNumber();
+    expect(a).type.toBe<number>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.concurrent.each(list)(
     'some test',
     async a => {
-      expect(a).type.toBeNumber();
+      expect(a).type.toBe<number>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.concurrent.each(tupleList)('some test', async b => {
     expect(b).type.toBe<'one' | 'two' | 'three'>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.concurrent.each(tupleList)(
     'some test',
@@ -315,13 +315,13 @@ expect(
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.concurrent.each([3, 4, 'seven'])('some test', async c => {
     expect(c).type.toBe<string | number>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.concurrent.each([3, 4, 'seven'])(
     'some test',
@@ -330,7 +330,7 @@ expect(
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.concurrent.each(table)('some test', async (a, b, expected) => {
@@ -338,7 +338,7 @@ expect(
     expect(b).type.toBe<string | number>();
     expect(expected).type.toBe<string | number>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.concurrent.each(table)(
     'some test',
@@ -349,31 +349,31 @@ expect(
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.concurrent.each(tupleTable)(
     'some test',
     async (a, b, expected, extra) => {
-      expect(a).type.toBeNumber();
-      expect(b).type.toBeNumber();
-      expect(expected).type.toBeString();
+      expect(a).type.toBe<number>();
+      expect(b).type.toBe<number>();
+      expect(expected).type.toBe<string>();
       expect(extra).type.toBe<boolean | undefined>();
     },
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.concurrent.each(tupleTable)(
     'some test',
     async (a, b, expected, extra) => {
-      expect(a).type.toBeNumber();
-      expect(b).type.toBeNumber();
-      expect(expected).type.toBeString();
+      expect(a).type.toBe<number>();
+      expect(b).type.toBe<number>();
+      expect(expected).type.toBe<string>();
       expect(extra).type.toBe<boolean | undefined>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.concurrent.each`
@@ -382,11 +382,11 @@ expect(
     ${1} | ${2} | ${3}
     ${2} | ${1} | ${3}
   `('some test', async ({a, b, expected}) => {
-    expect(a).type.toBeNumber();
-    expect(b).type.toBeNumber();
-    expect(expected).type.toBeNumber();
+    expect(a).type.toBe<number>();
+    expect(b).type.toBe<number>();
+    expect(expected).type.toBe<number>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.concurrent.each`
     item   | expected
@@ -396,17 +396,17 @@ expect(
     expect(item).type.toBe<string | boolean>();
     expect(expected).type.toBe<string | boolean>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.concurrent.each<{item: string; expected: boolean}>`
     item   | expected
     ${'a'} | ${true}
     ${'b'} | ${false}
   `('some test', async ({item, expected}) => {
-    expect(item).type.toBeString();
-    expect(expected).type.toBeBoolean();
+    expect(item).type.toBe<string>();
+    expect(expected).type.toBe<boolean>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.concurrent.each`
     a    | b    | expected
@@ -416,13 +416,13 @@ expect(
   `(
     'some test',
     async ({a, b, expected}) => {
-      expect(a).type.toBeNumber();
-      expect(b).type.toBeNumber();
-      expect(expected).type.toBeNumber();
+      expect(a).type.toBe<number>();
+      expect(b).type.toBe<number>();
+      expect(expected).type.toBe<number>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   test.each`
@@ -437,7 +437,7 @@ expect(
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   test.each<{item: string; expected: boolean}>`
     item   | expected
@@ -446,12 +446,12 @@ expect(
   `(
     'some test',
     ({item, expected}) => {
-      expect(item).type.toBeString();
-      expect(expected).type.toBeBoolean();
+      expect(item).type.toBe<string>();
+      expect(expected).type.toBe<boolean>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(test.concurrent.each()).type.toRaiseError();
 expect(test.concurrent.each('abc')).type.toRaiseError();
@@ -464,24 +464,24 @@ expect(test.concurrent.skip.each).type.toBe(test.concurrent.each);
 
 expect(
   describe.each(list)('describe each', a => {
-    expect(a).type.toBeNumber();
+    expect(a).type.toBe<number>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   describe.each(list)(
     'describe each',
     a => {
-      expect(a).type.toBeNumber();
+      expect(a).type.toBe<number>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   describe.each(tupleList)('describe each', b => {
     expect(b).type.toBe<'one' | 'two' | 'three'>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   describe.each(tupleList)(
     'describe each',
@@ -490,13 +490,13 @@ expect(
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   describe.each([3, 4, 'seven'])('describe each', c => {
     expect(c).type.toBe<string | number>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   describe.each([3, 4, 'seven'])(
     'describe each',
@@ -505,7 +505,7 @@ expect(
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   describe.each(table)('describe each', (a, b, expected) => {
@@ -513,7 +513,7 @@ expect(
     expect(b).type.toBe<string | number>();
     expect(expected).type.toBe<string | number>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   describe.each(table)(
     'describe each',
@@ -524,39 +524,39 @@ expect(
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   describe.each(tupleTable)('describe each', (a, b, expected, extra) => {
-    expect(a).type.toBeNumber();
-    expect(b).type.toBeNumber();
-    expect(expected).type.toBeString();
+    expect(a).type.toBe<number>();
+    expect(b).type.toBe<number>();
+    expect(expected).type.toBe<string>();
     expect(extra).type.toBe<boolean | undefined>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   describe.each(tupleTable)(
     'describe each',
     (a, b, expected, extra) => {
-      expect(a).type.toBeNumber();
-      expect(b).type.toBeNumber();
-      expect(expected).type.toBeString();
+      expect(a).type.toBe<number>();
+      expect(b).type.toBe<number>();
+      expect(expected).type.toBe<string>();
       expect(extra).type.toBe<boolean | undefined>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   describe.each([
     [1, 2, 'three'],
     [3, 4, 'seven'],
   ])('describe each', (a, b, expected) => {
-    expect(a).type.toBeNumber();
-    expect(b).type.toBeNumber();
-    expect(expected).type.toBeString();
+    expect(a).type.toBe<number>();
+    expect(b).type.toBe<number>();
+    expect(expected).type.toBe<string>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   describe.each([
     [1, 2, 'three'],
@@ -564,13 +564,13 @@ expect(
   ])(
     'describe each',
     (a, b, expected) => {
-      expect(a).type.toBeNumber();
-      expect(b).type.toBeNumber();
-      expect(expected).type.toBeString();
+      expect(a).type.toBe<number>();
+      expect(b).type.toBe<number>();
+      expect(expected).type.toBe<string>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   describe.each([
@@ -581,7 +581,7 @@ expect(
     expect(b).type.toBe<2 | 4>();
     expect(expected).type.toBe<'three' | 'seven'>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   describe.each([
     [1, 2, 'three'],
@@ -595,16 +595,16 @@ expect(
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   describe.each(objectTable)('describe each', ({a, b, expected, extra}) => {
-    expect(a).type.toBeNumber();
-    expect(b).type.toBeNumber();
-    expect(expected).type.toBeString();
+    expect(a).type.toBe<number>();
+    expect(b).type.toBe<number>();
+    expect(expected).type.toBe<string>();
     expect(extra).type.toBe<boolean | undefined>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   describe.each([
     {a: 1, b: 2, expected: 'three', extra: true},
@@ -613,14 +613,14 @@ expect(
   ])(
     'describe each',
     ({a, b, expected, extra}) => {
-      expect(a).type.toBeNumber();
-      expect(b).type.toBeNumber();
-      expect(expected).type.toBeString();
+      expect(a).type.toBe<number>();
+      expect(b).type.toBe<number>();
+      expect(expected).type.toBe<string>();
       expect(extra).type.toBe<boolean | undefined>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   describe.each`
@@ -629,11 +629,11 @@ expect(
     ${1} | ${2} | ${3}
     ${2} | ${1} | ${3}
   `('describe each', ({a, b, expected}) => {
-    expect(a).type.toBeNumber();
-    expect(b).type.toBeNumber();
-    expect(expected).type.toBeNumber();
+    expect(a).type.toBe<number>();
+    expect(b).type.toBe<number>();
+    expect(expected).type.toBe<number>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   describe.each<{
     a: number;
@@ -645,11 +645,11 @@ expect(
     ${1} | ${2} | ${3}
     ${2} | ${1} | ${3}
   `('describe each', ({a, b, expected}) => {
-    expect(a).type.toBeNumber();
-    expect(b).type.toBeNumber();
-    expect(expected).type.toBeString();
+    expect(a).type.toBe<number>();
+    expect(b).type.toBe<number>();
+    expect(expected).type.toBe<string>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   describe.each`
     a    | b    | expected
@@ -659,13 +659,13 @@ expect(
   `(
     'describe each',
     ({a, b, expected}) => {
-      expect(a).type.toBeNumber();
-      expect(b).type.toBeNumber();
-      expect(expected).type.toBeNumber();
+      expect(a).type.toBe<number>();
+      expect(b).type.toBe<number>();
+      expect(expected).type.toBe<number>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   describe.each<{
     a: number;
@@ -679,13 +679,13 @@ expect(
   `(
     'describe each',
     ({a, b, expected}) => {
-      expect(a).type.toBeNumber();
-      expect(b).type.toBeNumber();
-      expect(expected).type.toBeString();
+      expect(a).type.toBe<number>();
+      expect(b).type.toBe<number>();
+      expect(expected).type.toBe<string>();
     },
     1000,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(describe.each()).type.toRaiseError();
 expect(describe.each('abc')).type.toRaiseError();

--- a/packages/jest-types/__typetests__/expect/base.test.ts
+++ b/packages/jest-types/__typetests__/expect/base.test.ts
@@ -12,7 +12,7 @@ import type * as jestMatcherUtils from 'jest-matcher-utils';
 
 // asymmetric matchers
 
-expect(jestExpect('value').toEqual(jestExpect.any(String))).type.toBeVoid();
+expect(jestExpect('value').toEqual(jestExpect.any(String))).type.toBe<void>();
 expect(jestExpect(123).toEqual(jestExpect.any())).type.toRaiseError();
 expect(jestExpect.not).type.not.toHaveProperty('any');
 
@@ -20,7 +20,7 @@ expect(jestExpect.not).type.not.toHaveProperty('anything');
 
 expect(
   jestExpect(['A', 'B']).toEqual(jestExpect.arrayContaining(['A'])),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(['A']).toEqual(jestExpect.arrayContaining('A')),
 ).type.toRaiseError();
@@ -29,7 +29,7 @@ expect(
 ).type.toRaiseError();
 expect(
   jestExpect(['B']).toEqual(jestExpect.not.arrayContaining(['A'])),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(['A']).toEqual(jestExpect.not.arrayContaining('A')),
 ).type.toRaiseError();
@@ -37,10 +37,12 @@ expect(
   jestExpect(['A']).toEqual(jestExpect.not.arrayContaining()),
 ).type.toRaiseError();
 
-expect(jestExpect(0.1 + 0.2).toEqual(jestExpect.closeTo(0.3))).type.toBeVoid();
+expect(
+  jestExpect(0.1 + 0.2).toEqual(jestExpect.closeTo(0.3)),
+).type.toBe<void>();
 expect(
   jestExpect(0.1 + 0.2).toEqual(jestExpect.closeTo(0.3, 5)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(0.1 + 0.2).toEqual(jestExpect.closeTo('three')),
 ).type.toRaiseError();
@@ -50,10 +52,10 @@ expect(
 expect(jestExpect(0.1 + 0.2).toEqual(jestExpect.closeTo())).type.toRaiseError();
 expect(
   jestExpect(0.1 + 0.2).toEqual(jestExpect.not.closeTo(0.3)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(0.1 + 0.2).toEqual(jestExpect.not.closeTo(0.3, 5)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(0.1 + 0.2).toEqual(jestExpect.not.closeTo('three')),
 ).type.toRaiseError();
@@ -66,7 +68,7 @@ expect(
 
 expect(
   jestExpect({a: 1}).toEqual(jestExpect.objectContaining({a: 1})),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect({a: 1}).toEqual(jestExpect.objectContaining(1)),
 ).type.toRaiseError();
@@ -75,7 +77,7 @@ expect(
 ).type.toRaiseError();
 expect(
   jestExpect({b: 2}).toEqual(jestExpect.not.objectContaining({a: 1})),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect({a: 1}).toEqual(jestExpect.not.objectContaining(1)),
 ).type.toRaiseError();
@@ -85,7 +87,7 @@ expect(
 
 expect(
   jestExpect('one').toEqual(jestExpect.stringContaining('n')),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect('two').toEqual(jestExpect.stringContaining(2)),
 ).type.toRaiseError();
@@ -94,7 +96,7 @@ expect(
 ).type.toRaiseError();
 expect(
   jestExpect('one').toEqual(jestExpect.not.stringContaining('m')),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect('two').toEqual(jestExpect.not.stringContaining(2)),
 ).type.toRaiseError();
@@ -104,7 +106,7 @@ expect(
 
 expect(
   jestExpect('one').toEqual(jestExpect.stringMatching(/^[No]ne/)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect('one').toEqual(jestExpect.stringMatching(2)),
 ).type.toRaiseError();
@@ -113,7 +115,7 @@ expect(
 ).type.toRaiseError();
 expect(
   jestExpect('two').toEqual(jestExpect.not.stringMatching(/^[No]ne/)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect('two').toEqual(jestExpect.not.stringMatching(1)),
 ).type.toRaiseError();
@@ -123,10 +125,10 @@ expect(
 
 // modifiers and utilities
 
-expect(jestExpect.assertions(2)).type.toBeVoid();
+expect(jestExpect.assertions(2)).type.toBe<void>();
 expect(jestExpect.assertions()).type.toRaiseError();
 
-expect(jestExpect.hasAssertions()).type.toBeVoid();
+expect(jestExpect.hasAssertions()).type.toBe<void>();
 expect(jestExpect.hasAssertions(true)).type.toRaiseError();
 
 expect(jestExpect(Promise.resolve('lemon')).resolves.toBe('lemon')).type.toBe<
@@ -167,12 +169,12 @@ expect(jestExpect(1).rejects.not).type.not.toHaveProperty('rejects');
 
 // equality and relational matchers
 
-expect(jestExpect(2).toBe(2)).type.toBeVoid();
-expect(jestExpect('three').not.toBe('four')).type.toBeVoid();
+expect(jestExpect(2).toBe(2)).type.toBe<void>();
+expect(jestExpect('three').not.toBe('four')).type.toBe<void>();
 expect(jestExpect(false).toBe()).type.toRaiseError();
 
-expect(jestExpect(0.2 + 0.1).toBeCloseTo(0.3)).type.toBeVoid();
-expect(jestExpect(0.2 + 0.1).toBeCloseTo(0.3, 5)).type.toBeVoid();
+expect(jestExpect(0.2 + 0.1).toBeCloseTo(0.3)).type.toBe<void>();
+expect(jestExpect(0.2 + 0.1).toBeCloseTo(0.3, 5)).type.toBe<void>();
 expect(jestExpect(0.2 + 0.1).toBeCloseTo()).type.toRaiseError();
 expect(jestExpect(0.2 + 0.1).toBeCloseTo('three')).type.toRaiseError();
 expect(
@@ -180,151 +182,155 @@ expect(
 ).type.toRaiseError();
 expect(jestExpect(0.2 + 0.1).toBeCloseTo(0.3, false)).type.toRaiseError();
 
-expect(jestExpect('value').toBeDefined()).type.toBeVoid();
+expect(jestExpect('value').toBeDefined()).type.toBe<void>();
 expect(jestExpect(true).not.toBeDefined(false)).type.toRaiseError();
 
-expect(jestExpect(0).toBeFalsy()).type.toBeVoid();
+expect(jestExpect(0).toBeFalsy()).type.toBe<void>();
 expect(jestExpect(true).not.toBeFalsy(true)).type.toRaiseError();
 
-expect(jestExpect(10).toBeGreaterThan(5)).type.toBeVoid();
-expect(jestExpect(BigInt(5.65)).toBeGreaterThan(BigInt(5.61))).type.toBeVoid();
+expect(jestExpect(10).toBeGreaterThan(5)).type.toBe<void>();
+expect(
+  jestExpect(BigInt(5.65)).toBeGreaterThan(BigInt(5.61)),
+).type.toBe<void>();
 expect(jestExpect(10).toBeGreaterThan()).type.toRaiseError();
 expect(jestExpect(10).toBeGreaterThan('1')).type.toRaiseError();
 
-expect(jestExpect(10).toBeGreaterThanOrEqual(5)).type.toBeVoid();
+expect(jestExpect(10).toBeGreaterThanOrEqual(5)).type.toBe<void>();
 expect(
   jestExpect(BigInt(5.65)).toBeGreaterThanOrEqual(BigInt(5.61)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(jestExpect(10).toBeGreaterThanOrEqual()).type.toRaiseError();
 expect(jestExpect(10).toBeGreaterThanOrEqual('1')).type.toRaiseError();
 
-expect(jestExpect(5).toBeLessThan(10)).type.toBeVoid();
-expect(jestExpect(BigInt(5.61)).toBeLessThan(BigInt(5.65))).type.toBeVoid();
+expect(jestExpect(5).toBeLessThan(10)).type.toBe<void>();
+expect(jestExpect(BigInt(5.61)).toBeLessThan(BigInt(5.65))).type.toBe<void>();
 expect(jestExpect(1).toBeLessThan()).type.toRaiseError();
 expect(jestExpect(1).toBeLessThan('10')).type.toRaiseError();
 
-expect(jestExpect(5).toBeLessThanOrEqual(10)).type.toBeVoid();
+expect(jestExpect(5).toBeLessThanOrEqual(10)).type.toBe<void>();
 expect(
   jestExpect(BigInt(5.61)).toBeLessThanOrEqual(BigInt(5.65)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(jestExpect(1).toBeLessThanOrEqual()).type.toRaiseError();
 expect(jestExpect(1).toBeLessThanOrEqual('10')).type.toRaiseError();
 
-expect(jestExpect(() => {}).toBeInstanceOf(Function)).type.toBeVoid();
+expect(jestExpect(() => {}).toBeInstanceOf(Function)).type.toBe<void>();
 expect(jestExpect(() => {}).toBeInstanceOf()).type.toRaiseError();
 
-expect(jestExpect(Number('ten')).toBeNaN()).type.toBeVoid();
+expect(jestExpect(Number('ten')).toBeNaN()).type.toBe<void>();
 expect(jestExpect(Number('10')).not.toBeNaN(true)).type.toRaiseError();
 
-expect(jestExpect(null).toBeNull()).type.toBeVoid();
+expect(jestExpect(null).toBeNull()).type.toBe<void>();
 expect(jestExpect('not null').not.toBeNull(true)).type.toRaiseError();
 
-expect(jestExpect('true').toBeTruthy()).type.toBeVoid();
+expect(jestExpect('true').toBeTruthy()).type.toBe<void>();
 expect(jestExpect(false).not.toBeTruthy(true)).type.toRaiseError();
 
-expect(jestExpect(undefined).toBeUndefined()).type.toBeVoid();
+expect(jestExpect(undefined).toBeUndefined()).type.toBe<void>();
 expect(jestExpect('value').not.toBeUndefined(false)).type.toRaiseError();
 
-expect(jestExpect(['lemon', 'lime']).not.toContain('orange')).type.toBeVoid();
-expect(jestExpect('citrus fruits').toContain('fruit')).type.toBeVoid();
+expect(jestExpect(['lemon', 'lime']).not.toContain('orange')).type.toBe<void>();
+expect(jestExpect('citrus fruits').toContain('fruit')).type.toBe<void>();
 
 const a = {key1: true, key2: false};
 expect(
   jestExpect([{key1: true, key2: false}]).toContainEqual(a),
-).type.toBeVoid();
+).type.toBe<void>();
 
-expect(jestExpect({a: 1, b: undefined}).toEqual({a: 1})).type.toBeVoid();
+expect(jestExpect({a: 1, b: undefined}).toEqual({a: 1})).type.toBe<void>();
 expect(jestExpect({a: 1}).toEqual()).type.toRaiseError();
 
-expect(jestExpect({a: 1, b: 2}).toStrictEqual({a: 1, b: 2})).type.toBeVoid();
+expect(jestExpect({a: 1, b: 2}).toStrictEqual({a: 1, b: 2})).type.toBe<void>();
 expect(jestExpect({a: 1}).toStrictEqual()).type.toRaiseError();
 
-expect(jestExpect([1, 2, 3]).toHaveLength(3)).type.toBeVoid();
-expect(jestExpect('abc').not.toHaveLength(5)).type.toBeVoid();
+expect(jestExpect([1, 2, 3]).toHaveLength(3)).type.toBe<void>();
+expect(jestExpect('abc').not.toHaveLength(5)).type.toBe<void>();
 expect(jestExpect('abc').toHaveLength()).type.toRaiseError();
 
 expect(
   jestExpect({kitchen: {area: 20}}).toHaveProperty('kitchen.area', 20),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect({kitchen: {area: 20}}).not.toHaveProperty(['kitchen', 'color']),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(jestExpect({kitchen: {area: 20}}).toHaveProperty()).type.toRaiseError();
 expect(
   jestExpect({kitchen: {area: 20}}).toHaveProperty(true),
 ).type.toRaiseError();
 
-expect(jestExpect('grapefruits').toMatch(/fruit/)).type.toBeVoid();
-expect(jestExpect('grapefruits').toMatch('fruit')).type.toBeVoid();
+expect(jestExpect('grapefruits').toMatch(/fruit/)).type.toBe<void>();
+expect(jestExpect('grapefruits').toMatch('fruit')).type.toBe<void>();
 expect(jestExpect('grapefruits').toMatch(true)).type.toRaiseError();
 
-expect(jestExpect({a: 1, b: 2}).toMatchObject({b: 2})).type.toBeVoid();
+expect(jestExpect({a: 1, b: 2}).toMatchObject({b: 2})).type.toBe<void>();
 expect(
   jestExpect([{a: 1}, {b: 2, c: true}]).toMatchObject([{a: 1}, {b: 2}]),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(jestExpect({c: true}).toMatchObject(true)).type.toRaiseError();
 expect(jestExpect({c: true}).toMatchObject()).type.toRaiseError();
 
 // error matchers
 
-expect(jestExpect(() => {}).toThrow()).type.toBeVoid();
-expect(jestExpect(() => {}).toThrow(/error/)).type.toBeVoid();
-expect(jestExpect(() => {}).toThrow('error')).type.toBeVoid();
-expect(jestExpect(() => {}).toThrow(Error)).type.toBeVoid();
-expect(jestExpect(() => {}).toThrow(new Error('error'))).type.toBeVoid();
+expect(jestExpect(() => {}).toThrow()).type.toBe<void>();
+expect(jestExpect(() => {}).toThrow(/error/)).type.toBe<void>();
+expect(jestExpect(() => {}).toThrow('error')).type.toBe<void>();
+expect(jestExpect(() => {}).toThrow(Error)).type.toBe<void>();
+expect(jestExpect(() => {}).toThrow(new Error('error'))).type.toBe<void>();
 
 // mock matchers
-expect(jestExpect(jest.fn()).toHaveBeenCalled()).type.toBeVoid();
+expect(jestExpect(jest.fn()).toHaveBeenCalled()).type.toBe<void>();
 expect(jestExpect(jest.fn()).toHaveBeenCalled(false)).type.toRaiseError();
 expect(jestExpect(jest.fn()).toHaveBeenCalled('value')).type.toRaiseError();
 
-expect(jestExpect(jest.fn()).toHaveBeenCalledTimes(3)).type.toBeVoid();
+expect(jestExpect(jest.fn()).toHaveBeenCalledTimes(3)).type.toBe<void>();
 expect(jestExpect(jest.fn()).toHaveBeenCalledTimes(true)).type.toRaiseError();
 expect(
   jestExpect(jest.fn()).toHaveBeenCalledTimes('twice'),
 ).type.toRaiseError();
 expect(jestExpect(jest.fn()).toHaveBeenCalledTimes()).type.toRaiseError();
 
-expect(jestExpect(jest.fn()).toHaveReturned()).type.toBeVoid();
+expect(jestExpect(jest.fn()).toHaveReturned()).type.toBe<void>();
 expect(jestExpect(jest.fn()).toHaveReturned('value')).type.toRaiseError();
 expect(jestExpect(jest.fn()).toHaveReturned(false)).type.toRaiseError();
 
-expect(jestExpect(jest.fn()).toHaveReturnedTimes(3)).type.toBeVoid();
+expect(jestExpect(jest.fn()).toHaveReturnedTimes(3)).type.toBe<void>();
 expect(jestExpect(jest.fn()).toHaveReturnedTimes('twice')).type.toRaiseError();
 expect(jestExpect(jest.fn()).toHaveReturnedTimes(true)).type.toRaiseError();
 expect(jestExpect(jest.fn()).toHaveReturnedTimes()).type.toRaiseError();
 
-expect(jestExpect(jest.fn()).toHaveReturnedWith()).type.toBeVoid();
-expect(jestExpect(jest.fn()).toHaveReturnedWith('value')).type.toBeVoid();
-expect(jestExpect(jest.fn()).toHaveReturnedWith(123)).type.toBeVoid();
+expect(jestExpect(jest.fn()).toHaveReturnedWith()).type.toBe<void>();
+expect(jestExpect(jest.fn()).toHaveReturnedWith('value')).type.toBe<void>();
+expect(jestExpect(jest.fn()).toHaveReturnedWith(123)).type.toBe<void>();
 expect(
   jestExpect(jest.fn<() => string>()).toHaveReturnedWith(
     jestExpect.stringContaining('value'),
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
-expect(jestExpect(jest.fn()).toHaveLastReturnedWith()).type.toBeVoid();
-expect(jestExpect(jest.fn()).toHaveLastReturnedWith(123)).type.toBeVoid();
+expect(jestExpect(jest.fn()).toHaveLastReturnedWith()).type.toBe<void>();
+expect(jestExpect(jest.fn()).toHaveLastReturnedWith(123)).type.toBe<void>();
 expect(
   jestExpect(jest.fn<() => string>()).toHaveLastReturnedWith(
     jestExpect.stringContaining('value'),
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
-expect(jestExpect(jest.fn()).toHaveNthReturnedWith(1)).type.toBeVoid();
-expect(jestExpect(jest.fn()).toHaveNthReturnedWith(1, 'value')).type.toBeVoid();
+expect(jestExpect(jest.fn()).toHaveNthReturnedWith(1)).type.toBe<void>();
+expect(
+  jestExpect(jest.fn()).toHaveNthReturnedWith(1, 'value'),
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<() => string>()).toHaveNthReturnedWith(
     2,
     jestExpect.stringContaining('value'),
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(jestExpect(jest.fn()).toHaveNthReturnedWith()).type.toRaiseError();
 
 // snapshot matchers
 
-expect(jestExpect({a: 1}).toMatchSnapshot()).type.toBeVoid();
-expect(jestExpect({a: 1}).toMatchSnapshot('hint')).type.toBeVoid();
+expect(jestExpect({a: 1}).toMatchSnapshot()).type.toBe<void>();
+expect(jestExpect({a: 1}).toMatchSnapshot('hint')).type.toBe<void>();
 expect(jestExpect({a: 1}).toMatchSnapshot(true)).type.toRaiseError();
 
 expect(
@@ -335,7 +341,7 @@ expect(
     date: jestExpect.any(Date),
     name: jestExpect.any(String),
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   jestExpect({
@@ -348,7 +354,7 @@ expect(
     },
     'hint',
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   jestExpect({
@@ -360,10 +366,10 @@ expect(
   }),
 ).type.toRaiseError();
 
-expect(jestExpect('abc').toMatchInlineSnapshot()).type.toBeVoid();
+expect(jestExpect('abc').toMatchInlineSnapshot()).type.toBe<void>();
 expect(
   jestExpect('abc').toMatchInlineSnapshot('inline snapshot here'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(jestExpect('abc').toMatchInlineSnapshot(true)).type.toRaiseError();
 
 expect(
@@ -374,7 +380,7 @@ expect(
     date: jestExpect.any(Date),
     name: jestExpect.any(String),
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   jestExpect({
@@ -387,7 +393,7 @@ expect(
     },
     'inline snapshot here',
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   jestExpect({
@@ -399,22 +405,22 @@ expect(
   }),
 ).type.toRaiseError();
 
-expect(jestExpect(jest.fn()).toThrowErrorMatchingSnapshot()).type.toBeVoid();
+expect(jestExpect(jest.fn()).toThrowErrorMatchingSnapshot()).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toThrowErrorMatchingSnapshot('hint'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toThrowErrorMatchingSnapshot(true),
 ).type.toRaiseError();
 
 expect(
   jestExpect(jest.fn()).toThrowErrorMatchingInlineSnapshot(),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toThrowErrorMatchingInlineSnapshot(
     'inline snapshot here',
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toThrowErrorMatchingInlineSnapshot(true),
 ).type.toRaiseError();
@@ -429,7 +435,7 @@ type MatcherUtils = typeof jestMatcherUtils & {
 expect(
   jestExpect.extend({
     toBeWithinRange(actual: number, floor: number, ceiling: number) {
-      expect(this.assertionCalls).type.toBeNumber();
+      expect(this.assertionCalls).type.toBe<number>();
       expect(this.currentTestName).type.toBe<string | undefined>();
       expect(this.dontThrow).type.toBe<() => void>();
       expect(this.error).type.toBe<Error | undefined>();
@@ -437,10 +443,10 @@ expect(
       expect(this.expand).type.toBe<boolean | undefined>();
       expect(this.expectedAssertionsNumber).type.toBe<number | null>();
       expect(this.expectedAssertionsNumberError).type.toBe<Error | undefined>();
-      expect(this.isExpectingAssertions).type.toBeBoolean();
+      expect(this.isExpectingAssertions).type.toBe<boolean>();
       expect(this.isExpectingAssertionsError).type.toBe<Error | undefined>();
       expect(this.isNot).type.toBe<boolean | undefined>();
-      expect(this.numPassingAsserts).type.toBeNumber();
+      expect(this.numPassingAsserts).type.toBe<number>();
       expect(this.promise).type.toBe<string | undefined>();
       expect(this.suppressedErrors).type.toBe<Array<Error>>();
       expect(this.testPath).type.toBe<string | undefined>();
@@ -462,7 +468,7 @@ expect(
       }
     },
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 
 declare module 'expect' {
   interface AsymmetricMatchers {
@@ -473,12 +479,12 @@ declare module 'expect' {
   }
 }
 
-expect(jestExpect(100).toBeWithinRange(90, 110)).type.toBeVoid();
-expect(jestExpect(101).not.toBeWithinRange(0, 100)).type.toBeVoid();
+expect(jestExpect(100).toBeWithinRange(90, 110)).type.toBe<void>();
+expect(jestExpect(101).not.toBeWithinRange(0, 100)).type.toBe<void>();
 
 expect(
   jestExpect({apples: 6, bananas: 3}).toEqual({
     apples: jestExpect.toBeWithinRange(1, 10),
     bananas: jestExpect.not.toBeWithinRange(11, 20),
   }),
-).type.toBeVoid();
+).type.toBe<void>();

--- a/packages/jest-types/__typetests__/expect/toHaveBeenCalledWith.test.ts
+++ b/packages/jest-types/__typetests__/expect/toHaveBeenCalledWith.test.ts
@@ -21,66 +21,66 @@ export function overloaded(n?: number, sOrB?: string | boolean): void {
 
 expect(
   jestExpect(jest.fn()).toHaveBeenCalledWith(jestExpect.anything()),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toHaveBeenCalledWith(jestExpect.anything(true)),
 ).type.toRaiseError();
 
-expect(jestExpect(jest.fn()).toHaveBeenCalledWith()).type.toBeVoid();
-expect(jestExpect(jest.fn()).toHaveBeenCalledWith(123)).type.toBeVoid();
-expect(jestExpect(jest.fn()).toHaveBeenCalledWith('value')).type.toBeVoid();
+expect(jestExpect(jest.fn()).toHaveBeenCalledWith()).type.toBe<void>();
+expect(jestExpect(jest.fn()).toHaveBeenCalledWith(123)).type.toBe<void>();
+expect(jestExpect(jest.fn()).toHaveBeenCalledWith('value')).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toHaveBeenCalledWith(123, 'value'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toHaveBeenCalledWith('value', 123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(a: string, b: number) => void>()).toHaveBeenCalledWith(
     jestExpect.stringContaining('value'),
     123,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
-expect(jestExpect(jest.fn()).toHaveBeenCalledWith()).type.toBeVoid();
-expect(jestExpect(jest.fn()).toHaveBeenCalledWith(123)).type.toBeVoid();
-expect(jestExpect(jest.fn()).toHaveBeenCalledWith('value')).type.toBeVoid();
+expect(jestExpect(jest.fn()).toHaveBeenCalledWith()).type.toBe<void>();
+expect(jestExpect(jest.fn()).toHaveBeenCalledWith(123)).type.toBe<void>();
+expect(jestExpect(jest.fn()).toHaveBeenCalledWith('value')).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toHaveBeenCalledWith(123, 'value'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toHaveBeenCalledWith('value', 123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(a: string, b: number) => void>()).toHaveBeenCalledWith(
     jestExpect.stringContaining('value'),
     123,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   jestExpect(jest.fn<() => void>()).toHaveBeenCalledWith(),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<() => void>()).toHaveBeenCalledWith(123),
 ).type.toRaiseError();
 
-expect(jestExpect(() => {}).toHaveBeenCalledWith()).type.toBeVoid();
+expect(jestExpect(() => {}).toHaveBeenCalledWith()).type.toBe<void>();
 expect(jestExpect(() => {}).toHaveBeenCalledWith(123)).type.toRaiseError();
 
 expect(
   jestExpect(jest.fn<(n?: number) => void>()).toHaveBeenCalledWith(),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(n?: number) => void>()).toHaveBeenCalledWith(123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(n?: number) => void>()).toHaveBeenCalledWith('value'),
 ).type.toRaiseError();
 
 expect(
   jestExpect(jest.fn<(n: number) => void>()).toHaveBeenCalledWith(123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(n: number) => void>()).toHaveBeenCalledWith(),
 ).type.toRaiseError();
@@ -88,10 +88,12 @@ expect(
   jestExpect(jest.fn<(n: number) => void>()).toHaveBeenCalledWith('value'),
 ).type.toRaiseError();
 
-expect(jestExpect((n: number) => {}).toHaveBeenCalledWith(123)).type.toBeVoid();
+expect(
+  jestExpect((n: number) => {}).toHaveBeenCalledWith(123),
+).type.toBe<void>();
 expect(
   jestExpect((n: number) => {}).toHaveBeenCalledWith(jestExpect.any(Number)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect((n: number) => {}).toHaveBeenCalledWith(),
 ).type.toRaiseError();
@@ -101,7 +103,7 @@ expect(
 
 expect(
   jestExpect(jest.fn<(s: string) => void>()).toHaveBeenCalledWith('value'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(s: string) => void>()).toHaveBeenCalledWith(),
 ).type.toRaiseError();
@@ -114,7 +116,7 @@ expect(
     123,
     'value',
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(n: number, s: string) => void>()).toHaveBeenCalledWith(),
 ).type.toRaiseError();
@@ -147,12 +149,12 @@ expect(
     123,
     'value',
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(n: number, s?: string) => void>()).toHaveBeenCalledWith(
     123,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(n: number, s?: string) => void>()).toHaveBeenCalledWith(),
 ).type.toRaiseError();
@@ -182,16 +184,16 @@ expect(
 
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenCalledWith(),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenCalledWith(123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenCalledWith(123, 'value'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenCalledWith(123, true),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenCalledWith(123, 123),
 ).type.toRaiseError();
@@ -218,17 +220,17 @@ expect(
     jestExpect.any(String),
     jestExpect.any(String),
   ]),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name?: [string, string]) => void>(),
   ).toHaveBeenCalledWith(jestExpect.any(Date), jestExpect.any(Array)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name?: [string, string]) => void>(),
   ).toHaveBeenCalledWith(jestExpect.any(Date)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name?: [string, string]) => void>(),
@@ -249,12 +251,12 @@ expect(
   jestExpect(
     jest.fn<(date: Date, name: {foo: string}) => void>(),
   ).toHaveBeenCalledWith(jestExpect.any(Date), {foo: jestExpect.any(String)}),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: {foo: string}) => void>(),
   ).toHaveBeenCalledWith(jestExpect.any(Date), jestExpect.any(Object)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: {foo: string}) => void>(),
@@ -281,7 +283,7 @@ expect(
     jestExpect.any(String),
     [jestExpect.any(String)],
   ]),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: [string, [string]]) => void>(),
@@ -289,7 +291,7 @@ expect(
     'value',
     [jestExpect.any(String)],
   ]),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: [string, [string]]) => void>(),
@@ -297,9 +299,9 @@ expect(
     jestExpect.any(String),
     ['value'],
   ]),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: [string, [string]]) => void>(),
   ).toHaveBeenCalledWith(jestExpect.any(Date), ['value', ['value']]),
-).type.toBeVoid();
+).type.toBe<void>();

--- a/packages/jest-types/__typetests__/expect/toHaveBeenLastCalledWith.test.ts
+++ b/packages/jest-types/__typetests__/expect/toHaveBeenLastCalledWith.test.ts
@@ -9,59 +9,63 @@ import {expect} from 'tstyche';
 import {jest, expect as jestExpect} from '@jest/globals';
 import type {overloaded} from './toHaveBeenCalledWith.test';
 
-expect(jestExpect(jest.fn()).toHaveBeenLastCalledWith()).type.toBeVoid();
-expect(jestExpect(jest.fn()).toHaveBeenLastCalledWith('value')).type.toBeVoid();
-expect(jestExpect(jest.fn()).toHaveBeenLastCalledWith(123)).type.toBeVoid();
+expect(jestExpect(jest.fn()).toHaveBeenLastCalledWith()).type.toBe<void>();
+expect(
+  jestExpect(jest.fn()).toHaveBeenLastCalledWith('value'),
+).type.toBe<void>();
+expect(jestExpect(jest.fn()).toHaveBeenLastCalledWith(123)).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toHaveBeenLastCalledWith(123, 'value'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toHaveBeenLastCalledWith('value', 123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(a: string, b: number) => void>(),
   ).toHaveBeenLastCalledWith(jestExpect.stringContaining('value'), 123),
-).type.toBeVoid();
+).type.toBe<void>();
 
-expect(jestExpect(jest.fn()).toHaveBeenLastCalledWith()).type.toBeVoid();
-expect(jestExpect(jest.fn()).toHaveBeenLastCalledWith('value')).type.toBeVoid();
-expect(jestExpect(jest.fn()).toHaveBeenLastCalledWith(123)).type.toBeVoid();
+expect(jestExpect(jest.fn()).toHaveBeenLastCalledWith()).type.toBe<void>();
+expect(
+  jestExpect(jest.fn()).toHaveBeenLastCalledWith('value'),
+).type.toBe<void>();
+expect(jestExpect(jest.fn()).toHaveBeenLastCalledWith(123)).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toHaveBeenLastCalledWith(123, 'value'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toHaveBeenLastCalledWith('value', 123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(a: string, b: number) => void>(),
   ).toHaveBeenLastCalledWith(jestExpect.stringContaining('value'), 123),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(
   jestExpect(jest.fn<() => void>()).toHaveBeenLastCalledWith(),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<() => void>()).toHaveBeenLastCalledWith(1),
 ).type.toRaiseError();
 
-expect(jestExpect(() => {}).toHaveBeenLastCalledWith()).type.toBeVoid();
+expect(jestExpect(() => {}).toHaveBeenLastCalledWith()).type.toBe<void>();
 expect(jestExpect(() => {}).toHaveBeenLastCalledWith(123)).type.toRaiseError();
 
 expect(
   jestExpect(jest.fn<(n?: number) => void>()).toHaveBeenLastCalledWith(),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(n?: number) => void>()).toHaveBeenLastCalledWith(123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(n?: number) => void>()).toHaveBeenLastCalledWith('value'),
 ).type.toRaiseError();
 
 expect(
   jestExpect(jest.fn<(n: number) => void>()).toHaveBeenLastCalledWith(123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(n: number) => void>()).toHaveBeenLastCalledWith(),
 ).type.toRaiseError();
@@ -71,12 +75,12 @@ expect(
 
 expect(
   jestExpect((n: number) => {}).toHaveBeenLastCalledWith(123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect((n: number) => {}).toHaveBeenLastCalledWith(
     jestExpect.any(Number),
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect((n: number) => {}).toHaveBeenLastCalledWith(),
 ).type.toRaiseError();
@@ -86,7 +90,7 @@ expect(
 
 expect(
   jestExpect(jest.fn<(s: string) => void>()).toHaveBeenLastCalledWith('value'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(s: string) => void>()).toHaveBeenLastCalledWith(),
 ).type.toRaiseError();
@@ -98,7 +102,7 @@ expect(
   jestExpect(
     jest.fn<(n: number, s: string) => void>(),
   ).toHaveBeenLastCalledWith(123, 'value'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(n: number, s: string) => void>(),
@@ -129,12 +133,12 @@ expect(
   jestExpect(
     jest.fn<(n: number, s?: string) => void>(),
   ).toHaveBeenLastCalledWith(123, 'value'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(n: number, s?: string) => void>(),
   ).toHaveBeenLastCalledWith(123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(n: number, s?: string) => void>(),
@@ -163,19 +167,19 @@ expect(
 
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenLastCalledWith(),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenLastCalledWith(123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenLastCalledWith(
     123,
     'value',
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenLastCalledWith(123, true),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenLastCalledWith(123, 123),
 ).type.toRaiseError();
@@ -205,17 +209,17 @@ expect(
     jestExpect.any(String),
     jestExpect.any(String),
   ]),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name?: [string, string]) => void>(),
   ).toHaveBeenLastCalledWith(jestExpect.any(Date), jestExpect.any(Array)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name?: [string, string]) => void>(),
   ).toHaveBeenLastCalledWith(jestExpect.any(Date)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name?: [string, string]) => void>(),
@@ -241,12 +245,12 @@ expect(
   ).toHaveBeenLastCalledWith(jestExpect.any(Date), {
     foo: jestExpect.any(String),
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: {foo: string}) => void>(),
   ).toHaveBeenLastCalledWith(jestExpect.any(Date), jestExpect.any(Object)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: {foo: string}) => void>(),
@@ -275,7 +279,7 @@ expect(
     jestExpect.any(String),
     [jestExpect.any(String)],
   ]),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: [string, [string]]) => void>(),
@@ -283,7 +287,7 @@ expect(
     'value',
     [jestExpect.any(String)],
   ]),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: [string, [string]]) => void>(),
@@ -291,9 +295,9 @@ expect(
     jestExpect.any(String),
     ['value'],
   ]),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: [string, [string]]) => void>(),
   ).toHaveBeenLastCalledWith(jestExpect.any(Date), ['value', ['value']]),
-).type.toBeVoid();
+).type.toBe<void>();

--- a/packages/jest-types/__typetests__/expect/toHaveBeenNthCalledWith.test.ts
+++ b/packages/jest-types/__typetests__/expect/toHaveBeenNthCalledWith.test.ts
@@ -9,56 +9,56 @@ import {expect} from 'tstyche';
 import {jest, expect as jestExpect} from '@jest/globals';
 import type {overloaded} from './toHaveBeenCalledWith.test';
 
-expect(jestExpect(jest.fn()).toHaveBeenNthCalledWith(2)).type.toBeVoid();
+expect(jestExpect(jest.fn()).toHaveBeenNthCalledWith(2)).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toHaveBeenNthCalledWith(1, 'value'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toHaveBeenNthCalledWith(1, 'value', 123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(a: string, b: number) => void>()).toHaveBeenNthCalledWith(
     1,
     jestExpect.stringContaining('value'),
     123,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(jestExpect(jest.fn()).toHaveBeenNthCalledWith()).type.toRaiseError();
 
-expect(jestExpect(jest.fn()).toHaveBeenNthCalledWith(2)).type.toBeVoid();
+expect(jestExpect(jest.fn()).toHaveBeenNthCalledWith(2)).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toHaveBeenNthCalledWith(1, 'value'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn()).toHaveBeenNthCalledWith(1, 'value', 123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(a: string, b: number) => void>()).toHaveBeenNthCalledWith(
     1,
     jestExpect.stringContaining('value'),
     123,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(jestExpect(jest.fn()).toHaveBeenNthCalledWith()).type.toRaiseError();
 
 expect(
   jestExpect(jest.fn<() => void>()).toHaveBeenNthCalledWith(1),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<() => void>()).toHaveBeenNthCalledWith(1, 123),
 ).type.toRaiseError();
 
-expect(jestExpect(() => {}).toHaveBeenNthCalledWith(1)).type.toBeVoid();
+expect(jestExpect(() => {}).toHaveBeenNthCalledWith(1)).type.toBe<void>();
 expect(
   jestExpect(() => {}).toHaveBeenNthCalledWith(1, 123),
 ).type.toRaiseError();
 
 expect(
   jestExpect(jest.fn<(n?: number) => void>()).toHaveBeenNthCalledWith(1),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(n?: number) => void>()).toHaveBeenNthCalledWith(1, 123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(n?: number) => void>()).toHaveBeenNthCalledWith(
     1,
@@ -68,7 +68,7 @@ expect(
 
 expect(
   jestExpect(jest.fn<(n: number) => void>()).toHaveBeenNthCalledWith(1, 123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(n: number) => void>()).toHaveBeenNthCalledWith(1),
 ).type.toRaiseError();
@@ -81,13 +81,13 @@ expect(
 
 expect(
   jestExpect((n: number) => {}).toHaveBeenNthCalledWith(1, 123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect((n: number) => {}).toHaveBeenNthCalledWith(
     1,
     jestExpect.any(Number),
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect((n: number) => {}).toHaveBeenNthCalledWith(1),
 ).type.toRaiseError();
@@ -100,7 +100,7 @@ expect(
     1,
     'value',
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(s: string) => void>()).toHaveBeenNthCalledWith(1),
 ).type.toRaiseError();
@@ -114,7 +114,7 @@ expect(
     123,
     'value',
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<(n: number, s: string) => void>()).toHaveBeenNthCalledWith(
     1,
@@ -152,12 +152,12 @@ expect(
   jestExpect(
     jest.fn<(n: number, s?: string) => void>(),
   ).toHaveBeenNthCalledWith(1, 123, 'value'),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(n: number, s?: string) => void>(),
   ).toHaveBeenNthCalledWith(1, 123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(n: number, s?: string) => void>(),
@@ -186,24 +186,24 @@ expect(
 
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenNthCalledWith(1),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenNthCalledWith(1, 123),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenNthCalledWith(
     1,
     123,
     'value',
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenNthCalledWith(
     1,
     123,
     true,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(jest.fn<typeof overloaded>()).toHaveBeenNthCalledWith(1, 123, 123),
 ).type.toRaiseError();
@@ -235,17 +235,17 @@ expect(
     jestExpect.any(String),
     jestExpect.any(String),
   ]),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name?: [string, string]) => void>(),
   ).toHaveBeenNthCalledWith(1, jestExpect.any(Date), jestExpect.any(Array)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name?: [string, string]) => void>(),
   ).toHaveBeenNthCalledWith(1, jestExpect.any(Date)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name?: [string, string]) => void>(),
@@ -271,12 +271,12 @@ expect(
   ).toHaveBeenNthCalledWith(1, jestExpect.any(Date), {
     foo: jestExpect.any(String),
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: {foo: string}) => void>(),
   ).toHaveBeenNthCalledWith(1, jestExpect.any(Date), jestExpect.any(Object)),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: {foo: string}) => void>(),
@@ -305,7 +305,7 @@ expect(
     jestExpect.any(String),
     [jestExpect.any(String)],
   ]),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: [string, [string]]) => void>(),
@@ -313,7 +313,7 @@ expect(
     'value',
     [jestExpect.any(String)],
   ]),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: [string, [string]]) => void>(),
@@ -321,9 +321,9 @@ expect(
     jestExpect.any(String),
     ['value'],
   ]),
-).type.toBeVoid();
+).type.toBe<void>();
 expect(
   jestExpect(
     jest.fn<(date: Date, name: [string, [string]]) => void>(),
   ).toHaveBeenNthCalledWith(1, jestExpect.any(Date), ['value', ['value']]),
-).type.toBeVoid();
+).type.toBe<void>();

--- a/packages/jest-types/__typetests__/globals.test.ts
+++ b/packages/jest-types/__typetests__/globals.test.ts
@@ -52,23 +52,23 @@ test(testName, done => {
 
 // beforeAll
 
-expect(beforeAll(fn)).type.toBeVoid();
-expect(beforeAll(asyncFn)).type.toBeVoid();
-expect(beforeAll(genFn)).type.toBeVoid();
+expect(beforeAll(fn)).type.toBe<void>();
+expect(beforeAll(asyncFn)).type.toBe<void>();
+expect(beforeAll(genFn)).type.toBe<void>();
 expect(
   beforeAll(done => {
     expect(done).type.toBe<Global.DoneFn>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 
-expect(beforeAll(fn, timeout)).type.toBeVoid();
-expect(beforeAll(asyncFn, timeout)).type.toBeVoid();
-expect(beforeAll(genFn, timeout)).type.toBeVoid();
+expect(beforeAll(fn, timeout)).type.toBe<void>();
+expect(beforeAll(asyncFn, timeout)).type.toBe<void>();
+expect(beforeAll(genFn, timeout)).type.toBe<void>();
 expect(
   beforeAll(done => {
     expect(done).type.toBe<Global.DoneFn>();
   }, timeout),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(beforeAll()).type.toRaiseError();
 expect(beforeAll('abc')).type.toRaiseError();
@@ -86,23 +86,23 @@ expect(
 
 // beforeEach
 
-expect(beforeEach(fn)).type.toBeVoid();
-expect(beforeEach(asyncFn)).type.toBeVoid();
-expect(beforeEach(genFn)).type.toBeVoid();
+expect(beforeEach(fn)).type.toBe<void>();
+expect(beforeEach(asyncFn)).type.toBe<void>();
+expect(beforeEach(genFn)).type.toBe<void>();
 expect(
   beforeEach(done => {
     expect(done).type.toBe<Global.DoneFn>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 
-expect(beforeEach(fn, timeout)).type.toBeVoid();
-expect(beforeEach(asyncFn, timeout)).type.toBeVoid();
-expect(beforeEach(genFn, timeout)).type.toBeVoid();
+expect(beforeEach(fn, timeout)).type.toBe<void>();
+expect(beforeEach(asyncFn, timeout)).type.toBe<void>();
+expect(beforeEach(genFn, timeout)).type.toBe<void>();
 expect(
   beforeEach(done => {
     expect(done).type.toBe<Global.DoneFn>();
   }, timeout),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(beforeEach()).type.toRaiseError();
 expect(beforeEach('abc')).type.toRaiseError();
@@ -120,23 +120,23 @@ expect(
 
 // afterAll
 
-expect(afterAll(fn)).type.toBeVoid();
-expect(afterAll(asyncFn)).type.toBeVoid();
-expect(afterAll(genFn)).type.toBeVoid();
+expect(afterAll(fn)).type.toBe<void>();
+expect(afterAll(asyncFn)).type.toBe<void>();
+expect(afterAll(genFn)).type.toBe<void>();
 expect(
   afterAll(done => {
     expect(done).type.toBe<Global.DoneFn>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 
-expect(afterAll(fn, timeout)).type.toBeVoid();
-expect(afterAll(asyncFn, timeout)).type.toBeVoid();
-expect(afterAll(genFn, timeout)).type.toBeVoid();
+expect(afterAll(fn, timeout)).type.toBe<void>();
+expect(afterAll(asyncFn, timeout)).type.toBe<void>();
+expect(afterAll(genFn, timeout)).type.toBe<void>();
 expect(
   afterAll(done => {
     expect(done).type.toBe<Global.DoneFn>();
   }, timeout),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(afterAll()).type.toRaiseError();
 expect(afterAll('abc')).type.toRaiseError();
@@ -154,23 +154,23 @@ expect(
 
 // afterEach
 
-expect(afterEach(fn)).type.toBeVoid();
-expect(afterEach(asyncFn)).type.toBeVoid();
-expect(afterEach(genFn)).type.toBeVoid();
+expect(afterEach(fn)).type.toBe<void>();
+expect(afterEach(asyncFn)).type.toBe<void>();
+expect(afterEach(genFn)).type.toBe<void>();
 expect(
   afterEach(done => {
     expect(done).type.toBe<Global.DoneFn>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 
-expect(afterEach(fn, timeout)).type.toBeVoid();
-expect(afterEach(asyncFn, timeout)).type.toBeVoid();
-expect(afterEach(genFn, timeout)).type.toBeVoid();
+expect(afterEach(fn, timeout)).type.toBe<void>();
+expect(afterEach(asyncFn, timeout)).type.toBe<void>();
+expect(afterEach(genFn, timeout)).type.toBe<void>();
 expect(
   afterEach(done => {
     expect(done).type.toBe<Global.DoneFn>();
   }, timeout),
-).type.toBeVoid();
+).type.toBe<void>();
 
 expect(afterEach()).type.toRaiseError();
 expect(afterEach('abc')).type.toRaiseError();
@@ -188,18 +188,18 @@ expect(
 
 // test
 
-expect(test(testName, fn)).type.toBeVoid();
-expect(test(testName, asyncFn)).type.toBeVoid();
-expect(test(testName, genFn)).type.toBeVoid();
+expect(test(testName, fn)).type.toBe<void>();
+expect(test(testName, asyncFn)).type.toBe<void>();
+expect(test(testName, genFn)).type.toBe<void>();
 expect(
   test(testName, done => {
     expect(done).type.toBe<Global.DoneFn>();
   }),
-).type.toBeVoid();
+).type.toBe<void>();
 
-expect(test(testName, fn, timeout)).type.toBeVoid();
-expect(test(testName, asyncFn, timeout)).type.toBeVoid();
-expect(test(testName, genFn, timeout)).type.toBeVoid();
+expect(test(testName, fn, timeout)).type.toBe<void>();
+expect(test(testName, asyncFn, timeout)).type.toBe<void>();
+expect(test(testName, genFn, timeout)).type.toBe<void>();
 expect(
   test(
     testName,
@@ -208,13 +208,13 @@ expect(
     },
     timeout,
   ),
-).type.toBeVoid();
+).type.toBe<void>();
 
-expect(test(123, fn)).type.toBeVoid();
-expect(test(() => {}, fn)).type.toBeVoid();
-expect(test(function named() {}, fn)).type.toBeVoid();
-expect(test(class {}, fn)).type.toBeVoid();
-expect(test(class Named {}, fn)).type.toBeVoid();
+expect(test(123, fn)).type.toBe<void>();
+expect(test(() => {}, fn)).type.toBe<void>();
+expect(test(function named() {}, fn)).type.toBe<void>();
+expect(test(class {}, fn)).type.toBe<void>();
+expect(test(class Named {}, fn)).type.toBe<void>();
 
 expect(test()).type.toRaiseError();
 expect(test(testName)).type.toRaiseError();
@@ -234,42 +234,44 @@ expect(
 
 // test.concurrent
 
-expect(test.concurrent(testName, asyncFn)).type.toBeVoid();
-expect(test.concurrent(testName, asyncFn, timeout)).type.toBeVoid();
+expect(test.concurrent(testName, asyncFn)).type.toBe<void>();
+expect(test.concurrent(testName, asyncFn, timeout)).type.toBe<void>();
 
-expect(test.concurrent(123, asyncFn)).type.toBeVoid();
-expect(test.concurrent(() => {}, asyncFn)).type.toBeVoid();
-expect(test.concurrent(function named() {}, asyncFn)).type.toBeVoid();
-expect(test.concurrent(class {}, asyncFn)).type.toBeVoid();
-expect(test.concurrent(class Named {}, asyncFn)).type.toBeVoid();
+expect(test.concurrent(123, asyncFn)).type.toBe<void>();
+expect(test.concurrent(() => {}, asyncFn)).type.toBe<void>();
+expect(test.concurrent(function named() {}, asyncFn)).type.toBe<void>();
+expect(test.concurrent(class {}, asyncFn)).type.toBe<void>();
+expect(test.concurrent(class Named {}, asyncFn)).type.toBe<void>();
 
 expect(test.concurrent(testName, fn)).type.toRaiseError();
 
 // test.concurrent.each
 
-expect(test.concurrent.each(table)(testName, asyncFn)).type.toBeVoid();
-expect(test.concurrent.each(table)(testName, asyncFn, timeout)).type.toBeVoid();
+expect(test.concurrent.each(table)(testName, asyncFn)).type.toBe<void>();
+expect(
+  test.concurrent.each(table)(testName, asyncFn, timeout),
+).type.toBe<void>();
 
-expect(test.concurrent.each(table)(123, asyncFn)).type.toBeVoid();
-expect(test.concurrent.each(table)(() => {}, asyncFn)).type.toBeVoid();
+expect(test.concurrent.each(table)(123, asyncFn)).type.toBe<void>();
+expect(test.concurrent.each(table)(() => {}, asyncFn)).type.toBe<void>();
 expect(
   test.concurrent.each(table)(function named() {}, asyncFn),
-).type.toBeVoid();
-expect(test.concurrent.each(table)(class {}, asyncFn)).type.toBeVoid();
-expect(test.concurrent.each(table)(class Named {}, asyncFn)).type.toBeVoid();
+).type.toBe<void>();
+expect(test.concurrent.each(table)(class {}, asyncFn)).type.toBe<void>();
+expect(test.concurrent.each(table)(class Named {}, asyncFn)).type.toBe<void>();
 
 expect(test.concurrent.each(table)(testName, fn)).type.toRaiseError();
 
 // test.concurrent.failing
 
-expect(test.concurrent.failing(testName, asyncFn)).type.toBeVoid();
-expect(test.concurrent.failing(testName, asyncFn, timeout)).type.toBeVoid();
+expect(test.concurrent.failing(testName, asyncFn)).type.toBe<void>();
+expect(test.concurrent.failing(testName, asyncFn, timeout)).type.toBe<void>();
 
-expect(test.concurrent.failing(123, asyncFn)).type.toBeVoid();
-expect(test.concurrent.failing(() => {}, asyncFn)).type.toBeVoid();
-expect(test.concurrent.failing(function named() {}, asyncFn)).type.toBeVoid();
-expect(test.concurrent.failing(class {}, asyncFn)).type.toBeVoid();
-expect(test.concurrent.failing(class Named {}, asyncFn)).type.toBeVoid();
+expect(test.concurrent.failing(123, asyncFn)).type.toBe<void>();
+expect(test.concurrent.failing(() => {}, asyncFn)).type.toBe<void>();
+expect(test.concurrent.failing(function named() {}, asyncFn)).type.toBe<void>();
+expect(test.concurrent.failing(class {}, asyncFn)).type.toBe<void>();
+expect(test.concurrent.failing(class Named {}, asyncFn)).type.toBe<void>();
 
 expect(test.concurrent.failing.each).type.toBe(test.concurrent.each);
 
@@ -289,38 +291,38 @@ expect(test.concurrent.skip.failing.each).type.toBe(test.concurrent.each);
 
 // test.each
 
-expect(test.each(table)(testName, fn)).type.toBeVoid();
-expect(test.each(table)(testName, fn, timeout)).type.toBeVoid();
+expect(test.each(table)(testName, fn)).type.toBe<void>();
+expect(test.each(table)(testName, fn, timeout)).type.toBe<void>();
 
-expect(test.each(table)(123, fn)).type.toBeVoid();
-expect(test.each(table)(() => {}, fn)).type.toBeVoid();
-expect(test.each(table)(function named() {}, fn)).type.toBeVoid();
-expect(test.each(table)(class {}, fn)).type.toBeVoid();
-expect(test.each(table)(class Named {}, fn)).type.toBeVoid();
+expect(test.each(table)(123, fn)).type.toBe<void>();
+expect(test.each(table)(() => {}, fn)).type.toBe<void>();
+expect(test.each(table)(function named() {}, fn)).type.toBe<void>();
+expect(test.each(table)(class {}, fn)).type.toBe<void>();
+expect(test.each(table)(class Named {}, fn)).type.toBe<void>();
 
 // test.failing
 
-expect(test.failing(testName, fn)).type.toBeVoid();
-expect(test.failing(testName, fn, timeout)).type.toBeVoid();
+expect(test.failing(testName, fn)).type.toBe<void>();
+expect(test.failing(testName, fn, timeout)).type.toBe<void>();
 
-expect(test.failing(123, fn)).type.toBeVoid();
-expect(test.failing(() => {}, fn)).type.toBeVoid();
-expect(test.failing(function named() {}, fn)).type.toBeVoid();
-expect(test.failing(class {}, fn)).type.toBeVoid();
-expect(test.failing(class Named {}, fn)).type.toBeVoid();
+expect(test.failing(123, fn)).type.toBe<void>();
+expect(test.failing(() => {}, fn)).type.toBe<void>();
+expect(test.failing(function named() {}, fn)).type.toBe<void>();
+expect(test.failing(class {}, fn)).type.toBe<void>();
+expect(test.failing(class Named {}, fn)).type.toBe<void>();
 
 expect(test.failing.each).type.toBe(test.each);
 
 // test.only
 
-expect(test.only(testName, fn)).type.toBeVoid();
-expect(test.only(testName, fn, timeout)).type.toBeVoid();
+expect(test.only(testName, fn)).type.toBe<void>();
+expect(test.only(testName, fn, timeout)).type.toBe<void>();
 
-expect(test.only(123, fn)).type.toBeVoid();
-expect(test.only(() => {}, fn)).type.toBeVoid();
-expect(test.only(function named() {}, fn)).type.toBeVoid();
-expect(test.only(class {}, fn)).type.toBeVoid();
-expect(test.only(class Named {}, fn)).type.toBeVoid();
+expect(test.only(123, fn)).type.toBe<void>();
+expect(test.only(() => {}, fn)).type.toBe<void>();
+expect(test.only(function named() {}, fn)).type.toBe<void>();
+expect(test.only(class {}, fn)).type.toBe<void>();
+expect(test.only(class Named {}, fn)).type.toBe<void>();
 
 expect(test.only.each).type.toBe(test.each);
 expect(test.only.failing).type.toBe(test.failing);
@@ -328,14 +330,14 @@ expect(test.only.failing.each).type.toBe(test.each);
 
 // test.skip
 
-expect(test.skip(testName, fn)).type.toBeVoid();
-expect(test.skip(testName, fn, timeout)).type.toBeVoid();
+expect(test.skip(testName, fn)).type.toBe<void>();
+expect(test.skip(testName, fn, timeout)).type.toBe<void>();
 
-expect(test.skip(123, fn)).type.toBeVoid();
-expect(test.skip(() => {}, fn)).type.toBeVoid();
-expect(test.skip(function named() {}, fn)).type.toBeVoid();
-expect(test.skip(class {}, fn)).type.toBeVoid();
-expect(test.skip(class Named {}, fn)).type.toBeVoid();
+expect(test.skip(123, fn)).type.toBe<void>();
+expect(test.skip(() => {}, fn)).type.toBe<void>();
+expect(test.skip(function named() {}, fn)).type.toBe<void>();
+expect(test.skip(class {}, fn)).type.toBe<void>();
+expect(test.skip(class Named {}, fn)).type.toBe<void>();
 
 expect(test.skip.each).type.toBe(test.each);
 expect(test.skip.failing).type.toBe(test.failing);
@@ -343,68 +345,68 @@ expect(test.skip.failing.each).type.toBe(test.each);
 
 // test.todo
 
-expect(test.todo(testName)).type.toBeVoid();
+expect(test.todo(testName)).type.toBe<void>();
 
-expect(test.todo(123)).type.toBeVoid();
-expect(test.todo(() => {})).type.toBeVoid();
-expect(test.todo(function named() {})).type.toBeVoid();
-expect(test.todo(class {})).type.toBeVoid();
-expect(test.todo(class Named {})).type.toBeVoid();
+expect(test.todo(123)).type.toBe<void>();
+expect(test.todo(() => {})).type.toBe<void>();
+expect(test.todo(function named() {})).type.toBe<void>();
+expect(test.todo(class {})).type.toBe<void>();
+expect(test.todo(class Named {})).type.toBe<void>();
 
 expect(test.todo()).type.toRaiseError();
 expect(test.todo(testName, fn)).type.toRaiseError();
 
 // describe
 
-expect(describe(testName, fn)).type.toBeVoid();
+expect(describe(testName, fn)).type.toBe<void>();
 
 expect(describe()).type.toRaiseError();
 expect(describe(fn)).type.toRaiseError();
 expect(describe(testName, fn, timeout)).type.toRaiseError();
 
-expect(describe(123, fn)).type.toBeVoid();
-expect(describe(() => {}, fn)).type.toBeVoid();
-expect(describe(function named() {}, fn)).type.toBeVoid();
-expect(describe(class {}, fn)).type.toBeVoid();
-expect(describe(class Named {}, fn)).type.toBeVoid();
+expect(describe(123, fn)).type.toBe<void>();
+expect(describe(() => {}, fn)).type.toBe<void>();
+expect(describe(function named() {}, fn)).type.toBe<void>();
+expect(describe(class {}, fn)).type.toBe<void>();
+expect(describe(class Named {}, fn)).type.toBe<void>();
 
-expect(describe.each(table)(testName, fn)).type.toBeVoid();
-expect(describe.each(table)(testName, fn, timeout)).type.toBeVoid();
+expect(describe.each(table)(testName, fn)).type.toBe<void>();
+expect(describe.each(table)(testName, fn, timeout)).type.toBe<void>();
 
-expect(describe.each(table)(testName, fn)).type.toBeVoid();
-expect(describe.each(table)(123, fn)).type.toBeVoid();
-expect(describe.each(table)(() => {}, fn)).type.toBeVoid();
-expect(describe.each(table)(function named() {}, fn)).type.toBeVoid();
-expect(describe.each(table)(class Named {}, fn)).type.toBeVoid();
+expect(describe.each(table)(testName, fn)).type.toBe<void>();
+expect(describe.each(table)(123, fn)).type.toBe<void>();
+expect(describe.each(table)(() => {}, fn)).type.toBe<void>();
+expect(describe.each(table)(function named() {}, fn)).type.toBe<void>();
+expect(describe.each(table)(class Named {}, fn)).type.toBe<void>();
 
 // describe.only
 
-expect(describe.only(testName, fn)).type.toBeVoid();
+expect(describe.only(testName, fn)).type.toBe<void>();
 
 expect(describe.only()).type.toRaiseError();
 expect(describe.only(fn)).type.toRaiseError();
 expect(describe.only(testName, fn, timeout)).type.toRaiseError();
 
-expect(describe.only(123, fn)).type.toBeVoid();
-expect(describe.only(() => {}, fn)).type.toBeVoid();
-expect(describe.only(function named() {}, fn)).type.toBeVoid();
-expect(describe.only(class {}, fn)).type.toBeVoid();
-expect(describe.only(class Named {}, fn)).type.toBeVoid();
+expect(describe.only(123, fn)).type.toBe<void>();
+expect(describe.only(() => {}, fn)).type.toBe<void>();
+expect(describe.only(function named() {}, fn)).type.toBe<void>();
+expect(describe.only(class {}, fn)).type.toBe<void>();
+expect(describe.only(class Named {}, fn)).type.toBe<void>();
 
 expect(describe.only.each).type.toBe(describe.each);
 
 // describe.skip
 
-expect(describe.skip(testName, fn)).type.toBeVoid();
+expect(describe.skip(testName, fn)).type.toBe<void>();
 
 expect(describe.skip()).type.toRaiseError();
 expect(describe.skip(fn)).type.toRaiseError();
 expect(describe.skip(testName, fn, timeout)).type.toRaiseError();
 
-expect(describe.skip(123, fn)).type.toBeVoid();
-expect(describe.skip(() => {}, fn)).type.toBeVoid();
-expect(describe.skip(function named() {}, fn)).type.toBeVoid();
-expect(describe.skip(class {}, fn)).type.toBeVoid();
-expect(describe.skip(class Named {}, fn)).type.toBeVoid();
+expect(describe.skip(123, fn)).type.toBe<void>();
+expect(describe.skip(() => {}, fn)).type.toBe<void>();
+expect(describe.skip(function named() {}, fn)).type.toBe<void>();
+expect(describe.skip(class {}, fn)).type.toBe<void>();
+expect(describe.skip(class Named {}, fn)).type.toBe<void>();
 
 expect(describe.skip.each).type.toBe(describe.each);

--- a/packages/jest-types/__typetests__/jest.test.ts
+++ b/packages/jest-types/__typetests__/jest.test.ts
@@ -68,7 +68,7 @@ const someModule = {
   propertyB: 'B',
 };
 
-expect(jest.createMockFromModule('moduleName')).type.toBeUnknown();
+expect(jest.createMockFromModule('moduleName')).type.toBe<unknown>();
 expect(jest.createMockFromModule<typeof someModule>('moduleName')).type.toBe<
   Mocked<typeof someModule>
 >();
@@ -163,13 +163,13 @@ expect(
   ),
 ).type.toRaiseError();
 
-expect(jest.requireActual('./pathToModule')).type.toBeUnknown();
+expect(jest.requireActual('./pathToModule')).type.toBe<unknown>();
 expect(jest.requireActual<{some: 'module'}>('./pathToModule')).type.toBe<{
   some: 'module';
 }>();
 expect(jest.requireActual()).type.toRaiseError();
 
-expect(jest.requireMock('./pathToModule')).type.toBeUnknown();
+expect(jest.requireMock('./pathToModule')).type.toBe<unknown>();
 expect(jest.requireMock<{some: 'module'}>('./pathToModule')).type.toBe<{
   some: 'module';
 }>();
@@ -198,7 +198,7 @@ expect(jest.resetAllMocks(true)).type.toRaiseError();
 expect(jest.restoreAllMocks()).type.toBe<typeof jest>();
 expect(jest.restoreAllMocks(false)).type.toRaiseError();
 
-expect(jest.isMockFunction(() => {})).type.toBeBoolean();
+expect(jest.isMockFunction(() => {})).type.toBe<boolean>();
 expect(jest.isMockFunction()).type.toRaiseError();
 
 const maybeMock = (a: string, b: number) => true;
@@ -224,7 +224,7 @@ if (jest.isMockFunction(surelyMock)) {
 }
 
 if (!jest.isMockFunction(surelyMock)) {
-  expect(surelyMock).type.toBeNever();
+  expect(surelyMock).type.toBe<never>();
 }
 
 const spiedObject = {
@@ -245,7 +245,7 @@ if (jest.isMockFunction(surelySpy)) {
 }
 
 if (!jest.isMockFunction(surelySpy)) {
-  expect(surelySpy).type.toBeNever();
+  expect(surelySpy).type.toBe<never>();
 }
 
 declare const stringMaybeMock: string;
@@ -257,7 +257,7 @@ if (jest.isMockFunction(stringMaybeMock)) {
 }
 
 if (!jest.isMockFunction(stringMaybeMock)) {
-  expect(stringMaybeMock).type.toBeString();
+  expect(stringMaybeMock).type.toBe<string>();
 }
 
 declare const anyMaybeMock: any;
@@ -267,7 +267,7 @@ if (jest.isMockFunction(anyMaybeMock)) {
 }
 
 if (!jest.isMockFunction(anyMaybeMock)) {
-  expect(anyMaybeMock).type.toBeAny();
+  expect(anyMaybeMock).type.toBe<any>();
 }
 
 declare const unknownMaybeMock: unknown;
@@ -279,7 +279,7 @@ if (jest.isMockFunction(unknownMaybeMock)) {
 }
 
 if (!jest.isMockFunction(unknownMaybeMock)) {
-  expect(unknownMaybeMock).type.toBeUnknown();
+  expect(unknownMaybeMock).type.toBe<unknown>();
 }
 
 expect(jest.fn).type.toBe<ModuleMocker['fn']>();
@@ -535,58 +535,58 @@ expect<jest.SpiedSetter<typeof someObject.propertyC>>().type.toBeAssignableWith(
 
 // Mock Timers
 
-expect(jest.advanceTimersByTime(6000)).type.toBeVoid();
+expect(jest.advanceTimersByTime(6000)).type.toBe<void>();
 expect(jest.advanceTimersByTime()).type.toRaiseError();
 
 expect(jest.advanceTimersByTimeAsync(6000)).type.toBe<Promise<void>>();
 expect(jest.advanceTimersByTimeAsync()).type.toRaiseError();
 
-expect(jest.advanceTimersToNextTimer()).type.toBeVoid();
-expect(jest.advanceTimersToNextTimer(2)).type.toBeVoid();
+expect(jest.advanceTimersToNextTimer()).type.toBe<void>();
+expect(jest.advanceTimersToNextTimer(2)).type.toBe<void>();
 expect(jest.advanceTimersToNextTimer('2')).type.toRaiseError();
 
 expect(jest.advanceTimersToNextTimerAsync()).type.toBe<Promise<void>>();
 expect(jest.advanceTimersToNextTimerAsync(2)).type.toBe<Promise<void>>();
 expect(jest.advanceTimersToNextTimerAsync('2')).type.toRaiseError();
 
-expect(jest.clearAllTimers()).type.toBeVoid();
+expect(jest.clearAllTimers()).type.toBe<void>();
 expect(jest.clearAllTimers(false)).type.toRaiseError();
 
-expect(jest.getTimerCount()).type.toBeNumber();
+expect(jest.getTimerCount()).type.toBe<number>();
 expect(jest.getTimerCount(true)).type.toRaiseError();
 
-expect(jest.now()).type.toBeNumber();
+expect(jest.now()).type.toBe<number>();
 expect(jest.now('1995-12-17T03:24:00')).type.toRaiseError();
 
-expect(jest.getRealSystemTime()).type.toBeNumber();
+expect(jest.getRealSystemTime()).type.toBe<number>();
 expect(jest.getRealSystemTime(true)).type.toRaiseError();
 
-expect(jest.runAllImmediates()).type.toBeVoid();
+expect(jest.runAllImmediates()).type.toBe<void>();
 expect(jest.runAllImmediates(true)).type.toRaiseError();
 
-expect(jest.runAllTicks()).type.toBeVoid();
+expect(jest.runAllTicks()).type.toBe<void>();
 expect(jest.runAllTicks(true)).type.toRaiseError();
 
-expect(jest.runAllTimers()).type.toBeVoid();
+expect(jest.runAllTimers()).type.toBe<void>();
 expect(jest.runAllTimers(false)).type.toRaiseError();
 
 expect(jest.runAllTimersAsync()).type.toBe<Promise<void>>();
 expect(jest.runAllTimersAsync(false)).type.toRaiseError();
 
-expect(jest.runOnlyPendingTimers()).type.toBeVoid();
+expect(jest.runOnlyPendingTimers()).type.toBe<void>();
 expect(jest.runOnlyPendingTimers(true)).type.toRaiseError();
 
 expect(jest.runOnlyPendingTimersAsync()).type.toBe<Promise<void>>();
 expect(jest.runOnlyPendingTimersAsync(true)).type.toRaiseError();
 
-expect(jest.advanceTimersToNextFrame()).type.toBeVoid();
+expect(jest.advanceTimersToNextFrame()).type.toBe<void>();
 expect(jest.advanceTimersToNextFrame(true)).type.toRaiseError();
 expect(jest.advanceTimersToNextFrame(100)).type.toRaiseError();
 
-expect(jest.setSystemTime()).type.toBeVoid();
-expect(jest.setSystemTime(1_483_228_800_000)).type.toBeVoid();
-expect(jest.setSystemTime(Date.now())).type.toBeVoid();
-expect(jest.setSystemTime(new Date(1995, 11, 17))).type.toBeVoid();
+expect(jest.setSystemTime()).type.toBe<void>();
+expect(jest.setSystemTime(1_483_228_800_000)).type.toBe<void>();
+expect(jest.setSystemTime(Date.now())).type.toBe<void>();
+expect(jest.setSystemTime(new Date(1995, 11, 17))).type.toBe<void>();
 expect(jest.setSystemTime('1995-12-17T03:24:00')).type.toRaiseError();
 
 expect(jest.useFakeTimers()).type.toBe<typeof jest>();
@@ -670,8 +670,8 @@ expect(jest.retryTimes()).type.toRaiseError();
 expect(jest.setTimeout(6000)).type.toBe<typeof jest>();
 expect(jest.setTimeout()).type.toRaiseError();
 
-expect(jest.getSeed()).type.toBeNumber();
+expect(jest.getSeed()).type.toBe<number>();
 expect(jest.getSeed(123)).type.toRaiseError();
 
-expect(jest.isEnvironmentTornDown()).type.toBeBoolean();
+expect(jest.isEnvironmentTornDown()).type.toBe<boolean>();
 expect(jest.isEnvironmentTornDown(123)).type.toRaiseError();


### PR DESCRIPTION
## Summary

Primitive type matchers like `.toBeString()` or `.toBeBoolean()` will be removed in the next major TSTyche release. Reference: https://tstyche.org/releases/tstyche-4#matchers

This PR is replacing them with `.toBe()`.

---

The primitive type were adding bloat to the code base and did not look needed anyhow. For example, if some behaviour is changing it is easier to move from `.toBe<string>()` to `.toBe<Promise<string>>()`. It was not clear why using `.toBeString()` is anyhow better.

## Test plan

Green CI.