### PR TITLE
fix: optimized replaceAll with regexp

### DIFF
--- a/packages/jest-each/src/table/array.ts
+++ b/packages/jest-each/src/table/array.ts
@@ -17,7 +17,7 @@ const PRETTY_PLACEHOLDER = '%p';
 const INDEX_PLACEHOLDER = '%#';
 const NUMBER_PLACEHOLDER = '%$';
 const PLACEHOLDER_PREFIX = '%';
-const ESCAPED_PLACEHOLDER_PREFIX = /%%/g;
+const ESCAPED_PLACEHOLDER_PREFIX = '%%';
 const JEST_EACH_PLACEHOLDER_ESCAPE = '@@__JEST_EACH_PLACEHOLDER_ESCAPE__@@';
 
 export default function array(
@@ -77,17 +77,11 @@ const formatTitle = (
         rowIndex,
       ),
     )
-    .replaceAll(
-      new RegExp(JEST_EACH_PLACEHOLDER_ESCAPE, 'g'),
-      PLACEHOLDER_PREFIX,
-    );
+    .replaceAll(JEST_EACH_PLACEHOLDER_ESCAPE, PLACEHOLDER_PREFIX);
 
 const normalisePlaceholderValue = (value: unknown) =>
   typeof value === 'string'
-    ? value.replaceAll(
-        new RegExp(PLACEHOLDER_PREFIX, 'g'),
-        JEST_EACH_PLACEHOLDER_ESCAPE,
-      )
+    ? value.replaceAll(PLACEHOLDER_PREFIX, JEST_EACH_PLACEHOLDER_ESCAPE)
     : value;
 
 const getMatchingPlaceholders = (title: string) =>


### PR DESCRIPTION
With replaceAll, there's no need to use regular expressions with the g flag.
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
