### PR TITLE
Deduplicate static checks in CI workflow

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -56,8 +56,8 @@ jobs:
       - name: Run tests depending on type information
         run: yarn test-with-type-info
 
-  typecheck:
-    name: Typecheck Examples and Tests
+  static-checks:
+    name: Static Checks (Lint, Typecheck, Yarn Validate)
     runs-on: ubuntu-latest
     needs: prepare-yarn-cache-ubuntu
 
@@ -71,30 +71,14 @@ jobs:
           cache: yarn
       - name: install
         run: yarn --immutable
-      - name: build
+      - name: build TypeScript
         run: yarn build:ts
+      - name: build JavaScript
+        run: yarn build:js
       - name: typecheck examples
         run: yarn typecheck:examples
       - name: typecheck tests
         run: yarn typecheck:tests
-
-  lint:
-    name: Lint
-    runs-on: ubuntu-latest
-    needs: prepare-yarn-cache-ubuntu
-
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: lts/*
-          cache: yarn
-      - name: install
-        run: yarn --immutable
-      - name: build
-        run: yarn build:js
       - name: verify Yarn PnP compatibility
         run: yarn verify-pnp
       - name: run eslint
@@ -105,21 +89,6 @@ jobs:
         run: yarn check-changelog
       - name: check copyright headers
         run: yarn check-copyright-headers
-
-  yarn-validate:
-    name: Validate Yarn dependencies and constraints
-    runs-on: ubuntu-latest
-    needs: prepare-yarn-cache-ubuntu
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        with:
-          persist-credentials: false
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
-        with:
-          node-version: lts/*
-          cache: yarn
-      - name: install
-        run: yarn --immutable
       - name: 'Check for unmet constraints (fix w/ "yarn constraints --fix")'
         run: yarn constraints
       - name: 'Check for duplicate dependencies (fix w/ "yarn dedupe")'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Fixes
 
 - `[expect]` Fix `bigint` error ([#15702](https://github.com/jestjs/jest/pull/15702))
+- `[ci]` Deduplicate static checks in CI workflow by combining typecheck, lint, and yarn-validate jobs
 
 ## 30.0.4
 


### PR DESCRIPTION
## Context
We conducted an analysis of the `nodejs.yml` workflow run history using GitHub API data from recent successful executions. The analysis revealed potential resource optimisation in setup steps across three static check jobs (`typecheck`, `lint`, `yarn-validate`), each performing identical dependency installation and environment setup.

## Change
Combined three jobs into one `static-checks` job, eliminating redundant setup (installations and checkouts)

## Impact

Based on the runs history this workflow. We could estimate: 

- **Estimated time saved per run**: **48.3 seconds**
- **Setup overhead**: 79s → 29s (63% reduction)
- **Estimated Annual savings**: **35 hours** (~$17)

## Technical
- All checks preserved
- Same failure detection
- No functionality loss

## Files
- `.github/workflows/nodejs.yml`
- `CHANGELOG.md`

## Additional Context
We are a team of researchers from University of Zurich (https://www.ifi.uzh.ch/en/zest.html) currently working on automating energy optimizations in GitHub Actions workflows. This optimization maintains full functionality while potentially reducing computational overhead and energy consumption.

souhaila.serbout@uzh.ch
