### PR TITLE
chore: upgrade TSTyche

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "strip-json-comments": "^3.1.1",
     "tempy": "^1.0.0",
     "ts-node": "^10.5.0",
-    "tstyche": "^3.0.0",
+    "tstyche": "^4.0.0-rc.0",
     "typescript": "^5.0.4",
     "typescript-eslint": "^8.26.0",
     "webpack": "^5.68.0",

--- a/packages/expect/__typetests__/expectTyped.test.ts
+++ b/packages/expect/__typetests__/expectTyped.test.ts
@@ -19,8 +19,6 @@ describe('Expect', () => {
     expect(_expect(100).toTypedEqual(100)).type.toBe<void>();
     expect(_expect(101).not.toTypedEqual(100)).type.toBe<void>();
 
-    expect(_expect(100).toTypedEqual('three')).type.toRaiseError(
-      "Argument of type 'string' is not assignable to parameter of type 'number'.",
-    );
+    expect(_expect(100).toTypedEqual).type.not.toBeCallableWith('three');
   });
 });

--- a/packages/jest-expect/__typetests__/jest-expect.test.ts
+++ b/packages/jest-expect/__typetests__/jest-expect.test.ts
@@ -38,8 +38,6 @@ describe('JestExpect', () => {
     expect(jestExpect(100).toTypedEqual(100)).type.toBe<void>();
     expect(jestExpect(101).not.toTypedEqual(100)).type.toBe<void>();
 
-    expect(jestExpect(100).toTypedEqual('three')).type.toRaiseError(
-      "Argument of type 'string' is not assignable to parameter of type 'number'.",
-    );
+    expect(jestExpect(100).toTypedEqual).type.not.toBeCallableWith('three');
   });
 });

--- a/packages/jest-mock/__typetests__/Mocked.test.ts
+++ b/packages/jest-mock/__typetests__/Mocked.test.ts
@@ -33,15 +33,13 @@ describe('Mocked', () => {
     >();
 
     expect(
-      MockSomeClass.prototype.methodA.mockReturnValue('true'),
-    ).type.toRaiseError();
+      MockSomeClass.prototype.methodA.mockReturnValue,
+    ).type.not.toBeCallableWith('true');
     expect(
-      MockSomeClass.prototype.methodB.mockImplementation(
-        (a: string, b?: string) => {
-          return;
-        },
-      ),
-    ).type.toRaiseError();
+      MockSomeClass.prototype.methodB.mockImplementation,
+    ).type.not.toBeCallableWith((a: string, b?: string) => {
+      return;
+    });
 
     expect(MockSomeClass.mock.instances[0].methodA.mock.calls[0]).type.toBe<
       []
@@ -59,14 +57,14 @@ describe('Mocked', () => {
       [a: string, b?: number]
     >();
 
+    expect(mockSomeInstance.methodA.mockReturnValue).type.not.toBeCallableWith(
+      'true',
+    );
     expect(
-      mockSomeInstance.methodA.mockReturnValue('true'),
-    ).type.toRaiseError();
-    expect(
-      mockSomeInstance.methodB.mockImplementation((a: string, b?: string) => {
-        return;
-      }),
-    ).type.toRaiseError();
+      mockSomeInstance.methodB.mockImplementation,
+    ).type.not.toBeCallableWith((a: string, b?: string) => {
+      return;
+    });
 
     expect(new SomeClass('sample')).type.toBeAssignableWith(mockSomeInstance);
   });
@@ -80,10 +78,10 @@ describe('Mocked', () => {
 
     expect(mockFunction.mock.calls[0]).type.toBe<[a: string, b?: number]>();
 
-    expect(mockFunction.mockReturnValue(123)).type.toRaiseError();
-    expect(
-      mockFunction.mockImplementation((a: boolean, b?: number) => true),
-    ).type.toRaiseError();
+    expect(mockFunction.mockReturnValue).type.not.toBeCallableWith(123);
+    expect(mockFunction.mockImplementation).type.not.toBeCallableWith(
+      (a: boolean, b?: number) => true,
+    );
 
     expect(someFunction).type.toBeAssignableWith(mockFunction);
   });
@@ -99,12 +97,10 @@ describe('Mocked', () => {
 
     expect(mockAsyncFunction.mock.calls[0]).type.toBe<[Array<boolean>]>();
 
-    expect(mockAsyncFunction.mockResolvedValue(123)).type.toRaiseError();
-    expect(
-      mockAsyncFunction.mockImplementation((a: Array<boolean>) =>
-        Promise.resolve(true),
-      ),
-    ).type.toRaiseError();
+    expect(mockAsyncFunction.mockResolvedValue).type.not.toBeCallableWith(123);
+    expect(mockAsyncFunction.mockImplementation).type.not.toBeCallableWith(
+      (a: Array<boolean>) => Promise.resolve(true),
+    );
 
     expect(someAsyncFunction).type.toBeAssignableWith(mockAsyncFunction);
   });
@@ -130,23 +126,23 @@ describe('Mocked', () => {
       [a: number, b?: string]
     >();
 
-    expect(mockFunctionObject.mockReturnValue(123)).type.toRaiseError();
-    expect(
-      mockFunctionObject.mockImplementation(() => true),
-    ).type.toRaiseError();
+    expect(mockFunctionObject.mockReturnValue).type.not.toBeCallableWith(123);
+    expect(mockFunctionObject.mockImplementation).type.not.toBeCallableWith(
+      () => true,
+    );
 
     expect(mockFunctionObject.one.more.time.mock.calls[0]).type.toBe<
       [time: number]
     >();
 
     expect(
-      mockFunctionObject.one.more.time.mockReturnValue(123),
-    ).type.toRaiseError();
+      mockFunctionObject.one.more.time.mockReturnValue,
+    ).type.not.toBeCallableWith(123);
     expect(
-      mockFunctionObject.one.more.time.mockImplementation((time: string) => {
-        return;
-      }),
-    ).type.toRaiseError();
+      mockFunctionObject.one.more.time.mockImplementation,
+    ).type.not.toBeCallableWith((time: string) => {
+      return;
+    });
 
     expect(someFunctionObject).type.toBeAssignableWith(mockFunctionObject);
   });
