### PR TITLE
Globals cleanup: avoid setting protection symbol when feature is off

### DIFF
--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -33,7 +33,7 @@ jobs:
         id: cpu-cores
         uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
       - name: run node-env tests
-        run: yarn test-node-env
+        run: yarn workspace jest-environment-node test
       - name: run tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
         id: cpu-cores
         uses: SimenB/github-actions-cpu-cores@97ba232459a8e02ff6121db9362b09661c875ab8 # v2.0.0
       - name: run node-env tests
-        run: yarn test-node-env
+        run: yarn workspace jest-environment-node test
       - name: run tests
         uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # v3.0.2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - `[jest-resolver]` Resolve builtin modules correctly ([#15683](https://github.com/jestjs/jest/pull/15683))
+- `[jest-environment-node, jest-util]` Avoid setting globals cleanup protection symbol when feature is off ([#15684](https://github.com/jestjs/jest/pull/15684))
 
 ### Chore & Maintenance
 

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -38,7 +38,7 @@ export default {
   },
   snapshotSerializers: [require.resolve('jest-serializer-ansi-escapes')],
   testEnvironmentOptions: {
-    globalsCleanup: 'on',
+    globalsCleanup: process.env.GLOBALS_CLEANUP ?? 'on',
   },
   testPathIgnorePatterns: [
     '/__arbitraries__/',

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "test-ts": "yarn jest --config jest.config.ts.mjs",
     "test-types": "yarn tstyche",
     "test-with-type-info": "yarn jest e2e/__tests__/jest.config.ts.test.ts",
-    "test-node-env": "yarn jest packages/jest-environment-node/src/__tests__",
     "test": "yarn lint && yarn jest",
     "typecheck": "yarn typecheck:examples && yarn typecheck:tests",
     "typecheck:examples": "tsc -p examples/expect-extend && tsc -p examples/typescript",

--- a/packages/jest-environment-node/package.json
+++ b/packages/jest-environment-node/package.json
@@ -31,6 +31,13 @@
     "@jest/test-utils": "workspace:*",
     "clsx": "^2.1.1"
   },
+  "scripts": {
+    "test:base": "echo GLOBALS_CLEANUP=$GLOBALS_CLEANUP && yarn --cwd='../.' jest --runInBand packages/jest-environment-node/src/__tests__",
+    "test:globals-cleanup-off": "GLOBALS_CLEANUP=off yarn test:base",
+    "test:globals-cleanup-soft": "GLOBALS_CLEANUP=soft yarn test:base",
+    "test:globals-cleanup-on": "GLOBALS_CLEANUP=on yarn test:base",
+    "test": "yarn test:globals-cleanup-off && yarn test:globals-cleanup-soft && yarn test:globals-cleanup-on"
+  },
   "engines": {
     "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
   },

--- a/packages/jest-environment-node/src/__tests__/globals_cleanup_1.test.ts
+++ b/packages/jest-environment-node/src/__tests__/globals_cleanup_1.test.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import { AsyncLocalStorage, createHook } from "async_hooks";
-import { clsx } from "clsx";
-import { onNodeVersions } from "@jest/test-utils";
+import {AsyncLocalStorage, createHook} from 'async_hooks';
+import {clsx} from 'clsx';
+import {onNodeVersions} from '@jest/test-utils';
 
 describe('Globals Cleanup 1', () => {
   test('dispatch event', () => {

--- a/packages/jest-environment-node/src/__tests__/globals_cleanup_1.test.ts
+++ b/packages/jest-environment-node/src/__tests__/globals_cleanup_1.test.ts
@@ -5,11 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {AsyncLocalStorage, createHook} from 'async_hooks';
-import {clsx} from 'clsx';
-import {onNodeVersions} from '@jest/test-utils';
+import { AsyncLocalStorage, createHook } from "async_hooks";
+import { clsx } from "clsx";
+import { onNodeVersions } from "@jest/test-utils";
 
-describe('NodeEnvironment 2', () => {
+describe('Globals Cleanup 1', () => {
   test('dispatch event', () => {
     new EventTarget().dispatchEvent(new Event('foo'));
   });

--- a/packages/jest-environment-node/src/__tests__/globals_cleanup_2.test.ts
+++ b/packages/jest-environment-node/src/__tests__/globals_cleanup_2.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {AsyncLocalStorage, createHook} from 'async_hooks';
+import {clsx} from 'clsx';
+import {onNodeVersions} from '@jest/test-utils';
+
+describe('Globals Cleanup 2', () => {
+  test('dispatch event', () => {
+    new EventTarget().dispatchEvent(new Event('foo'));
+  });
+
+  test('set modules on global', () => {
+    (globalThis as any).async_hooks = require('async_hooks');
+    (globalThis as any).AsyncLocalStorage =
+      require('async_hooks').AsyncLocalStorage;
+    (globalThis as any).createHook = require('async_hooks').createHook;
+    (globalThis as any).clsx = require('clsx');
+    expect(AsyncLocalStorage).toBeDefined();
+    expect(clsx).toBeDefined();
+    expect(createHook).toBeDefined();
+    expect(createHook({})).toBeDefined();
+    expect(clsx()).toBeDefined();
+  });
+
+  onNodeVersions('>=19.8.0', () => {
+    test('use static function from core module set on global', () => {
+      expect(AsyncLocalStorage.snapshot).toBeDefined();
+      expect(AsyncLocalStorage.snapshot()).toBeDefined();
+    });
+  });
+});

--- a/packages/jest-environment-node/src/__tests__/globals_cleanup_3.test.ts
+++ b/packages/jest-environment-node/src/__tests__/globals_cleanup_3.test.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+function onlyIfGlobalsCleanup(
+  globalsCleanup: string,
+  testBody: () => void,
+): void {
+  const describeFunc =
+    process.env.GLOBALS_CLEANUP === globalsCleanup ? describe : describe.skip;
+  describeFunc(`GLOBALS_CLEANUP=${globalsCleanup}`, testBody);
+}
+
+describe('Globals Cleanup 3', () => {
+  onlyIfGlobalsCleanup('off', () => {
+    test('assign Object prototype descriptors to a new empty object', () => {
+      const descriptors = Object.getOwnPropertyDescriptors(
+        Object.getPrototypeOf({}),
+      );
+      Object.assign({}, descriptors);
+    });
+  });
+});

--- a/packages/jest-environment-node/src/__tests__/node_environment.test.ts
+++ b/packages/jest-environment-node/src/__tests__/node_environment.test.ts
@@ -6,14 +6,8 @@
  */
 
 import type {EnvironmentContext} from '@jest/environment';
-import {
-  makeGlobalConfig,
-  makeProjectConfig,
-  onNodeVersions,
-} from '@jest/test-utils';
+import {makeGlobalConfig, makeProjectConfig} from '@jest/test-utils';
 import NodeEnvironment from '../';
-import {AsyncLocalStorage, createHook} from 'async_hooks';
-import {clsx} from 'clsx';
 
 const context: EnvironmentContext = {
   console,
@@ -92,29 +86,5 @@ describe('NodeEnvironment', () => {
 
   test('TextEncoder references the same global Uint8Array constructor', () => {
     expect(new TextEncoder().encode('abc')).toBeInstanceOf(Uint8Array);
-  });
-
-  test('dispatch event', () => {
-    new EventTarget().dispatchEvent(new Event('foo'));
-  });
-
-  test('set modules on global', () => {
-    (globalThis as any).async_hooks = require('async_hooks');
-    (globalThis as any).AsyncLocalStorage =
-      require('async_hooks').AsyncLocalStorage;
-    (globalThis as any).createHook = require('async_hooks').createHook;
-    (globalThis as any).clsx = require('clsx');
-    expect(AsyncLocalStorage).toBeDefined();
-    expect(clsx).toBeDefined();
-    expect(createHook).toBeDefined();
-    expect(createHook({})).toBeDefined();
-    expect(clsx()).toBeDefined();
-  });
-
-  onNodeVersions('>=19.8.0', () => {
-    test('use static function from core module set on global', () => {
-      expect(AsyncLocalStorage.snapshot).toBeDefined();
-      expect(AsyncLocalStorage.snapshot()).toBeDefined();
-    });
   });
 });

--- a/packages/jest-util/src/index.ts
+++ b/packages/jest-util/src/index.ts
@@ -32,6 +32,7 @@ export {default as isNonNullable} from './isNonNullable';
 export {
   type DeletionMode,
   canDeleteProperties,
+  initializeGarbageCollectionUtils,
   protectProperties,
   deleteProperties,
 } from './garbage-collection-utils';

--- a/packages/jest-util/src/installCommonGlobals.ts
+++ b/packages/jest-util/src/installCommonGlobals.ts
@@ -9,12 +9,17 @@ import * as fs from 'graceful-fs';
 import type {Config} from '@jest/types';
 import createProcessObject from './createProcessObject';
 import deepCyclicCopy from './deepCyclicCopy';
+import {
+  type DeletionMode,
+  initializeGarbageCollectionUtils,
+} from './garbage-collection-utils';
 
 const DTRACE = Object.keys(globalThis).filter(key => key.startsWith('DTRACE'));
 
 export default function installCommonGlobals(
   globalObject: typeof globalThis,
   globals: Config.ConfigGlobals,
+  garbageCollectionDeletionMode?: DeletionMode,
 ): typeof globalThis & Config.ConfigGlobals {
   globalObject.process = createProcessObject();
 
@@ -60,6 +65,13 @@ export default function installCommonGlobals(
       // @ts-expect-error: no index
       return globalThis[dtrace].apply(this, args);
     };
+  }
+
+  if (garbageCollectionDeletionMode) {
+    initializeGarbageCollectionUtils(
+      globalObject,
+      garbageCollectionDeletionMode,
+    );
   }
 
   return Object.assign(globalObject, deepCyclicCopy(globals));


### PR DESCRIPTION
## Summary

Fixes #15678.

First commit also makes sure to run `jest-environment-node` tests will every combination of the `globalsCleanup` configuration.