### PR TITLE
chore: test types against a range of supported TypeScript versions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -48,7 +48,7 @@ jobs:
       - name: ts integration
         run: yarn test-ts --selectProjects ts-integration
       - name: type tests
-        run: yarn test-types --target 5.4,current
+        run: yarn test-types --target '>=5.4' # For documentation, see: https://tstyche.org/guide/typescript-versions
       - name: verify TypeScript@5.4 compatibility
         run: yarn verify-old-ts
       - name: run ESLint with type info

--- a/docs/UpgradingToJest30.md
+++ b/docs/UpgradingToJest30.md
@@ -20,7 +20,7 @@ Upgrading from an older version? You can see the upgrade guide from v28 to v29 [
 ## Compatibility
 
 - Jest 30 drops support for Node 14, 16, 19, and 21. The minimum supported Node versions are now 18.x. Ensure your environment is using a compatible Node release before upgrading.
-- The minimum TypeScript version is now 5.0. Support for TypeScript 4.3 and below has been removed. Update your TypeScript dependency to v5+ if you use TypeScript with Jest.
+- The minimum TypeScript version is now 5.4. Update TypeScript, if you are using type definitions of Jest (or any of its packages).
 - The `jest-environment-jsdom` package now uses JSDOM v26. This update may introduce behavior changes in the DOM environment. If you encounter differences in DOM behavior or new warnings, refer to the JSDOM release notes for [v21–26](https://github.com/jsdom/jsdom/compare/21.0.0...26.0.0).
 
 ## Jest Expect & Matchers


### PR DESCRIPTION
## Summary

Currently type tests run against the lowest supported (`5.4`) and the currently installed versions of TypeScript. While setting this up, I was assuming that the currently installed version will always be the latest. Or at least tests will fail while upgrading TypeScript.

That proved to be incorrect thinking. Recently #15623 got merge and the installed TypeScript version got downgraded from `5.8` to `5.5`. This means that now types are tested only agains `5.4` and `5.5`.

Another aspect: TypeScript does introduce breaking changes between major versions. To be sure that types work as expected for users of TypeScript `5.4` and above, one has to test agains `5.4`, `5.5`, `5.6` and so on.

TSTyche does exactly this when a range like `>=5.4` is passed as a target. It can also skip tests conditionally on certain versions (if that is needed). I have added a link to documentation page that explains all this in detail (;

## Test plan

Green CI.
