### PR TITLE
chore: add sample snippet to configure main fields for module resolution algorithm

### DIFF
--- a/website/versioned_docs/version-30.0/Configuration.md
+++ b/website/versioned_docs/version-30.0/Configuration.md
@@ -1529,6 +1529,20 @@ const config: Config = {
 export default config;
 ```
 
+Based on the fact that `jest-resolve` uses `unrs-resolver` and passes additional options to it, we can modify the configuration of `mainFields`. For example, for React Native projects, you might use this config:
+
+```js
+module.exports = (path, options) => {
+  // Call the defaultResolver, so we leverage its cache, error handling, etc.
+  return options.defaultResolver(path, {
+    ...options,
+    // This is option from unrs-resolver from https://github.com/unrs/unrs-resolver?tab=readme-ov-file#main-field
+    // We use the fact that jest-resolve just passes extra options to unrs-resolver
+    mainFields: ['react-native', 'main'],
+  });
+};
+```
+
 ### `restoreMocks` \[boolean]
 
 Default: `false`

--- a/website/versioned_docs/version-30.0/Configuration.md
+++ b/website/versioned_docs/version-30.0/Configuration.md
@@ -1529,15 +1529,14 @@ const config: Config = {
 export default config;
 ```
 
-Based on the fact that `jest-resolve` uses `unrs-resolver` and passes additional options to it, we can modify the configuration of `mainFields`. For example, for React Native projects, you might use this config:
+Jest's `jest-resolve` relies on `unrs-resolver`. We can pass additional options, for example modifying `mainFields` for resolution. For example, for React Native projects, you might want to use this config:
 
 ```js
 module.exports = (path, options) => {
   // Call the defaultResolver, so we leverage its cache, error handling, etc.
   return options.defaultResolver(path, {
     ...options,
-    // This is option from unrs-resolver from https://github.com/unrs/unrs-resolver?tab=readme-ov-file#main-field
-    // We use the fact that jest-resolve just passes extra options to unrs-resolver
+    // See this `unrs-resolver` option: from https://github.com/unrs/unrs-resolver?tab=readme-ov-file#main-field
     mainFields: ['react-native', 'main'],
   });
 };


### PR DESCRIPTION
## Summary

jest 30 changes resolver implementation and removed incorrect snippet from docs in #15679

It is replacement suitable to use with jest 30, as suggested in [comment](https://github.com/jestjs/jest/pull/15679/files/37399db93e4c46d132b4213f79b7007d35f950b0#r2153120470).

## Test plan

There is no code changes, just documentation.

## Open questions

I think that this small PR can be merged as is, other improvements can be made in separate changes, but still...

1. #15679 changed website folder with docs for jest 30, but old docs still exists in docs folder... Do we need to deal with them?
2. Do I need to fill changelog for so small change? It seems that this is not worth it