@@ -211,57 +207,51 @@ describe('Mocked', () => {
       [a: string, b?: number]
     >();
 
-    expect(mockObject.methodA.mockReturnValue(123)).type.toRaiseError();
-    expect(
-      mockObject.methodA.mockImplementation((a: number) => 123),
-    ).type.toRaiseError();
-    expect(mockObject.methodB.mockReturnValue(123)).type.toRaiseError();
-    expect(
-      mockObject.methodB.mockImplementation((b: number) => 123),
-    ).type.toRaiseError();
-    expect(mockObject.methodC.mockReturnValue(123)).type.toRaiseError();
-    expect(
-      mockObject.methodC.mockImplementation((c: number) => 123),
-    ).type.toRaiseError();
+    expect(mockObject.methodA.mockReturnValue).type.not.toBeCallableWith(123);
+    expect(mockObject.methodA.mockImplementation).type.not.toBeCallableWith(
+      (a: number) => 123,
+    );
+    expect(mockObject.methodB.mockReturnValue).type.not.toBeCallableWith(123);
+    expect(mockObject.methodB.mockImplementation).type.not.toBeCallableWith(
+      (b: number) => 123,
+    );
+    expect(mockObject.methodC.mockReturnValue).type.not.toBeCallableWith(123);
+    expect(mockObject.methodC.mockImplementation).type.not.toBeCallableWith(
+      (c: number) => 123,
+    );
 
-    expect(mockObject.one.more.time.mockReturnValue(123)).type.toRaiseError();
+    expect(mockObject.one.more.time.mockReturnValue).type.not.toBeCallableWith(
+      123,
+    );
     expect(
-      mockObject.one.more.time.mockImplementation((t: boolean) => 123),
-    ).type.toRaiseError();
-
-    expect(
-      mockObject.SomeClass.prototype.methodA.mockReturnValue(123),
-    ).type.toRaiseError();
-    expect(
-      mockObject.SomeClass.prototype.methodA.mockImplementation(
-        (a: number) => 123,
-      ),
-    ).type.toRaiseError();
-    expect(
-      mockObject.SomeClass.prototype.methodB.mockReturnValue(123),
-    ).type.toRaiseError();
-    expect(
-      mockObject.SomeClass.prototype.methodB.mockImplementation(
-        (a: number) => 123,
-      ),
-    ).type.toRaiseError();
+      mockObject.one.more.time.mockImplementation,
+    ).type.not.toBeCallableWith((t: boolean) => 123);
 
     expect(
-      mockObject.someClassInstance.methodA.mockReturnValue(123),
-    ).type.toRaiseError();
+      mockObject.SomeClass.prototype.methodA.mockReturnValue,
+    ).type.not.toBeCallableWith(123);
     expect(
-      mockObject.someClassInstance.methodA.mockImplementation(
-        (a: number) => 123,
-      ),
-    ).type.toRaiseError();
+      mockObject.SomeClass.prototype.methodA.mockImplementation,
+    ).type.not.toBeCallableWith((a: number) => 123);
     expect(
-      mockObject.someClassInstance.methodB.mockReturnValue(123),
-    ).type.toRaiseError();
+      mockObject.SomeClass.prototype.methodB.mockReturnValue,
+    ).type.not.toBeCallableWith(123);
     expect(
-      mockObject.someClassInstance.methodB.mockImplementation(
-        (a: number) => 123,
-      ),
-    ).type.toRaiseError();
+      mockObject.SomeClass.prototype.methodB.mockImplementation,
+    ).type.not.toBeCallableWith((a: number) => 123);
+
+    expect(
+      mockObject.someClassInstance.methodA.mockReturnValue,
+    ).type.not.toBeCallableWith(123);
+    expect(
+      mockObject.someClassInstance.methodA.mockImplementation,
+    ).type.not.toBeCallableWith((a: number) => 123);
+    expect(
+      mockObject.someClassInstance.methodB.mockReturnValue,
+    ).type.not.toBeCallableWith(123);
+    expect(
+      mockObject.someClassInstance.methodB.mockImplementation,
+    ).type.not.toBeCallableWith((a: number) => 123);
 
     expect(someObject).type.toBeAssignableWith(mockObject);
   });

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -49,12 +49,12 @@ describe('jest.fn()', () => {
         .mockReturnValueOnce('value'),
     ).type.toBe<Mock<() => string>>();
 
-    expect(
-      fn(() => 'value').mockReturnValue(Promise.resolve('value')),
-    ).type.toRaiseError();
-    expect(
-      fn(() => 'value').mockReturnValueOnce(Promise.resolve('value')),
-    ).type.toRaiseError();
+    expect(fn(() => 'value').mockReturnValue).type.not.toBeCallableWith(
+      Promise.resolve('value'),
+    );
+    expect(fn(() => 'value').mockReturnValueOnce).type.not.toBeCallableWith(
+      Promise.resolve('value'),
+    );
   });
 
   test('when async function is provided, returned object can be chained', () => {
@@ -74,15 +74,19 @@ describe('jest.fn()', () => {
         .mockReturnValueOnce(Promise.resolve('value')),
     ).type.toBe<Mock<() => Promise<string>>>();
 
-    expect(fn(() => 'value').mockResolvedValue('value')).type.toRaiseError();
-    expect(
-      fn(() => 'value').mockResolvedValueOnce('value'),
-    ).type.toRaiseError();
+    expect(fn(() => 'value').mockResolvedValue).type.not.toBeCallableWith(
+      'value',
+    );
+    expect(fn(() => 'value').mockResolvedValueOnce).type.not.toBeCallableWith(
+      'value',
+    );
 
-    expect(fn(() => 'value').mockRejectedValue('error')).type.toRaiseError();
-    expect(
-      fn(() => 'value').mockRejectedValueOnce('error'),
-    ).type.toRaiseError();
+    expect(fn(() => 'value').mockRejectedValue).type.not.toBeCallableWith(
+      'error',
+    );
+    expect(fn(() => 'value').mockRejectedValueOnce).type.not.toBeCallableWith(
+      'error',
+    );
   });
 
   test('models typings of mocked function', () => {
@@ -99,15 +103,15 @@ describe('jest.fn()', () => {
       }),
     ).type.toBe<Mock<(e: any) => never>>();
 
-    expect(fn('moduleName')).type.toRaiseError();
+    expect(fn).type.not.toBeCallableWith('moduleName');
   });
 
   test('infers argument and return types of mocked function', () => {
     expect(mockFn('one', 2)).type.toBe<boolean>();
     expect(mockAsyncFn(false)).type.toBe<Promise<string>>();
 
-    expect(mockFn()).type.toRaiseError();
-    expect(mockAsyncFn()).type.toRaiseError();
+    expect(mockFn).type.not.toBeCallableWith();
+    expect(mockAsyncFn).type.not.toBeCallableWith();
   });
 
   test('infers argument and return types of mocked object', () => {
@@ -116,7 +120,7 @@ describe('jest.fn()', () => {
       disconnect(): void;
     }>();
 
-    expect(new MockObject()).type.toRaiseError();
+    expect(MockObject).type.not.toBeConstructableWith();
   });
 
   test('.getMockImplementation()', () => {
@@ -124,13 +128,13 @@ describe('jest.fn()', () => {
       ((a: string, b?: number | undefined) => boolean) | undefined
     >();
 
-    expect(mockFn.getMockImplementation('some-mock')).type.toRaiseError();
+    expect(mockFn.getMockImplementation).type.not.toBeCallableWith('some-mock');
   });
 
   test('.getMockName()', () => {
     expect(mockFn.getMockName()).type.toBe<string>();
 
-    expect(mockFn.getMockName('some-mock')).type.toRaiseError();
+    expect(mockFn.getMockName).type.not.toBeCallableWith('some-mock');
   });
 
   test('.mock', () => {
@@ -180,7 +184,7 @@ describe('jest.fn()', () => {
       Mock<(a: string, b?: number | undefined) => boolean>
     >();
 
-    expect(mockFn.mockClear('some-mock')).type.toRaiseError();
+    expect(mockFn.mockClear).type.not.toBeCallableWith('some-mock');
   });
 
   test('.mockReset()', () => {
@@ -188,13 +192,13 @@ describe('jest.fn()', () => {
       Mock<(a: string, b?: number | undefined) => boolean>
     >();
 
-    expect(mockFn.mockReset('some-mock')).type.toRaiseError();
+    expect(mockFn.mockReset).type.not.toBeCallableWith('some-mock');
   });
 
   test('.mockRestore()', () => {
     expect(mockFn.mockRestore()).type.toBe<void>();
 
-    expect(mockFn.mockRestore('some-mock')).type.toRaiseError();
+    expect(mockFn.mockRestore).type.not.toBeCallableWith('some-mock');
   });
 
   test('.mockImplementation()', () => {
@@ -206,9 +210,11 @@ describe('jest.fn()', () => {
       }),
     ).type.toBe<Mock<(a: string, b?: number | undefined) => boolean>>();
 
-    expect(mockFn.mockImplementation((a: number) => false)).type.toRaiseError();
-    expect(mockFn.mockImplementation(a => 'false')).type.toRaiseError();
-    expect(mockFn.mockImplementation()).type.toRaiseError();
+    expect(mockFn.mockImplementation).type.not.toBeCallableWith(
+      (a: number) => false,
+    );
+    expect(mockFn.mockImplementation).type.not.toBeCallableWith(() => 'false');
+    expect(mockFn.mockImplementation).type.not.toBeCallableWith();
 
     expect(
       mockAsyncFn.mockImplementation(async a => {
@@ -217,9 +223,9 @@ describe('jest.fn()', () => {
       }),
     ).type.toBe<Mock<(p: boolean) => Promise<string>>>();
 
-    expect(
-      mockAsyncFn.mockImplementation(a => 'mock value'),
-    ).type.toRaiseError();
+    expect(mockAsyncFn.mockImplementation).type.not.toBeCallableWith(
+      () => 'mock value',
+    );
   });
 
   test('.mockImplementationOnce()', () => {
@@ -231,11 +237,13 @@ describe('jest.fn()', () => {
       }),
     ).type.toBe<Mock<(a: string, b?: number | undefined) => boolean>>();
 
-    expect(
-      mockFn.mockImplementationOnce((a: number) => false),
-    ).type.toRaiseError();
-    expect(mockFn.mockImplementationOnce(a => 'false')).type.toRaiseError();
-    expect(mockFn.mockImplementationOnce()).type.toRaiseError();
+    expect(mockFn.mockImplementationOnce).type.not.toBeCallableWith(
+      (a: number) => false,
+    );
+    expect(mockFn.mockImplementationOnce).type.not.toBeCallableWith(
+      () => 'false',
+    );
+    expect(mockFn.mockImplementationOnce).type.not.toBeCallableWith();
 
     expect(
       mockAsyncFn.mockImplementationOnce(async a => {
@@ -243,9 +251,9 @@ describe('jest.fn()', () => {
         return 'mock value';
       }),
     ).type.toBe<Mock<(p: boolean) => Promise<string>>>();
-    expect(
-      mockAsyncFn.mockImplementationOnce(a => 'mock value'),
-    ).type.toRaiseError();
+    expect(mockAsyncFn.mockImplementationOnce).type.not.toBeCallableWith(
+      () => 'mock value',
+    );
   });
 
   test('.mockName()', () => {
@@ -253,8 +261,8 @@ describe('jest.fn()', () => {
       Mock<(a: string, b?: number | undefined) => boolean>
     >();
 
-    expect(mockFn.mockName(123)).type.toRaiseError();
-    expect(mockFn.mockName()).type.toRaiseError();
+    expect(mockFn.mockName).type.not.toBeCallableWith(123);
+    expect(mockFn.mockName).type.not.toBeCallableWith();
   });
 
   test('.mockReturnThis()', () => {
@@ -262,7 +270,7 @@ describe('jest.fn()', () => {
       Mock<(a: string, b?: number | undefined) => boolean>
     >();
 
-    expect(mockFn.mockReturnThis('this')).type.toRaiseError();
+    expect(mockFn.mockReturnThis).type.not.toBeCallableWith('this');
   });
 
   test('.mockReturnValue()', () => {
@@ -270,33 +278,33 @@ describe('jest.fn()', () => {
       Mock<(a: string, b?: number | undefined) => boolean>
     >();
 
-    expect(mockFn.mockReturnValue('true')).type.toRaiseError();
-    expect(mockFn.mockReturnValue()).type.toRaiseError();
+    expect(mockFn.mockReturnValue).type.not.toBeCallableWith('true');
+    expect(mockFn.mockReturnValue).type.not.toBeCallableWith();
 
     expect(
       mockAsyncFn.mockReturnValue(Promise.resolve('mock value')),
     ).type.toBe<Mock<(p: boolean) => Promise<string>>>();
 
-    expect(
-      mockAsyncFn.mockReturnValue(Promise.resolve(true)),
-    ).type.toRaiseError();
+    expect(mockAsyncFn.mockReturnValue).type.not.toBeCallableWith(
+      Promise.resolve(true),
+    );
   });
 
   test('.mockReturnValueOnce()', () => {
     expect(mockFn.mockReturnValueOnce(false)).type.toBe<
       Mock<(a: string, b?: number | undefined) => boolean>
     >();
-    expect(mockFn.mockReturnValueOnce('true')).type.toRaiseError();
+    expect(mockFn.mockReturnValueOnce).type.not.toBeCallableWith('true');
 
-    expect(mockFn.mockReturnValueOnce()).type.toRaiseError();
+    expect(mockFn.mockReturnValueOnce).type.not.toBeCallableWith();
 
     expect(
       mockAsyncFn.mockReturnValueOnce(Promise.resolve('mock value')),
     ).type.toBe<Mock<(p: boolean) => Promise<string>>>();
 
-    expect(
-      mockAsyncFn.mockReturnValueOnce(Promise.resolve(true)),
-    ).type.toRaiseError();
+    expect(mockAsyncFn.mockReturnValueOnce).type.not.toBeCallableWith(
+      Promise.resolve(true),
+    );
   });
 
   test('.mockResolvedValue()', () => {
@@ -305,11 +313,11 @@ describe('jest.fn()', () => {
     ).type.toBe<Mock<() => Promise<string>>>();
 
     expect(
-      fn(() => Promise.resolve('')).mockResolvedValue(123),
-    ).type.toRaiseError();
+      fn(() => Promise.resolve('')).mockResolvedValue,
+    ).type.not.toBeCallableWith(123);
     expect(
-      fn(() => Promise.resolve('')).mockResolvedValue(),
-    ).type.toRaiseError();
+      fn(() => Promise.resolve('')).mockResolvedValue,
+    ).type.not.toBeCallableWith();
   });
 
   test('.mockResolvedValueOnce()', () => {
@@ -318,11 +326,11 @@ describe('jest.fn()', () => {
     ).type.toBe<Mock<() => Promise<string>>>();
 
     expect(
-      fn(() => Promise.resolve('')).mockResolvedValueOnce(123),
-    ).type.toRaiseError();
+      fn(() => Promise.resolve('')).mockResolvedValueOnce,
+    ).type.not.toBeCallableWith(123);
     expect(
-      fn(() => Promise.resolve('')).mockResolvedValueOnce(),
-    ).type.toRaiseError();
+      fn(() => Promise.resolve('')).mockResolvedValueOnce,
+    ).type.not.toBeCallableWith();
   });
 
   test('.mockRejectedValue()', () => {
@@ -334,8 +342,8 @@ describe('jest.fn()', () => {
     ).type.toBe<Mock<() => Promise<string>>>();
 
     expect(
-      fn(() => Promise.resolve('')).mockRejectedValue(),
-    ).type.toRaiseError();
+      fn(() => Promise.resolve('')).mockRejectedValue,
+    ).type.not.toBeCallableWith();
   });
 
   test('.mockRejectedValueOnce()', () => {
@@ -349,8 +357,8 @@ describe('jest.fn()', () => {
     ).type.toBe<Mock<() => Promise<string>>>();
 
     expect(
-      fn(() => Promise.resolve('')).mockRejectedValueOnce(),
-    ).type.toRaiseError();
+      fn(() => Promise.resolve('')).mockRejectedValueOnce,
+    ).type.not.toBeCallableWith();
   });
 
   test('.withImplementation()', () => {
@@ -359,7 +367,7 @@ describe('jest.fn()', () => {
       Promise<void>
     >();
 
-    expect(mockFn.withImplementation(mockFnImpl)).type.toRaiseError();
+    expect(mockFn.withImplementation).type.not.toBeCallableWith(mockFnImpl);
   });
 });
 
@@ -424,8 +432,10 @@ describe('jest.spyOn()', () => {
   test('models typings of spied object', () => {
     expect(spy).type.not.toBeAssignableTo<Function>();
 
-    expect(spy()).type.toRaiseError();
-    expect(new spy()).type.toRaiseError();
+    expect(spy()).type.toRaiseError('This expression is not callable.');
+    expect(new spy()).type.toRaiseError(
+      'This expression is not constructable.',
+    );
 
     expect(spyOn(spiedObject, 'methodA')).type.toBe<
       SpiedFunction<typeof spiedObject.methodA>
@@ -443,9 +453,9 @@ describe('jest.spyOn()', () => {
     expect(spyOn(spiedObject, 'propertyB', 'set')).type.toBe<
       SpiedSetter<typeof spiedObject.propertyB>
     >();
-    expect(spyOn(spiedObject, 'propertyB')).type.toRaiseError();
-    expect(spyOn(spiedObject, 'methodB', 'get')).type.toRaiseError();
-    expect(spyOn(spiedObject, 'methodB', 'set')).type.toRaiseError();
+    expect(spyOn).type.not.toBeCallableWith(spiedObject, 'propertyB');
+    expect(spyOn).type.not.toBeCallableWith(spiedObject, 'methodB', 'get');
+    expect(spyOn).type.not.toBeCallableWith(spiedObject, 'methodB', 'set');
 
     expect(spyOn(spiedObject, 'propertyA', 'get')).type.toBe<
       SpiedGetter<typeof spiedObject.propertyA>
@@ -453,24 +463,24 @@ describe('jest.spyOn()', () => {
     expect(spyOn(spiedObject, 'propertyA', 'set')).type.toBe<
       SpiedSetter<typeof spiedObject.propertyA>
     >();
-    expect(spyOn(spiedObject, 'propertyA')).type.toRaiseError();
+    expect(spyOn).type.not.toBeCallableWith(spiedObject, 'propertyA');
 
-    expect(spyOn(spiedObject, 'notThere')).type.toRaiseError();
-    expect(spyOn('abc', 'methodA')).type.toRaiseError();
-    expect(spyOn(123, 'methodA')).type.toRaiseError();
-    expect(spyOn(true, 'methodA')).type.toRaiseError();
-    expect(spyOn(spiedObject)).type.toRaiseError();
-    expect(spyOn()).type.toRaiseError();
+    expect(spyOn).type.not.toBeCallableWith(spiedObject, 'notThere');
+    expect(spyOn).type.not.toBeCallableWith('abc', 'methodA');
+    expect(spyOn).type.not.toBeCallableWith(123, 'methodA');
+    expect(spyOn).type.not.toBeCallableWith(true, 'methodA');
+    expect(spyOn).type.not.toBeCallableWith(spiedObject);
+    expect(spyOn).type.not.toBeCallableWith();
 
     expect(
       spyOn(spiedArray as unknown as ArrayConstructor, 'isArray'),
     ).type.toBe<SpiedFunction<typeof Array.isArray>>();
-    expect(spyOn(spiedArray, 'isArray')).type.toRaiseError();
+    expect(spyOn).type.not.toBeCallableWith(spiedArray, 'isArray');
 
     expect(spyOn(spiedFunction as unknown as Function, 'toString')).type.toBe<
       SpiedFunction<typeof spiedFunction.toString>
     >();
-    expect(spyOn(spiedFunction, 'toString')).type.toRaiseError();
+    expect(spyOn).type.not.toBeCallableWith(spiedFunction, 'toString');
 
     expect(spyOn(globalThis, 'Date')).type.toBe<SpiedClass<typeof Date>>();
     expect(spyOn(Date, 'now')).type.toBe<SpiedFunction<typeof Date.now>>();
@@ -496,9 +506,9 @@ describe('jest.spyOn()', () => {
     expect(spyOn(indexSpiedObject, 'propertyA', 'set')).type.toBe<
       SpiedSetter<typeof indexSpiedObject.propertyA>
     >();
-    expect(spyOn(indexSpiedObject, 'propertyA')).type.toRaiseError();
+    expect(spyOn).type.not.toBeCallableWith(indexSpiedObject, 'propertyA');
 
-    expect(spyOn(indexSpiedObject, 'notThere')).type.toRaiseError();
+    expect(spyOn).type.not.toBeCallableWith(indexSpiedObject, 'notThere');
   });
 
   test('handles interface with optional properties', () => {
@@ -535,12 +545,16 @@ describe('jest.spyOn()', () => {
       SpiedClass<typeof optionalSpiedObject.constructorB>
     >();
 
-    expect(
-      spyOn(optionalSpiedObject, 'constructorA', 'get'),
-    ).type.toRaiseError();
-    expect(
-      spyOn(optionalSpiedObject, 'constructorA', 'set'),
-    ).type.toRaiseError();
+    expect(spyOn).type.not.toBeCallableWith(
+      optionalSpiedObject,
+      'constructorA',
+      'get',
+    );
+    expect(spyOn).type.not.toBeCallableWith(
+      optionalSpiedObject,
+      'constructorA',
+      'set',
+    );
 
     expect(spyOn(optionalSpiedObject, 'methodA')).type.toBe<
       SpiedFunction<NonNullable<typeof optionalSpiedObject.methodA>>
@@ -549,8 +563,16 @@ describe('jest.spyOn()', () => {
       SpiedFunction<typeof optionalSpiedObject.methodB>
     >();
 
-    expect(spyOn(optionalSpiedObject, 'methodA', 'get')).type.toRaiseError();
-    expect(spyOn(optionalSpiedObject, 'methodA', 'set')).type.toRaiseError();
+    expect(spyOn).type.not.toBeCallableWith(
+      optionalSpiedObject,
+      'methodA',
+      'get',
+    );
+    expect(spyOn).type.not.toBeCallableWith(
+      optionalSpiedObject,
+      'methodA',
+      'set',
+    );
 
     expect(spyOn(optionalSpiedObject, 'propertyA', 'get')).type.toBe<
       SpiedGetter<NonNullable<typeof optionalSpiedObject.propertyA>>
@@ -577,8 +599,8 @@ describe('jest.spyOn()', () => {
       SpiedSetter<typeof optionalSpiedObject.propertyD>
     >();
 
-    expect(spyOn(optionalSpiedObject, 'propertyA')).type.toRaiseError();
-    expect(spyOn(optionalSpiedObject, 'propertyB')).type.toRaiseError();
+    expect(spyOn).type.not.toBeCallableWith(optionalSpiedObject, 'propertyA');
+    expect(spyOn).type.not.toBeCallableWith(optionalSpiedObject, 'propertyB');
   });
 
   test('handles properties of `prototype`', () => {
@@ -589,10 +611,8 @@ describe('jest.spyOn()', () => {
     ).type.toBe<SpiedFunction<(key: string, value: string) => void>>();
 
     expect(
-      spyOn(Storage.prototype, 'setItem').mockImplementation(
-        (key: string, value: number) => {},
-      ),
-    ).type.toRaiseError();
+      spyOn(Storage.prototype, 'setItem').mockImplementation,
+    ).type.not.toBeCallableWith((key: string, value: number) => {});
   });
 });
 
@@ -627,16 +647,20 @@ describe('jest.replaceProperty()', () => {
       replaceProperty(replaceObject, 'property', 1).replaceValue(1).restore(),
     ).type.toBe<void>();
 
-    expect(replaceProperty(replaceObject, 'invalid', 1)).type.toRaiseError();
-    expect(
-      replaceProperty(replaceObject, 'property', 'not a number'),
-    ).type.toRaiseError();
+    expect(replaceProperty).type.not.toBeCallableWith(
+      replaceObject,
+      'invalid',
+      1,
+    );
+    expect(replaceProperty).type.not.toBeCallableWith(
+      replaceObject,
+      'property',
+      'not a number',
+    );
 
     expect(
-      replaceProperty(replaceObject, 'property', 1).replaceValue(
-        'not a number',
-      ),
-    ).type.toRaiseError();
+      replaceProperty(replaceObject, 'property', 1).replaceValue,
+    ).type.not.toBeCallableWith('not a number');
 
     expect(
       replaceProperty(complexObject, 'numberOrUndefined', undefined),
@@ -645,13 +669,11 @@ describe('jest.replaceProperty()', () => {
       Replaced<number | undefined>
     >();
 
-    expect(
-      replaceProperty(
-        complexObject,
-        'numberOrUndefined',
-        'string is not valid TypeScript type',
-      ),
-    ).type.toRaiseError();
+    expect(replaceProperty).type.not.toBeCallableWith(
+      complexObject,
+      'numberOrUndefined',
+      'string is not valid TypeScript type',
+    );
 
     expect(replaceProperty(complexObject, 'optionalString', 'foo')).type.toBe<
       Replaced<string | undefined>
@@ -663,13 +685,17 @@ describe('jest.replaceProperty()', () => {
     expect(
       replaceProperty(objectWithDynamicProperties, 'dynamic prop 1', true),
     ).type.toBe<Replaced<boolean>>();
-    expect(
-      replaceProperty(objectWithDynamicProperties, 'dynamic prop 1', undefined),
-    ).type.toRaiseError();
+    expect(replaceProperty).type.not.toBeCallableWith(
+      objectWithDynamicProperties,
+      'dynamic prop 1',
+      undefined,
+    );
 
-    expect(
-      replaceProperty(complexObject, 'not a property', undefined),
-    ).type.toRaiseError();
+    expect(replaceProperty).type.not.toBeCallableWith(
+      complexObject,
+      'not a property',
+      undefined,
+    );
 
     expect(
       replaceProperty(complexObject, 'multipleTypes', 1)

--- a/packages/jest-reporters/__typetests__/jest-reporters.test.ts
+++ b/packages/jest-reporters/__typetests__/jest-reporters.test.ts
@@ -27,10 +27,10 @@ declare const testResult: TestResult;
 
 expect(utils.formatTestPath(globalConfig, 'some/path')).type.toBe<string>();
 expect(utils.formatTestPath(projectConfig, 'some/path')).type.toBe<string>();
-expect(utils.formatTestPath()).type.toRaiseError();
-expect(utils.formatTestPath({}, 'some/path')).type.toRaiseError();
-expect(utils.formatTestPath(globalConfig, 123)).type.toRaiseError();
-expect(utils.formatTestPath(projectConfig, 123)).type.toRaiseError();
+expect(utils.formatTestPath).type.not.toBeCallableWith();
+expect(utils.formatTestPath).type.not.toBeCallableWith({}, 'some/path');
+expect(utils.formatTestPath).type.not.toBeCallableWith(globalConfig, 123);
+expect(utils.formatTestPath).type.not.toBeCallableWith(projectConfig, 123);
 
 // utils.getResultHeader()
 
@@ -38,50 +38,62 @@ expect(
   utils.getResultHeader(testResult, globalConfig, projectConfig),
 ).type.toBe<string>();
 expect(utils.getResultHeader(testResult, globalConfig)).type.toBe<string>();
-expect(utils.getResultHeader()).type.toRaiseError();
-expect(utils.getResultHeader({}, globalConfig)).type.toRaiseError();
-expect(
-  utils.getResultHeader({}, globalConfig, projectConfig),
-).type.toRaiseError();
-expect(utils.getResultHeader(testResult, {})).type.toRaiseError();
-expect(utils.getResultHeader(testResult, globalConfig, {})).type.toRaiseError();
+expect(utils.getResultHeader).type.not.toBeCallableWith();
+expect(utils.getResultHeader).type.not.toBeCallableWith({}, globalConfig);
+expect(utils.getResultHeader).type.not.toBeCallableWith(
+  {},
+  globalConfig,
+  projectConfig,
+);
+expect(utils.getResultHeader).type.not.toBeCallableWith(testResult, {});
+expect(utils.getResultHeader).type.not.toBeCallableWith(
+  testResult,
+  globalConfig,
+  {},
+);
 
 // utils.getSnapshotStatus()
 
 expect(utils.getSnapshotStatus(snapshot, true)).type.toBe<Array<string>>();
-expect(utils.getSnapshotStatus()).type.toRaiseError();
-expect(utils.getSnapshotStatus({}, true)).type.toRaiseError();
-expect(utils.getSnapshotStatus(snapshot, 123)).type.toRaiseError();
+expect(utils.getSnapshotStatus).type.not.toBeCallableWith();
+expect(utils.getSnapshotStatus).type.not.toBeCallableWith({}, true);
+expect(utils.getSnapshotStatus).type.not.toBeCallableWith(snapshot, 123);
 
 // utils.getSnapshotSummary()
 
 expect(
   utils.getSnapshotSummary(snapshotSummary, globalConfig, 'press `u`'),
 ).type.toBe<Array<string>>();
-expect(utils.getSnapshotSummary()).type.toRaiseError();
-expect(
-  utils.getSnapshotSummary({}, globalConfig, 'press `u`'),
-).type.toRaiseError();
-expect(
-  utils.getSnapshotSummary(snapshotSummary, {}, 'press `u`'),
-).type.toRaiseError();
-expect(
-  utils.getSnapshotSummary(snapshotSummary, globalConfig, true),
-).type.toRaiseError();
+expect(utils.getSnapshotSummary).type.not.toBeCallableWith();
+expect(utils.getSnapshotSummary).type.not.toBeCallableWith(
+  {},
+  globalConfig,
+  'press `u`',
+);
+expect(utils.getSnapshotSummary).type.not.toBeCallableWith(
+  snapshotSummary,
+  {},
+  'press `u`',
+);
+expect(utils.getSnapshotSummary).type.not.toBeCallableWith(
+  snapshotSummary,
+  globalConfig,
+  true,
+);
 
 // utils.getSummary()
 
 expect(utils.getSummary(aggregatedResults, summaryOptions)).type.toBe<string>();
 expect(utils.getSummary(aggregatedResults)).type.toBe<string>();
-expect(utils.getSummary()).type.toRaiseError();
-expect(utils.getSummary({})).type.toRaiseError();
-expect(utils.getSummary(aggregatedResults, true)).type.toRaiseError();
+expect(utils.getSummary).type.not.toBeCallableWith();
+expect(utils.getSummary).type.not.toBeCallableWith({});
+expect(utils.getSummary).type.not.toBeCallableWith(aggregatedResults, true);
 
 // utils.printDisplayName()
 
 expect(utils.printDisplayName(projectConfig)).type.toBe<string>();
-expect(utils.printDisplayName()).type.toRaiseError();
-expect(utils.printDisplayName({})).type.toRaiseError();
+expect(utils.printDisplayName).type.not.toBeCallableWith();
+expect(utils.printDisplayName).type.not.toBeCallableWith({});
 
 // utils.relativePath()
 
@@ -93,21 +105,37 @@ expect(utils.relativePath(projectConfig, 'some/path')).type.toBe<{
   basename: string;
   dirname: string;
 }>();
-expect(utils.relativePath()).type.toRaiseError();
-expect(utils.relativePath({}, 'some/path')).type.toRaiseError();
-expect(utils.relativePath(projectConfig, true)).type.toRaiseError();
+expect(utils.relativePath).type.not.toBeCallableWith();
+expect(utils.relativePath).type.not.toBeCallableWith({}, 'some/path');
+expect(utils.relativePath).type.not.toBeCallableWith(projectConfig, true);
 
 // utils.trimAndFormatPath()
 
 expect(
   utils.trimAndFormatPath(2, globalConfig, 'some/path', 4),
 ).type.toBe<string>();
-expect(utils.trimAndFormatPath()).type.toRaiseError();
-expect(
-  utils.trimAndFormatPath(true, globalConfig, 'some/path', 4),
-).type.toRaiseError();
-expect(utils.trimAndFormatPath(2, {}, 'some/path', 4)).type.toRaiseError();
-expect(utils.trimAndFormatPath(2, globalConfig, true, 4)).type.toRaiseError();
-expect(
-  utils.trimAndFormatPath(2, globalConfig, 'some/path', '4'),
-).type.toRaiseError();
+expect(utils.trimAndFormatPath).type.not.toBeCallableWith();
+expect(utils.trimAndFormatPath).type.not.toBeCallableWith(
+  true,
+  globalConfig,
+  'some/path',
+  4,
+);
+expect(utils.trimAndFormatPath).type.not.toBeCallableWith(
+  2,
+  {},
+  'some/path',
+  4,
+);
+expect(utils.trimAndFormatPath).type.not.toBeCallableWith(
+  2,
+  globalConfig,
+  true,
+  4,
+);
+expect(utils.trimAndFormatPath).type.not.toBeCallableWith(
+  2,
+  globalConfig,
+  'some/path',
+  '4',
+);

--- a/packages/jest-snapshot/__typetests__/matchers.test.ts
+++ b/packages/jest-snapshot/__typetests__/matchers.test.ts
@@ -43,7 +43,7 @@ expect(
   ),
 ).type.toBe<ExpectationResult>();
 
-expect(toMatchSnapshot({received: 'value'})).type.toRaiseError();
+expect(toMatchSnapshot).type.not.toBeCallableWith({received: 'value'});
 
 // toMatchInlineSnapshot
 
@@ -76,7 +76,7 @@ expect(
   ),
 ).type.toBe<ExpectationResult>();
 
-expect(toMatchInlineSnapshot({received: 'value'})).type.toRaiseError();
+expect(toMatchInlineSnapshot).type.not.toBeCallableWith({received: 'value'});
 
 // toThrowErrorMatchingSnapshot
 
@@ -110,7 +110,9 @@ expect(
   ),
 ).type.toBe<ExpectationResult>();
 
-expect(toThrowErrorMatchingSnapshot({received: 'value'})).type.toRaiseError();
+expect(toThrowErrorMatchingSnapshot).type.not.toBeCallableWith({
+  received: 'value',
+});
 
 // toThrowErrorMatchingInlineSnapshot
 
@@ -144,6 +146,6 @@ expect(
   ),
 ).type.toBe<ExpectationResult>();
 
-expect(
-  toThrowErrorMatchingInlineSnapshot({received: 'value'}),
-).type.toRaiseError();
+expect(toThrowErrorMatchingInlineSnapshot).type.not.toBeCallableWith({
+  received: 'value',
+});

--- a/packages/jest-types/__typetests__/each.test.ts
+++ b/packages/jest-types/__typetests__/each.test.ts
@@ -278,9 +278,9 @@ expect(
   ),
 ).type.toBe<void>();
 
-expect(test.each()).type.toRaiseError();
-expect(test.each('abc')).type.toRaiseError();
-expect(test.each(() => {})).type.toRaiseError();
+expect(test.each).type.not.toBeCallableWith();
+expect(test.each).type.not.toBeCallableWith('abc');
+expect(test.each).type.not.toBeCallableWith(() => {});
 
 expect(test.only.each).type.toBe(test.each);
 expect(test.skip.each).type.toBe(test.each);
@@ -453,9 +453,9 @@ expect(
   ),
 ).type.toBe<void>();
 
-expect(test.concurrent.each()).type.toRaiseError();
-expect(test.concurrent.each('abc')).type.toRaiseError();
-expect(test.concurrent.each(() => {})).type.toRaiseError();
+expect(test.concurrent.each).type.not.toBeCallableWith();
+expect(test.concurrent.each).type.not.toBeCallableWith('abc');
+expect(test.concurrent.each).type.not.toBeCallableWith(() => {});
 
 expect(test.concurrent.only.each).type.toBe(test.concurrent.each);
 expect(test.concurrent.skip.each).type.toBe(test.concurrent.each);
@@ -687,9 +687,9 @@ expect(
   ),
 ).type.toBe<void>();
 
-expect(describe.each()).type.toRaiseError();
-expect(describe.each('abc')).type.toRaiseError();
-expect(describe.each(() => {})).type.toRaiseError();
+expect(describe.each).type.not.toBeCallableWith();
+expect(describe.each).type.not.toBeCallableWith('abc');
+expect(describe.each).type.not.toBeCallableWith(() => {});
 
 expect(describe.only.each).type.toBe(describe.each);
 expect(describe.skip.each).type.toBe(describe.each);

--- a/packages/jest-worker/__typetests__/jest-worker.test.ts
+++ b/packages/jest-worker/__typetests__/jest-worker.test.ts
@@ -52,12 +52,12 @@ test('inferred JestWorkerFarm', () => {
   expect(inferredWorkerFarm.doSomethingAsync()).type.toBe<Promise<void>>();
   expect(inferredWorkerFarm.doSomethingAsync()).type.toBe<Promise<void>>();
 
-  expect(inferredWorkerFarm.runTest()).type.toRaiseError();
-  expect(inferredWorkerFarm.runTest('abc')).type.toRaiseError();
-  expect(inferredWorkerFarm.runTestAsync()).type.toRaiseError();
-  expect(inferredWorkerFarm.runTestAsync(123)).type.toRaiseError();
-  expect(inferredWorkerFarm.doSomething(123)).type.toRaiseError();
-  expect(inferredWorkerFarm.doSomethingAsync('abc')).type.toRaiseError();
+  expect(inferredWorkerFarm.runTest).type.not.toBeCallableWith();
+  expect(inferredWorkerFarm.runTest).type.not.toBeCallableWith('abc');
+  expect(inferredWorkerFarm.runTestAsync).type.not.toBeCallableWith();
+  expect(inferredWorkerFarm.runTestAsync).type.not.toBeCallableWith(123);
+  expect(inferredWorkerFarm.doSomething).type.not.toBeCallableWith(123);
+  expect(inferredWorkerFarm.doSomethingAsync).type.not.toBeCallableWith('abc');
 
   expect(inferredWorkerFarm).type.not.toHaveProperty('getResult');
   expect(inferredWorkerFarm).type.not.toHaveProperty('isResult');
@@ -78,9 +78,9 @@ test('typed JestWorkerFarm', () => {
   expect(typedWorkerFarm.runTest('abc', 123)).type.toBe<Promise<void>>();
   expect(typedWorkerFarm.doSomething()).type.toBe<Promise<void>>();
 
-  expect(typedWorkerFarm.runTest()).type.toRaiseError();
-  expect(typedWorkerFarm.runTest('abc')).type.toRaiseError();
-  expect(typedWorkerFarm.doSomething('abc')).type.toRaiseError();
+  expect(typedWorkerFarm.runTest).type.not.toBeCallableWith();
+  expect(typedWorkerFarm.runTest).type.not.toBeCallableWith('abc');
+  expect(typedWorkerFarm.doSomething).type.not.toBeCallableWith('abc');
 
   expect(typedWorkerFarm).type.not.toHaveProperty('isResult');
   expect(typedWorkerFarm).type.not.toHaveProperty('runTestAsync');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3909,7 +3909,7 @@ __metadata:
     strip-json-comments: ^3.1.1
     tempy: ^1.0.0
     ts-node: ^10.5.0
-    tstyche: ^3.0.0
+    tstyche: ^4.0.0-rc.0
     typescript: ^5.0.4
     typescript-eslint: ^8.26.0
     webpack: ^5.68.0
@@ -21612,17 +21612,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tstyche@npm:^3.0.0":
-  version: 3.5.0
-  resolution: "tstyche@npm:3.5.0"
+"tstyche@npm:^4.0.0-rc.0":
+  version: 4.0.0-rc.0
+  resolution: "tstyche@npm:4.0.0-rc.0"
   peerDependencies:
-    typescript: 4.x || 5.x
+    typescript: ">=4.7"
   peerDependenciesMeta:
     typescript:
       optional: true
   bin:
     tstyche: ./build/bin.js
-  checksum: 1269bab345211eeda2e4013b82c15f7c6ff1b15a716244c025cadd28dcc9c791fdd53f18424e9aba6acb5af259cc7a6d3109d6044f7e14b46efc2edaba09afc2
+  checksum: d0a59cf6a7c209195182a0e40e648ee90fc1b1f0b495793104dcd6f1dd7cf005062a481cd1daa0e79a71f5a0a3abd26f4bd7e39f2f7c1ceb68f2ef437db8ed43
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

The next major version of TSTyche ships with `.toBeCallableWith()` and `.toBeConstructableWith()` matchers. This means there is no need to use `.toRaiseError()` anymore and there are no more red squiggles in type test files.

This PR migrates several smaller files to the new matchers. I left larger ones for later.

## Test plan

Green CI.
