### PR TITLE
Do not invoke Circle CI on Pull Requests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,4 +56,14 @@ workflows:
           matrix:
             parameters:
               node-version: ['18', '20', '22', '24']
-      - test-jest-jasmine
+          filters:
+            branches:
+              only: main
+            pull_requests:
+              ignore: /.*/
+      - test-jest-jasmine:
+          filters:
+            branches:
+              only: main
+            pull_requests:
+              ignore: /.*/


### PR DESCRIPTION
## Summary

I bypass checks all the time because Circle is not doing anything on Pull Requests. We are just "waiting" for the status updates, and it seems to take forever. This PR disables circle on PRs, but still runs them on main.

imho, we should just get rid of it. Our GitHub Actions pipeline takes care of everything, and we don't need to run Jest across 4 versions of on another CI provider. If Jest passes on GitHub Actions, and breaks on Circle, it's because of them, not because of us.

## Test plan

Circle shouldn't run on this PR (or subsequent ones, I guess?).