### PR TITLE
fix: worker state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@
   - Adds a `conditional/check` to ensure the argument passed to `expect` is an object.
   - Add unit tests for new `ObjectContaining` behavior.
   - Remove `invalid/wrong` test case assertions for `ObjectContaining`.
+- `[jest-worker]` Addresses incorrect state on exit ([#15610](https://github.com/jestjs/jest/pull/15610))
 
 ### Performance
 

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -233,7 +233,8 @@ export default class ChildProcessWorker
       ) {
         if (
           this.state === WorkerStates.OK ||
-          this.state === WorkerStates.STARTING
+          this.state === WorkerStates.STARTING ||
+          this.state === WorkerStates.SHUT_DOWN
         ) {
           this.state = WorkerStates.OUT_OF_MEMORY;
         }

--- a/packages/jest-worker/src/workers/WorkerAbstract.ts
+++ b/packages/jest-worker/src/workers/WorkerAbstract.ts
@@ -125,8 +125,7 @@ export default abstract class WorkerAbstract
    * killed off.
    */
   protected _shutdown(): void {
-    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-    this.state === WorkerStates.SHUT_DOWN;
+    this.state = WorkerStates.SHUT_DOWN;
 
     // End the permanent stream so the merged stream end too
     if (this._fakeStream) {


### PR DESCRIPTION
## Summary

The state was not being correctly updated on exit, which then meant downstream the check for a OOM crash was not detected in tests
