### PR TITLE
chore: drop TypeScript versions below 5.4

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -48,8 +48,8 @@ jobs:
       - name: ts integration
         run: yarn test-ts --selectProjects ts-integration
       - name: type tests
-        run: yarn test-types --target 5.0,current
-      - name: verify TypeScript@5.0 compatibility
+        run: yarn test-types --target 5.4,current
+      - name: verify TypeScript@5.4 compatibility
         run: yarn verify-old-ts
       - name: run ESLint with type info
         run: yarn lint-ts-files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,7 @@
 - `[*]` [**BREAKING**] Add ESM wrapper for all of Jest's modules ([#14661](https://github.com/jestjs/jest/pull/14661))
 - `[*]` [**BREAKING**] Upgrade to `glob@10` ([#14509](https://github.com/jestjs/jest/pull/14509))
 - `[*]` Use `TypeError` over `Error` where appropriate ([#14799](https://github.com/jestjs/jest/pull/14799))
+- `[*]` [**BREAKING**] Drop support for TypeScript versions below 5.4 ([#15621](https://github.com/jestjs/jest/pull/15621))
 - `[docs]` Fix typos in `CHANGELOG.md` and `packages/jest-validate/README.md` ([#14640](https://github.com/jestjs/jest/pull/14640))
 - `[docs]` Don't use alias matchers in docs ([#14631](https://github.com/jestjs/jest/pull/14631))
 - `[babel-jest, babel-preset-jest]` [**BREAKING**] Increase peer dependency of `@babel/core` to `^7.11` ([#14109](https://github.com/jestjs/jest/pull/14109))

--- a/e2e/__tests__/jest.config.ts.test.ts
+++ b/e2e/__tests__/jest.config.ts.test.ts
@@ -95,12 +95,13 @@ onNodeVersions('<23.6', () => {
       writeFiles(DIR, {
         '__tests__/a-giraffe.js': "test('giraffe', () => expect(1).toBe(1));",
         'jest.config.ts': `
-        /**@jest-config-loader-options {"transpileOnly":${!!skipTypeCheck}}*/
+        /**@jest-config-loader-options {"transpileOnly":${skipTypeCheck}}*/
         import {Config} from 'jest';
         const config: Config = { testTimeout: "10000" };
         export default config;
       `,
         'package.json': '{}',
+        'tsconfig.json': '{}',
       });
 
       const typeErrorString =

--- a/scripts/verifyOldTs.mjs
+++ b/scripts/verifyOldTs.mjs
@@ -41,7 +41,7 @@ const tsConfig = {
 };
 /* eslint-enable sort-keys */
 
-const tsVersion = '5.0';
+const tsVersion = '5.4';
 
 function smoketest() {
   const jestDirectory = path.resolve(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "preserve",
+    "moduleResolution": "bundler",
     "composite": true,
     "declaration": true,
     "emitDeclarationOnly": true,

--- a/tsconfig.typetest.json
+++ b/tsconfig.typetest.json
@@ -1,8 +1,8 @@
 {
   "extends": "@tsconfig/node16/tsconfig.json",
   "compilerOptions": {
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "preserve",
+    "moduleResolution": "bundler",
     "noEmit": true,
     "noUnusedLocals": false,
     "noUnusedParameters": false,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

I wanna use 

```json
    "module": "preserve",
    "moduleResolution": "bundler",
```

but `preserve` was only added in 5.4: https://www.typescriptlang.org/docs/handbook/release-notes/typescript-5-4.html#support-for-require-calls-in---moduleresolution-bundler-and---module-preserve.

Note that there is zero changes to the output `d.ts` files, but since we no longer _test_ against the older versions of TS, I'll call it out in the changelog

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
