### PR TITLE
Support workerIdleMemoryLimit=0 to always restart worker child processes between test files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 - `[jest-config]` Allow `testMatch` to take a string value
+- `[jest-worker]` Let `workerIdleMemoryLimit` accept 0 to always restart worker child processes
 
 ### Fixes
 

--- a/packages/jest-config/src/__tests__/stringToBytes.test.ts
+++ b/packages/jest-config/src/__tests__/stringToBytes.test.ts
@@ -8,6 +8,10 @@
 import stringToBytes from '../stringToBytes';
 
 describe('numeric input', () => {
+  test('0 should be 0', () => {
+    expect(stringToBytes(0)).toBe(0);
+  });
+
   test('> 1 represents bytes', () => {
     expect(stringToBytes(50.8)).toBe(50);
   });
@@ -33,6 +37,10 @@ describe('numeric input', () => {
 
 describe('string input', () => {
   describe('numeric passthrough', () => {
+    test('0 should be 0', () => {
+      expect(stringToBytes('0')).toBe(0);
+    });
+
     test('> 1 represents bytes', () => {
       expect(stringToBytes('50.8')).toBe(50);
     });
@@ -55,10 +63,8 @@ describe('string input', () => {
   });
 
   describe('parsing', () => {
-    test('0% should throw an error', () => {
-      expect(() => stringToBytes('0%', 51)).toThrow(
-        'Unexpected numerical input',
-      );
+    test('0%', () => {
+      expect(stringToBytes('0%', 51)).toBe(0);
     });
 
     test('30%', () => {

--- a/packages/jest-config/src/stringToBytes.ts
+++ b/packages/jest-config/src/stringToBytes.ts
@@ -68,7 +68,9 @@ function stringToBytes(
   }
 
   if (typeof input === 'number') {
-    if (input <= 1 && input > 0) {
+    if (input === 0) {
+      return 0;
+    } else if (input <= 1 && input > 0) {
       if (percentageReference) {
         return Math.floor(input * percentageReference);
       } else {

--- a/packages/jest-core/src/testSchedulerHelper.ts
+++ b/packages/jest-core/src/testSchedulerHelper.ts
@@ -48,7 +48,7 @@ export function shouldRunInBand(
 
   return (
     // When specifying a memory limit, workers should be used
-    !workerIdleMemoryLimit &&
+    workerIdleMemoryLimit === undefined &&
     (oneWorkerOrLess ||
       oneTestOrLess ||
       (tests.length <= 20 && timings.length > 0 && areFastTests))

--- a/packages/jest-worker/src/types.ts
+++ b/packages/jest-worker/src/types.ts
@@ -175,6 +175,10 @@ export type WorkerOptions = {
    * a job is complete. So you could have a resource limit of 500MB but an idle
    * limit of 50MB. The latter will only trigger if after a job has completed the
    * memory usage hasn't returned back down under 50MB.
+   *
+   * Special case: setting this to 0 will restart the worker process after each
+   * job completes, providing complete process isolation between test files
+   * regardless of memory usage.
    */
   idleMemoryLimit?: number;
   /**

--- a/packages/jest-worker/src/workers/ChildProcessWorker.ts
+++ b/packages/jest-worker/src/workers/ChildProcessWorker.ts
@@ -448,7 +448,7 @@ export default class ChildProcessWorker
         hasRequest
       ) {
         if (this._childIdleMemoryUsageLimit === 0) {
-          // Special case: idleMemoryLimit of 0 means always restart
+          // Special case: `idleMemoryLimit` of `0` means always restart.
           this._restart();
         } else {
           this.checkMemoryUsage();

--- a/website/versioned_docs/version-29.7/Configuration.md
+++ b/website/versioned_docs/version-29.7/Configuration.md
@@ -2463,6 +2463,7 @@ Specifies the memory limit for workers before they are recycled and is primarily
 
 After the worker has executed a test the memory usage of it is checked. If it exceeds the value specified the worker is killed and restarted. The limit can be specified in a number of different ways and whatever the result is `Math.floor` is used to turn it into an integer value:
 
+- `0` - Always restart the worker between tests.
 - `<= 1` - The value is assumed to be a percentage of system memory. So 0.5 sets the memory limit of the worker to half of the total system memory
 - `\> 1` - Assumed to be a fixed byte value. Because of the previous rule if you wanted a value of 1 byte (I don't know why) you could use `1.1`.
 - With units


### PR DESCRIPTION
## Summary

This adds a way to create a new worker child process for each test file, providing complete memory isolation between test files. This is useful for integration and E2E tests that test programs with global state that persists until the OS terminates the process in a production scenario.

The process-based worker already supports recreating a new child process between test files when its memory consumption exceeds a given threshold specified by `workerIdleMemoryLimit` in the Jest config options. This PR extends this configuration API. Developers may specify `workerIdleMemoryLimit=0` to mean the worker should always create a new child process between test files, regardless of memory usage. This way, the worker does not need to asynchronously query the child process for its memory usage and can more directly recreate the child process.

The `stringToBytes` parsing function now supports "0" and its variants like "0%" so `workerIdleMemoryLimit`  can be set to 0.

## Test plan

Added a test case to **ChildProcessWorker.test.ts** that sets the idle memory limit to 0 and asserts the worker recreates the child process without querying for its memory usage.

I also manually tested this feature end-to-end by editing **e2e/worker-restarting/package.json** to be:
```json5
{
  "jest": {
    "maxWorkers": 2,
    "workerIdleMemoryLimit": "0" // <--- changed this to 0
  }
}
```
and ran `yarn jest workerRestarting`. I verified `ChildProcessWorker` received `options.idleMemoryLimit = 0`.
