### PR TITLE
Remove testPathPatterns Jest config details from v30 upgrade guide

### DIFF
--- a/docs/UpgradingToJest30.md
+++ b/docs/UpgradingToJest30.md
@@ -77,41 +77,19 @@ If your project contains files with these extensions that are **not** intended t
 
 :::
 
-### `testPathPattern` Renamed to `testPathPatterns`
+### `--testPathPattern` Renamed to `--testPathPatterns`
 
-If you filter tests by path, note that the configuration option and CLI flag have changed:
+If you filter tests by path, note that the CLI flag has changed: The `--testPathPattern` flag is now `--testPathPatterns`. You can pass multiple patterns by separating them with spaces or by repeating the flag. For example:
 
-- **Configuration:** The `testPathPattern` option (singular) has been replaced by `testPathPatterns` (plural). Instead of a single regex string, this option now takes an array of patterns. For example:
+```bash
+# Old (Jest 29)
+jest --testPathPattern="unit/.*"
 
-  Jest 29 configuration:
+# New (Jest 30)
+jest --testPathPatterns "unit/.*" "integration/.*"
+```
 
-  ```js
-  export default {
-    testPathPattern: 'e2e/.*\\.spec\\.js',
-  };
-  ```
-
-  Jest 30 configuration:
-
-  ```js
-  export default {
-    testPathPatterns: ['e2e/.*\\.spec\\.js'],
-  };
-  ```
-
-  Each pattern in the array is treated as a regex or glob to match test file paths.
-
-- **CLI usage:** The `--testPathPattern` flag is now `--testPathPatterns`. You can pass multiple patterns by separating them with spaces or by repeating the flag. For example:
-
-  ```bash
-  # Old (Jest 29)
-  jest --testPathPattern="unit/.*"
-
-  # New (Jest 30)
-  jest --testPathPatterns "unit/.*" "integration/.*"
-  ```
-
-  Internally, Jest consolidates these patterns into a `TestPathPatterns` object. If you were programmatically calling Jest’s watch mode with a `testPathPattern`, you must now construct a `TestPathPatterns` instance instead.
+Internally, Jest consolidates these patterns into a `TestPathPatterns` object. If you were programmatically calling Jest’s watch mode with a `testPathPattern`, you must now construct a `TestPathPatterns` instance instead.
 
 ### Removed `--init` Command
 


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
It seems that this is only a CLI option, and not supported in the Jest config file, so we shouldn't include those details in this upgrade guide.

More details in https://github.com/jestjs/jest/issues/15645

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
I cloned this repo: https://github.com/lencioni/jest-test-path-patterns

Then I installed Jest v29 and ran `yarn jest --config singular.config.js`. It logged this validation warning:

```
● Validation Warning:

  Unknown option "testPathPattern" with value /__tests__\/.*\.test\.js$/ was found.
  This is probably a typing mistake. Fixing it will remove this message.

  Configuration Documentation:
  https://jestjs.io/docs/configuration

● Validation Warning:

  Unknown option "testPathPattern" with value /__tests__\/.*\.test\.js$/ was found.
  This is probably a typing mistake. Fixing it will remove this message.

  Configuration Documentation:
  https://jestjs.io/docs/configuration
```