### PR TITLE
docs: update the type removal notes

### DIFF
--- a/docs/UpgradingToJest30.md
+++ b/docs/UpgradingToJest30.md
@@ -196,8 +196,6 @@ The type changes are only applicable if you explicitly import Jest APIs:
 import {expect, jest, test} from '@jest/globals';
 ```
 
-Consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
-
 :::
 
 Some TypeScript types related to mock functions have been removed from the public API.

--- a/docs/UpgradingToJest30.md
+++ b/docs/UpgradingToJest30.md
@@ -188,14 +188,6 @@ const mockFs = jest.createMockFromModule('fs');
 
 ### Removed Mock Function Types
 
-Some TypeScript types related to mock functions have been removed from the public API.
-
-- `MockFunctionMetadata`
-- `MockFunctionMetadataType`
-- `SpyInstance`
-
-If you were using `jest.SpyInstance` (for instance, to annotate the return of `jest.spyOn`), you should update to using [`jest.Spied`](./MockFunctionAPI.md#jestspiedsource).
-
 :::info
 
 The type changes are only applicable if you explicitly import Jest APIs:
@@ -207,6 +199,14 @@ import {expect, jest, test} from '@jest/globals';
 Consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
 
 :::
+
+Some TypeScript types related to mock functions have been removed from the public API.
+
+- `MockFunctionMetadata`
+- `MockFunctionMetadataType`
+- `SpyInstance`
+
+If you were using `jest.SpyInstance` (for instance, to annotate the return of `jest.spyOn`), you should update to using [`jest.Spied`](./MockFunctionAPI.md#jestspiedsource).
 
 ## Module & Runtime Changes
 

--- a/docs/UpgradingToJest30.md
+++ b/docs/UpgradingToJest30.md
@@ -194,11 +194,17 @@ Some TypeScript types related to mock functions have been removed from the publi
 - `MockFunctionMetadataType`
 - `SpyInstance`
 
-If you were using `jest.SpyInstance` in your TypeScript code (for instance, to annotate the return of `jest.spyOn`), you should update to using `jest.Mock` or the more specific `jest.MockedFunction` types.
+If you were using `jest.SpyInstance` (for instance, to annotate the return of `jest.spyOn`), you should update to using [`jest.Spied`](./MockFunctionAPI.md#jestspiedsource).
 
-:::note
+:::info
 
-These type removals do not affect runtime behavior – they are only relevant for TypeScript users. JavaScript users or tests will not notice any difference.
+The type changes are only applicable if you explicitly import Jest APIs:
+
+```ts
+import {expect, jest, test} from '@jest/globals';
+```
+
+Consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
 
 :::
 


### PR DESCRIPTION
Closes #15637

## Summary

This updates the type removal notes:

- actually `jest.SpyInstance` was just an alias of `jest.Spied`, see #14621
- it is also important to note that these are types shipped with `@jest/globals` (there are no changes for `@types/jest` users)

## Test plan

Deploy preview.