### PR TITLE
Stop closing untriaged issues

### DIFF
--- a/.github/workflows/close-stale.yml
+++ b/.github/workflows/close-stale.yml
@@ -24,7 +24,7 @@ jobs:
           days-before-issue-close: 30
           days-before-pr-close: 30
           exempt-all-milestones: true
-          exempt-issue-labels: Pinned
+          exempt-issue-labels: Pinned,"Needs Triage"
           exempt-pr-labels: Pinned
           exempt-draft-pr: true
           operations-per-run: 1750


### PR DESCRIPTION
Needs Triage means you need to look at the issue, so why is it getting closed all the time?

This is just ridiculous:
![image](https://github.com/user-attachments/assets/189c083a-adb2-4876-af0b-01f7fa78e1e2)
