### PR TITLE
fix(jest-environment-jsdom): bump canvas peer dependency to v3

### DIFF
--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -29,7 +29,7 @@
     "@jest/test-utils": "workspace:*"
   },
   "peerDependencies": {
-    "canvas": "^2.5.0"
+    "canvas": "^3.0.0"
   },
   "peerDependenciesMeta": {
     "canvas": {


### PR DESCRIPTION
As far as I understand it, the optional `canvas` peer dependency was only [introduced](https://github.com/jestjs/jest/pull/13409) to propagate the dependency from `jsdom`. `jsdom` has [since upgraded the peer dependency to `^3.0.0`](https://github.com/jsdom/jsdom/blob/6cf36809c500643160f4626c077cc597967f8871/package.json#L48), therefore this package should follow suit.

closes https://github.com/jestjs/jest/issues/15507

Let me know if there are any other changes required!