### PR TITLE
chore: update `fast-check`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3422,12 +3422,12 @@ __metadata:
   linkType: hard
 
 "@fast-check/jest@npm:^2.0.0":
-  version: 2.0.3
-  resolution: "@fast-check/jest@npm:2.0.3"
+  version: 2.1.1
+  resolution: "@fast-check/jest@npm:2.1.1"
   dependencies:
-    fast-check: ^3.0.0
+    fast-check: ^3.0.0 || ^4.0.0
   peerDependencies:
-    "@fast-check/worker": ">=0.0.7 <0.5.0"
+    "@fast-check/worker": ">=0.0.7 <0.6.0"
     "@jest/expect": ">=28.0.0"
     "@jest/globals": ">=25.5.2"
   peerDependenciesMeta:
@@ -3435,7 +3435,7 @@ __metadata:
       optional: true
     "@jest/expect":
       optional: true
-  checksum: 6cb83946a03f52ab5f78770933858ffb6a4e94b322c45c1641048320696e52f6229b4fb2163d93bcf335c9a6303e725479682eb1a2c5746d3ddc7246d8a17b8f
+  checksum: 6e51c5d6f4d51a3a52d985262a383351a4f5506cd595f7639aad7fa8dd54aef8d49d156926a16a0d8bdc619b9ed2f6b9f6f9a27c87573307eee6bb7bb4576b72
   languageName: node
   linkType: hard
 
@@ -11046,12 +11046,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-check@npm:^3.0.0":
-  version: 3.23.2
-  resolution: "fast-check@npm:3.23.2"
+"fast-check@npm:^3.0.0 || ^4.0.0":
+  version: 4.1.1
+  resolution: "fast-check@npm:4.1.1"
   dependencies:
-    pure-rand: ^6.1.0
-  checksum: b815bd1a2bda33b8e1927a732368f94c3919d5c3b626065479e2389739dfbc6de885fdf48b7a576505edff4f8931798dc737c7bc7039a58b3412746f0d2e9b86
+    pure-rand: ^7.0.0
+  checksum: 775f1c1d64cfc49aa84dbf9e6f84faefc8c333103bab1e80e14e58d055c2f50f3e29126a5ff1a2740be4d573de9dd184416596da7f9d7fb536cdc60511dc68a1
   languageName: node
   linkType: hard
 
@@ -18801,10 +18801,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"pure-rand@npm:^6.0.0, pure-rand@npm:^6.1.0":
+"pure-rand@npm:^6.0.0":
   version: 6.1.0
   resolution: "pure-rand@npm:6.1.0"
   checksum: 8d53bc02bed99eca0b65b505090152ee7e9bd67dd74f8ff32ba1c883b87234067c5bf68d2614759fb217d82594d7a92919e6df80f97885e7b12b42af4bd3316a
+  languageName: node
+  linkType: hard
+
+"pure-rand@npm:^7.0.0":
+  version: 7.0.1
+  resolution: "pure-rand@npm:7.0.1"
+  checksum: 4f543b97a487857a791b8e4c139aad54937397dc8177f1353f7da88556bfa40f5c32bfce3856843b1c3fc3a00b8472cceb22957c10b21c14e59e36a02ec9353b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I think this is the only failure in https://github.com/jestjs/jest/pull/15478

/cc @dubzzz I wonder if the dependency range is wrong (i.e. just `yarn up` will pull in the v4, and renovate also). Maybe make `fast-check` a peer dep instead?

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

Green CI (eventually)

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
