### PR TITLE
Add support for VError-style cause() methods on errors when printing the call stack of test exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@
 - `[@jest/fake-timers]` [**BREAKING**] Upgrade `@sinonjs/fake-timers` to v13 ([#14544](https://github.com/jestjs/jest/pull/14544) & [#15470](https://github.com/jestjs/jest/pull/15470))
 - `[@jest/fake-timers]` Exposing new modern timers function `advanceTimersToFrame()` which advances all timers by the needed milliseconds to execute callbacks currently scheduled with `requestAnimationFrame` ([#14598](https://github.com/jestjs/jest/pull/14598))
 - `[jest-matcher-utils]` Add `SERIALIZABLE_PROPERTIES` to allow custom serialization of objects ([#14893](https://github.com/jestjs/jest/pull/14893))
+- `[jest-message-util]` Add support for [VError](https://www.npmjs.com/package/verror)-style `cause()` methods on errors when printing the call stack of test exceptions ([#15624](https://github.com/jestjs/jest/issues/15624))
 - `[jest-mock]` Add support for the Explicit Resource Management proposal to use the `using` keyword with `jest.spyOn(object, methodName)` ([#14895](https://github.com/jestjs/jest/pull/14895))
 - `[jest-reporters]` Add support for [DEC mode 2026](https://gist.github.com/christianparpart/d8a62cc1ab659194337d73e399004036) ([#15008](https://github.com/jestjs/jest/pull/15008))
 - `[jest-resolver]` Support `file://` URLs as paths ([#15154](https://github.com/jestjs/jest/pull/15154))

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -391,22 +391,22 @@ type FailedResults = Array<{
 }>;
 
 function getCauseFromErrorOrStack(
-  errorOrStack: Error | string
+  errorOrStack: Error | string,
 ): Error | string | null {
-  if (typeof errorOrStack === "string" || !("cause" in errorOrStack)) {
+  if (typeof errorOrStack === 'string' || !('cause' in errorOrStack)) {
     return null;
   }
 
-  let cause = errorOrStack.cause;
-  if (
-    typeof cause === "string" ||
+  let cause =
+    errorOrStack.cause instanceof Function
+      ? errorOrStack.cause()
+      : errorOrStack.cause;
+
+  return typeof cause === 'string' ||
     types.isNativeError(cause) ||
     cause instanceof Error
-  ) {
-    return cause;
-  } else {
-    return null;
-  }
+    ? cause
+    : null;
 }
 
 function formatErrorStack(
@@ -432,12 +432,7 @@ function formatErrorStack(
   let cause = '';
   let causeError = getCauseFromErrorOrStack(errorOrStack);
   if (causeError) {
-    const nestedCause = formatErrorStack(
-      causeError,
-      config,
-      options,
-      testPath,
-    );
+    const nestedCause = formatErrorStack(causeError, config, options, testPath);
     cause = `\n${MESSAGE_INDENT}Cause:\n${nestedCause}`;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

Fixes https://github.com/jestjs/jest/issues/15624

## Test plan

```ts
import { VError } from 'verror';

function a() {
    throw new VError("root error");
}

function b() {
    try {
        a();
    } catch (cause) {
        throw new VError(cause, "b caught an error");
    }
}

test('causes are displayed correctly', () => {
    b();
});
```

Before|After
-|-
![Screenshot from 2025-05-26 22-08-47](https://github.com/user-attachments/assets/f5e53ad0-8096-45e2-9fe8-ee9fe3c510f7)|![Screenshot from 2025-05-26 22-07-14](https://github.com/user-attachments/assets/97a5e62d-a9be-4e7e-8ab5-f5dcab941065)


<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
