### PR TITLE
Fix destruction of core nodejs modules

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Get number of CPU cores
         id: cpu-cores
         uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
+      - name: run node-env tests
+        run: yarn test-node-env
       - name: run tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Get number of CPU cores
         id: cpu-cores
         uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
+      - name: run node-env tests
+        run: yarn test-node-env
       - name: run tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:

--- a/e2e/console-debugging/jest.config.js
+++ b/e2e/console-debugging/jest.config.js
@@ -10,5 +10,8 @@ require('./stdout-spy');
 
 module.exports = {
   testEnvironment: 'node',
+  testEnvironmentOptions: {
+    globalsCleanupMode: 'hard',
+  },
   verbose: true,
 };

--- a/e2e/esm-config/cjs/jest.config.cjs
+++ b/e2e/esm-config/cjs/jest.config.cjs
@@ -8,4 +8,7 @@
 module.exports = {
   displayName: 'Config from cjs file',
   testEnvironment: 'node',
+  testEnvironmentOptions: {
+    globalsCleanupMode: 'hard',
+  },
 };

--- a/e2e/esm-config/js/jest.config.js
+++ b/e2e/esm-config/js/jest.config.js
@@ -10,4 +10,7 @@ const displayName = await Promise.resolve('Config from js file');
 export default {
   displayName,
   testEnvironment: 'node',
+  testEnvironmentOptions: {
+    globalsCleanupMode: 'hard',
+  },
 };

--- a/e2e/esm-config/mjs/jest.config.mjs
+++ b/e2e/esm-config/mjs/jest.config.mjs
@@ -10,4 +10,7 @@ const displayName = await Promise.resolve('Config from mjs file');
 export default {
   displayName,
   testEnvironment: 'node',
+  testEnvironmentOptions: {
+    globalsCleanupMode: 'hard',
+  },
 };

--- a/e2e/esm-config/ts/jest.config.ts
+++ b/e2e/esm-config/ts/jest.config.ts
@@ -10,11 +10,17 @@
 type DummyConfig = {
   displayName: string;
   testEnvironment: string;
+  testEnvironmentOptions?: {
+    globalsCleanupMode: 'hard' | 'soft' | 'off';
+  };
 };
 
 const config: DummyConfig = {
   displayName: 'Config from ts file',
   testEnvironment: 'node',
+  testEnvironmentOptions: {
+    globalsCleanupMode: 'hard',
+  },
 };
 
 export default () => config;

--- a/e2e/typescript-config/modern-module-resolution/jest.config.ts
+++ b/e2e/typescript-config/modern-module-resolution/jest.config.ts
@@ -8,5 +8,8 @@
 const config = {
   displayName: 'Config from modern ts file',
   testEnvironment: 'node',
+  testEnvironmentOptions: {
+    globalsCleanupMode: 'hard',
+  },
 };
 export default config;

