### PR TITLE
refactor: use `util.stripVTControlCharacters()` instead of `strip-ansi`

### DIFF
--- a/e2e/__tests__/runProgrammaticallyMultipleProjects.test.ts
+++ b/e2e/__tests__/runProgrammaticallyMultipleProjects.test.ts
@@ -6,7 +6,7 @@
  */
 
 import {resolve} from 'path';
-import stripAnsi = require('strip-ansi');
+import {stripVTControlCharacters as stripAnsi} from 'util';
 import {extractSummary, run} from '../Utils';
 
 const dir = resolve(__dirname, '../run-programmatically-multiple-projects');

--- a/e2e/runJest.ts
+++ b/e2e/runJest.ts
@@ -8,10 +8,10 @@
 
 import * as path from 'path';
 import {Writable} from 'stream';
+import {stripVTControlCharacters as stripAnsi} from 'util';
 import dedent from 'dedent';
 import execa = require('execa');
 import * as fs from 'graceful-fs';
-import stripAnsi = require('strip-ansi');
 import {TestPathPatterns} from '@jest/pattern';
 import type {FormattedTestResults} from '@jest/test-result';
 import {normalizeIcons} from '@jest/test-utils';

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "rimraf": "^5.0.10",
     "semver": "^7.7.2",
     "slash": "^3.0.0",
-    "strip-ansi": "^6.0.1",
     "strip-json-comments": "^3.1.1",
     "tempy": "^1.0.1",
     "ts-node": "^10.5.0",

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -41,8 +41,7 @@
     "jest-watcher": "workspace:*",
     "micromatch": "^4.0.8",
     "pretty-format": "workspace:*",
-    "slash": "^3.0.0",
-    "strip-ansi": "^6.0.1"
+    "slash": "^3.0.0"
   },
   "devDependencies": {
     "@jest/test-sequencer": "workspace:*",

--- a/packages/jest-core/src/__tests__/watchFilenamePatternMode.test.js
+++ b/packages/jest-core/src/__tests__/watchFilenamePatternMode.test.js
@@ -48,9 +48,6 @@ jest.mock(
 
 jest.doMock('chalk', () => new chalk.Instance({level: 0}));
 
-jest.doMock('strip-ansi');
-require('strip-ansi').mockImplementation(str => str);
-
 jest.doMock(
   '../runJest',
   () =>

--- a/packages/jest-core/src/__tests__/watchTestNamePatternMode.test.js
+++ b/packages/jest-core/src/__tests__/watchTestNamePatternMode.test.js
@@ -24,9 +24,6 @@ jest.mock(
 
 jest.doMock('chalk', () => new chalk.Instance({level: 0}));
 
-jest.doMock('strip-ansi');
-require('strip-ansi').mockImplementation(str => str);
-
 jest.doMock(
   '../runJest',
   () =>

--- a/packages/jest-core/src/collectHandles.ts
+++ b/packages/jest-core/src/collectHandles.ts
@@ -6,10 +6,9 @@
  */
 
 import * as asyncHooks from 'async_hooks';
-import {promisify} from 'util';
+import {promisify, stripVTControlCharacters as stripAnsi} from 'util';
 import * as v8 from 'v8';
 import * as vm from 'vm';
-import stripAnsi = require('strip-ansi');
 import type {Config} from '@jest/types';
 import {formatExecError} from 'jest-message-util';
 import {ErrorWithStack} from 'jest-util';

--- a/packages/jest-diff/package.json
+++ b/packages/jest-diff/package.json
@@ -25,8 +25,7 @@
     "pretty-format": "workspace:*"
   },
   "devDependencies": {
-    "@jest/test-utils": "workspace:*",
-    "strip-ansi": "^6.0.1"
+    "@jest/test-utils": "workspace:*"
   },
   "engines": {
     "node": "^18.14.0 || ^20.0.0 || >=22.0.0"

--- a/packages/jest-diff/src/__tests__/diff.test.ts
+++ b/packages/jest-diff/src/__tests__/diff.test.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {stripVTControlCharacters as stripAnsi} from 'util';
 import chalk = require('chalk');
-import stripAnsi = require('strip-ansi');
 import {alignedAnsiStyleSerializer} from '@jest/test-utils';
 import {diff} from '../';
 import {NO_DIFF_MESSAGE} from '../constants';

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -36,7 +36,6 @@
     "jest-worker": "workspace:*",
     "slash": "^3.0.0",
     "string-length": "^4.0.2",
-    "strip-ansi": "^6.0.1",
     "v8-to-istanbul": "^9.0.1"
   },
   "devDependencies": {

--- a/packages/jest-reporters/src/GitHubActionsReporter.ts
+++ b/packages/jest-reporters/src/GitHubActionsReporter.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {stripVTControlCharacters as stripAnsi} from 'util';
 import chalk = require('chalk');
-import stripAnsi = require('strip-ansi');
 import type {
   AggregatedResult,
   AssertionResult,

--- a/packages/jest-reporters/src/__tests__/utils.test.ts
+++ b/packages/jest-reporters/src/__tests__/utils.test.ts
@@ -6,8 +6,8 @@
  */
 
 import * as path from 'path';
+import {stripVTControlCharacters as stripAnsi} from 'util';
 import chalk = require('chalk');
-import stripAnsi = require('strip-ansi');
 import {makeProjectConfig} from '@jest/test-utils';
 import printDisplayName from '../printDisplayName';
 import trimAndFormatPath from '../trimAndFormatPath';

--- a/yarn.lock
+++ b/yarn.lock
@@ -3781,7 +3781,6 @@ __metadata:
     micromatch: ^4.0.8
     pretty-format: "workspace:*"
     slash: ^3.0.0
-    strip-ansi: ^6.0.1
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
@@ -3977,7 +3976,6 @@ __metadata:
     rimraf: ^5.0.10
     semver: ^7.7.2
     slash: ^3.0.0
-    strip-ansi: ^6.0.1
     strip-json-comments: ^3.1.1
     tempy: ^1.0.1
     ts-node: ^10.5.0
@@ -4037,7 +4035,6 @@ __metadata:
     node-notifier: ^10.0.0
     slash: ^3.0.0
     string-length: ^4.0.2
-    strip-ansi: ^6.0.1
     v8-to-istanbul: ^9.0.1
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
@@ -13821,7 +13818,6 @@ __metadata:
     "@jest/test-utils": "workspace:*"
     chalk: ^4.0.0
     pretty-format: "workspace:*"
-    strip-ansi: ^6.0.1
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
## Summary

Since support for Node.js 16 is dropped, it is possible to use the builtin `util.stripVTControlCharacters()` method instead of the `strip-ansi` package. It has strange name, but does exactly the same. The method is available since Node.js `16.11.0`.

Reference: https://nodejs.org/docs/latest/api/util.html#utilstripvtcontrolcharactersstr

## Test plan

Green CI.