### PR TITLE
chore: update `circleci` matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,5 +58,5 @@ workflows:
           name: test-node-partial-<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: ['16', '18', '20', '21', '22']
+              node-version: ['16', '18', '20', '22', '23']
       - test-jest-jasmine


### PR DESCRIPTION
## Summary

The GitHub Action matrix does not include Node.js 21:

https://github.com/jestjs/jest/blob/e126909930f38e05f912f08082097b9043f935fc/.github/workflows/test.yml#L18

The `circleci` matrix had to be updated as well. That was my oversight in https://github.com/jestjs/jest/pull/15118.

@cpojer Ping! (;

## Test plan

Green CI.