--- a/examples/react-native/jest.config.js
+++ b/examples/react-native/jest.config.js
@@ -3,7 +3,7 @@ const {resolve} = require('path');
 module.exports = {
   preset: 'react-native',
   testEnvironmentOptions: {
-    disableGlobalsCleanup: 'true',
+    globalsCleanupMode: 'soft',
   },
   // this is specific to the Jest repo, not generally needed (the files we ignore will be in node_modules which is ignored by default)
   transformIgnorePatterns: [resolve(__dirname, '../../packages')],

--- a/examples/react-native/jest.config.js
+++ b/examples/react-native/jest.config.js
@@ -2,6 +2,9 @@ const {resolve} = require('path');
 
 module.exports = {
   preset: 'react-native',
+  testEnvironmentOptions: {
+    disableGlobalsCleanup: 'true',
+  },
   // this is specific to the Jest repo, not generally needed (the files we ignore will be in node_modules which is ignored by default)
   transformIgnorePatterns: [resolve(__dirname, '../../packages')],
 };

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -37,6 +37,9 @@ export default {
     printBasicPrototype: true,
   },
   snapshotSerializers: [require.resolve('jest-serializer-ansi-escapes')],
+  testEnvironmentOptions: {
+    globalsCleanupMode: 'hard',
+  },
   testPathIgnorePatterns: [
     '/__arbitraries__/',
     '/__benchmarks__/',

--- a/package.json
+++ b/package.json
@@ -112,6 +112,7 @@
     "test-ts": "yarn jest --config jest.config.ts.mjs",
     "test-types": "yarn tstyche",
     "test-with-type-info": "yarn jest e2e/__tests__/jest.config.ts.test.ts",
+    "test-node-env": "yarn jest packages/jest-environment-node/src/__tests__",
     "test": "yarn lint && yarn jest",
     "typecheck": "yarn typecheck:examples && yarn typecheck:tests",
     "typecheck:examples": "tsc -p examples/expect-extend && tsc -p examples/typescript",

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -24,7 +24,8 @@
     "@jest/types": "workspace:*",
     "@types/node": "*",
     "jest-mock": "workspace:*",
-    "jest-util": "workspace:*"
+    "jest-util": "workspace:*",
+    "jest-validate": "workspace:*"
   },
   "devDependencies": {
     "@jest/test-utils": "workspace:*",

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -27,7 +27,8 @@
     "jest-util": "workspace:*"
   },
   "devDependencies": {
-    "@jest/test-utils": "workspace:*"
+    "@jest/test-utils": "workspace:*",
+    "clsx": "^2.0.0"
   },
   "engines": {
     "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"

--- a/packages/jest-environment-node/src/__tests__/node_environment.test.ts
+++ b/packages/jest-environment-node/src/__tests__/node_environment.test.ts
@@ -6,8 +6,14 @@
  */
 
 import type {EnvironmentContext} from '@jest/environment';
-import {makeGlobalConfig, makeProjectConfig} from '@jest/test-utils';
+import {
+  makeGlobalConfig,
+  makeProjectConfig,
+  onNodeVersions,
+} from '@jest/test-utils';
 import NodeEnvironment from '../';
+import {AsyncLocalStorage, createHook} from 'async_hooks';
+import {clsx} from 'clsx';
 
 const context: EnvironmentContext = {
   console,
@@ -90,5 +96,25 @@ describe('NodeEnvironment', () => {
 
   test('dispatch event', () => {
     new EventTarget().dispatchEvent(new Event('foo'));
+  });
+
+  test('set modules on global', () => {
+    (globalThis as any).async_hooks = require('async_hooks');
+    (globalThis as any).AsyncLocalStorage =
+      require('async_hooks').AsyncLocalStorage;
+    (globalThis as any).createHook = require('async_hooks').createHook;
+    (globalThis as any).clsx = require('clsx');
+    expect(AsyncLocalStorage).toBeDefined();
+    expect(clsx).toBeDefined();
+    expect(createHook).toBeDefined();
+    expect(createHook({})).toBeDefined();
+    expect(clsx()).toBeDefined();
+  });
+
+  onNodeVersions('>=19.8.0', () => {
+    test('use static function from core module set on global', () => {
+      expect(AsyncLocalStorage.snapshot).toBeDefined();
+      expect(AsyncLocalStorage.snapshot()).toBeDefined();
+    });
   });
 });

--- a/packages/jest-environment-node/src/__tests__/node_environment_2.test.ts
+++ b/packages/jest-environment-node/src/__tests__/node_environment_2.test.ts
@@ -5,8 +5,32 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {AsyncLocalStorage, createHook} from 'async_hooks';
+import {clsx} from 'clsx';
+import {onNodeVersions} from '@jest/test-utils';
+
 describe('NodeEnvironment 2', () => {
   test('dispatch event', () => {
     new EventTarget().dispatchEvent(new Event('foo'));
+  });
+
+  test('set modules on global', () => {
+    (globalThis as any).async_hooks = require('async_hooks');
+    (globalThis as any).AsyncLocalStorage =
+      require('async_hooks').AsyncLocalStorage;
+    (globalThis as any).createHook = require('async_hooks').createHook;
+    (globalThis as any).clsx = require('clsx');
+    expect(AsyncLocalStorage).toBeDefined();
+    expect(clsx).toBeDefined();
+    expect(createHook).toBeDefined();
+    expect(createHook({})).toBeDefined();
+    expect(clsx()).toBeDefined();
+  });
+
+  onNodeVersions('>=19.8.0', () => {
+    test('use static function from core module set on global', () => {
+      expect(AsyncLocalStorage.snapshot).toBeDefined();
+      expect(AsyncLocalStorage.snapshot()).toBeDefined();
+    });
   });
 });

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -15,11 +15,13 @@ import {LegacyFakeTimers, ModernFakeTimers} from '@jest/fake-timers';
 import type {Global} from '@jest/types';
 import {ModuleMocker} from 'jest-mock';
 import {
+  type DeletionMode,
   canDeleteProperties,
   deleteProperties,
   installCommonGlobals,
   protectProperties,
 } from 'jest-util';
+import {logValidationWarning} from 'jest-validate';
 
 type Timer = {
   id: number;
@@ -86,7 +88,7 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
   customExportConditions = ['node', 'node-addons'];
   private readonly _configuredExportConditions?: Array<string>;
   private _globalProxy: GlobalProxy;
-  private _clearGlobalsAtShutdown: boolean;
+  private _globalsCleanupMode: 'off' | DeletionMode;
 
   // while `context` is unused, it should always be passed
   constructor(config: JestEnvironmentConfig, _context: EnvironmentContext) {
@@ -204,9 +206,27 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
     });
 
     this._globalProxy.envSetupCompleted();
-    this._clearGlobalsAtShutdown = ![true, 'true'].includes(
-      projectConfig.testEnvironmentOptions['disableGlobalsCleanup'] as any,
-    );
+    this._globalsCleanupMode = (() => {
+      const rawConfig =
+        projectConfig.testEnvironmentOptions['globalsCleanupMode'];
+      const config = rawConfig?.toString()?.toLowerCase();
+      switch (config) {
+        case 'hard':
+        case 'soft':
+        case 'off':
+          return config;
+        default: {
+          if (config !== undefined) {
+            logValidationWarning(
+              'testEnvironmentOptions.globalsCleanupMode',
+              `Unknown value given: ${rawConfig}`,
+              'Available options are: [hard, soft, off]',
+            );
+          }
+          return 'soft';
+        }
+      }
+    })();
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -222,8 +242,8 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
     this.context = null;
     this.fakeTimers = null;
     this.fakeTimersModern = null;
-    if (this._clearGlobalsAtShutdown) {
-      this._globalProxy.clear();
+    if (this._globalsCleanupMode !== 'off') {
+      this._globalProxy.clear(this._globalsCleanupMode);
     }
   }
 
@@ -274,8 +294,10 @@ class GlobalProxy implements ProxyHandler<typeof globalThis> {
    * Deletes any property that was set on the global object, except for:
    * 1. Properties that were set before {@link #envSetupCompleted} was invoked.
    * 2. Properties protected by {@link #protectProperties}.
+   *
+   * @param mode determines whether to soft or hard delete the properties.
    */
-  clear(): void {
+  clear(mode: DeletionMode): void {
     for (const {value} of [
       ...[...this.propertyToValue.entries()].map(([property, value]) => ({
         property,
@@ -283,7 +305,7 @@ class GlobalProxy implements ProxyHandler<typeof globalThis> {
       })),
       ...this.leftovers,
     ]) {
-      deleteProperties(value);
+      deleteProperties(value, mode);
     }
     this.propertyToValue.clear();
     this.leftovers = [];

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -86,6 +86,7 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
   customExportConditions = ['node', 'node-addons'];
   private readonly _configuredExportConditions?: Array<string>;
   private _globalProxy: GlobalProxy;
+  private _clearGlobalsAtShutdown: boolean;
 
   // while `context` is unused, it should always be passed
   constructor(config: JestEnvironmentConfig, _context: EnvironmentContext) {
@@ -203,6 +204,9 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
     });
 
     this._globalProxy.envSetupCompleted();
+    this._clearGlobalsAtShutdown = ![true, 'true'].includes(
+      projectConfig.testEnvironmentOptions['disableGlobalsCleanup'] as any,
+    );
   }
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
@@ -218,7 +222,9 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
     this.context = null;
     this.fakeTimers = null;
     this.fakeTimersModern = null;
-    this._globalProxy.clear();
+    if (this._clearGlobalsAtShutdown) {
+      this._globalProxy.clear();
+    }
   }
 
   exportConditions(): Array<string> {

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -270,20 +270,14 @@ class GlobalProxy implements ProxyHandler<typeof globalThis> {
    * 2. Properties protected by {@link #protectProperties}.
    */
   clear(): void {
-    for (const {property, value} of [
+    for (const {value} of [
       ...[...this.propertyToValue.entries()].map(([property, value]) => ({
         property,
         value,
       })),
       ...this.leftovers,
     ]) {
-      /*
-       * React Native's test setup invokes their custom `performance` property after env teardown.
-       * Once they start using `protectProperties`, we can get rid of this.
-       */
-      if (property !== 'performance') {
-        deleteProperties(value);
-      }
+      deleteProperties(value);
     }
     this.propertyToValue.clear();
     this.leftovers = [];

--- a/packages/jest-environment-node/tsconfig.json
+++ b/packages/jest-environment-node/tsconfig.json
@@ -12,6 +12,7 @@
     {"path": "../jest-fake-timers"},
     {"path": "../jest-mock"},
     {"path": "../jest-types"},
-    {"path": "../jest-util"}
+    {"path": "../jest-util"},
+    {"path": "../jest-validate"}
   ]
 }

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -55,6 +55,7 @@ import {
   deepCyclicCopy,
   invariant,
   isNonNullable,
+  protectProperties,
 } from 'jest-util';
 import {
   createOutsideJestVmPath,
@@ -1767,7 +1768,9 @@ export default class Runtime {
       return this._getMockedNativeModule();
     }
 
-    return require(moduleName);
+    const coreModule = require(moduleName);
+    protectProperties(coreModule);
+    return coreModule;
   }
 
   private _importCoreModule(moduleName: string, context: VMContext) {

--- a/packages/jest-util/package.json
+++ b/packages/jest-util/package.json
@@ -28,7 +28,8 @@
   },
   "devDependencies": {
     "@types/graceful-fs": "^4.1.3",
-    "@types/picomatch": "^4.0.0"
+    "@types/picomatch": "^4.0.0",
+    "lodash": "^4.17.19"
   },
   "engines": {
     "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"

--- a/packages/jest-util/src/__tests__/garbage-collection-utils.test.ts
+++ b/packages/jest-util/src/__tests__/garbage-collection-utils.test.ts
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {protectProperties} from '../garbage-collection-utils';
+
+const omit = require('lodash').omit;
+
+it('protection symbol doesnt leak', () => {
+  const obj = {a: 1, b: 2};
+  protectProperties(obj);
+  expect(obj).toStrictEqual(obj);
+  expect(omit(obj, 'a')).toStrictEqual({b: 2});
+  expect({b: 2}).toStrictEqual(omit(obj, 'a'));
+});

--- a/packages/jest-util/src/garbage-collection-utils.ts
+++ b/packages/jest-util/src/garbage-collection-utils.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const PROTECT_PROPERTY = Symbol.for('$$jest-protect-from-deletion');
+const PROTECT_SYMBOL = Symbol.for('$$jest-protect-from-deletion');
 
 /**
  * Deletes all the properties from the given value (if it's an object),
@@ -15,12 +15,13 @@ const PROTECT_PROPERTY = Symbol.for('$$jest-protect-from-deletion');
  */
 export function deleteProperties(value: unknown): void {
   if (canDeleteProperties(value)) {
-    const protectedProperties = Reflect.get(value, PROTECT_PROPERTY);
-    if (!Array.isArray(protectedProperties) || protectedProperties.length > 0) {
-      for (const key of Reflect.ownKeys(value)) {
-        if (!protectedProperties?.includes(key)) {
-          Reflect.deleteProperty(value, key);
-        }
+    const protectedKeys = getProtectedKeys(
+      value,
+      Reflect.get(value, PROTECT_SYMBOL),
+    );
+    for (const key of Reflect.ownKeys(value)) {
+      if (!protectedKeys.includes(key) && key !== PROTECT_SYMBOL) {
+        Reflect.deleteProperty(value, key);
       }
     }
   }
@@ -31,15 +32,40 @@ export function deleteProperties(value: unknown): void {
  *
  * @param value The given value.
  * @param properties If the array contains any property,
- * then only these properties will not be deleted; otherwise if the array is empty,
- * all properties will not be deleted.
+ * then only these properties will be protected; otherwise if the array is empty,
+ * all properties will be protected.
+ * @param depth Determines how "deep" the protection should be.
+ * A value of 0 means that only the top-most properties will be protected,
+ * while a value larger than 0 means that deeper levels of nesting will be protected as well.
  */
-export function protectProperties<T extends object>(
+export function protectProperties<T>(
   value: T,
   properties: Array<keyof T> = [],
+  depth = 2,
 ): boolean {
-  if (canDeleteProperties(value)) {
-    return Reflect.set(value, PROTECT_PROPERTY, properties);
+  if (
+    depth >= 0 &&
+    canDeleteProperties(value) &&
+    !Reflect.has(value, PROTECT_SYMBOL)
+  ) {
+    const result = Reflect.set(value, PROTECT_SYMBOL, properties);
+    for (const key of getProtectedKeys(value, properties)) {
+      const originalEmitWarning = process.emitWarning;
+      try {
+        // Reflect.get may cause deprecation warnings, so we disable them temporarily
+        // eslint-disable-next-line @typescript-eslint/no-empty-function
+        process.emitWarning = () => {};
+
+        const nested = Reflect.get(value, key);
+        protectProperties(nested, [], depth - 1);
+      } catch {
+        // Reflect.get might fail in certain edge-cases
+        // Instead of failing the entire process, we will skip the property.
+      } finally {
+        process.emitWarning = originalEmitWarning;
+      }
+    }
+    return result;
   }
   return false;
 }
@@ -56,4 +82,16 @@ export function canDeleteProperties(value: unknown): value is object {
   }
 
   return false;
+}
+
+function getProtectedKeys<T extends object>(
+  value: T,
+  properties: Array<keyof T> | undefined,
+): Array<string | symbol | number> {
+  if (properties === undefined) {
+    return [];
+  }
+  const protectedKeys =
+    properties.length > 0 ? properties : Reflect.ownKeys(value);
+  return protectedKeys.filter(key => PROTECT_SYMBOL !== key);
 }

--- a/packages/jest-util/src/garbage-collection-utils.ts
+++ b/packages/jest-util/src/garbage-collection-utils.ts
@@ -58,7 +58,11 @@ export function protectProperties<T>(
       canDeleteProperties(value) &&
       !Reflect.has(value, PROTECT_SYMBOL)
     ) {
-      const result = Reflect.set(value, PROTECT_SYMBOL, properties);
+      const result = Reflect.defineProperty(value, PROTECT_SYMBOL, {
+        configurable: true,
+        enumerable: false,
+        value: properties,
+      });
       for (const key of getProtectedKeys(value, properties)) {
         try {
           const nested = Reflect.get(value, key);

--- a/packages/jest-util/src/index.ts
+++ b/packages/jest-util/src/index.ts
@@ -30,6 +30,7 @@ export {default as requireOrImportModule} from './requireOrImportModule';
 export {default as invariant} from './invariant';
 export {default as isNonNullable} from './isNonNullable';
 export {
+  type DeletionMode,
   canDeleteProperties,
   protectProperties,
   deleteProperties,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13872,6 +13872,7 @@ __metadata:
     clsx: ^2.0.0
     jest-mock: "workspace:*"
     jest-util: "workspace:*"
+    jest-validate: "workspace:*"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13869,6 +13869,7 @@ __metadata:
     "@jest/test-utils": "workspace:*"
     "@jest/types": "workspace:*"
     "@types/node": "*"
+    clsx: ^2.0.0
     jest-mock: "workspace:*"
     jest-util: "workspace:*"
   languageName: unknown

--- a/yarn.lock
+++ b/yarn.lock
@@ -14267,6 +14267,7 @@ __metadata:
     chalk: ^4.0.0
     ci-info: ^4.0.0
     graceful-fs: ^4.2.9
+    lodash: ^4.17.19
     picomatch: ^4.0.0
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

Fixes #15638 that was introduced in #15215.

The PR fixes the deletion of core modules that are set as globals (some third party libraries do that for some reason) by adding protection on them from deletion when they are required.

## Test plan

The `jest-environment-node` unit tests were expanded to catch the bug.

Plus I added a new yarn script `test-node-env` (+ added to CI) to make sure that the `jest-environment-node` unit tests run in the same CI shard; if they don't run in the same process/jest execution, then they don't properly test the bug (same for #15636).