### PR TITLE
fix: React Native projects redirecting you to 404 github

### DIFF
--- a/docs/MoreResources.md
+++ b/docs/MoreResources.md
@@ -15,7 +15,7 @@ By now you should have a good idea of how Jest can help you test your applicatio
 
 ## Learn by example
 
-You will find a number of example test cases in the [`examples`](https://github.com/jestjs/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/Libraries/Animated/__tests__) projects.
+You will find a number of example test cases in the [`examples`](https://github.com/jestjs/jest/tree/main/examples) folder on GitHub. You can also learn from the excellent tests used by the [React](https://github.com/facebook/react/tree/main/packages/react/src/__tests__), [Relay](https://github.com/facebook/relay/tree/main/packages/react-relay/__tests__), and [React Native](https://github.com/facebook/react-native/tree/main/packages/react-native/Libraries/Animated/__tests__) projects.
 
 ## Join the community
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

There is a broken link in https://jestjs.io/docs/more-resources that redirects you to a folder that doesn't exist in facebook's react native github. I saw it from [this issue](https://github.com/jestjs/jest/issues/15552)

## Test plan

Now it works. I see this as an absolute win.