### PR TITLE
fix: optimize match siblings

### DIFF
--- a/packages/jest-runtime/src/helpers.ts
+++ b/packages/jest-runtime/src/helpers.ts
@@ -43,15 +43,17 @@ export const findSiblingsWithFileExtension = (
 
       const matches = glob
         .sync(`${pathToModule}.*`, {windowsPathsNoEscape: true})
-        .map(match => slash(match))
         .map(match => {
-          const relativePath = path.posix.relative(slashedDirname, match);
+          const slashedMap = slash(match);
+          const relativePath = path.posix.relative(slashedDirname, slashedMap);
 
-          return path.posix.dirname(match) === slashedDirname
-            ? `./${relativePath}`
-            : relativePath;
+          const slashedPath =
+            path.posix.dirname(slashedMap) === slashedDirname
+              ? `./${relativePath}`
+              : relativePath;
+
+          return `\t'${slashedPath}'`;
         })
-        .map(match => `\t'${match}'`)
         .join('\n');
 
       if (matches) {


### PR DESCRIPTION
I just joined 3 `map` chains to single `map` to avoid creating needless objects.
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
