### PR TITLE
feat: Have `Inverse` exportable in types.ts

### DIFF
--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -106,7 +106,7 @@ export type Expect = (<T = unknown>(
   AsymmetricMatchers &
   Inverse<Omit<AsymmetricMatchers, 'any' | 'anything'>>;
 
-type Inverse<Matchers> = {
+export type Inverse<Matchers> = {
   /**
    * Inverse next matcher. If you know how to test something, `.not` lets you test its opposite.
    */


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

The [expect-webdriverio](https://github.com/webdriverio/expect-webdriverio) is based on the `expect` library, and it would be helpful  if the `Inverse<Matchers>` could be exportable [here](https://github.com/jestjs/jest/blob/77cc947dfc4a5801cd17fba580b5229f15c1ed97/packages/expect/src/types.ts#L109)
I can open a PR for it!The [expect-webdriverio](https://github.com/webdriverio/expect-webdriverio) is based on the `expect` library, and it would be helpful  if the `Inverse<Matchers>` could be exportable [here](https://github.com/jestjs/jest/blob/77cc947dfc4a5801cd17fba580b5229f15c1ed97/packages/expect/src/types.ts#L109)
I can open a PR for it!

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When implementing our `Expect` interface, we have a new method like `soft` where we want to reuse Inverse as shown below

```ts
// Copied while we would like to export it!
type Inverse<M> = {
    /**
     * Inverse next matcher. If you know how to test something, `.not` lets you test its opposite.
     */
    not: M;
}

declare namespace ExpectWebdriverIO {
    Inverse<R, T> = ExpectWebdriverIO.Matchers<R, T> & Inverse<ExpectWebdriverIO.Matchers<R, T>>

    interface Expect extends ExpectLibExpect {

        <T = unknown>(actual: T): MatchersAndInverse<void, T>;
        soft<T = unknown>(actual: T): T extends PromiseLikeType ? MatchersAndInverse<Promise<void>, T> : MatchersAndInverse<void, T>
    }
```

## Test plan
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

As it's just an export, it seems safe enough.
