### PR TITLE
Removed redundant check for NaN in parseShardPair

### DIFF
--- a/packages/jest-config/src/parseShardPair.ts
+++ b/packages/jest-config/src/parseShardPair.ts
@@ -13,8 +13,7 @@ export const parseShardPair = (pair: string): ShardPair => {
   const shardPair = pair
     .split('/')
     .filter(d => /^\d+$/.test(d))
-    .map(d => Number.parseInt(d, 10))
-    .filter(shard => !Number.isNaN(shard));
+    .map(d => Number.parseInt(d, 10));
 
   const [shardIndex, shardCount] = shardPair;
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The final `.filter(shard => !Number.isNaN(shard))` was redundant and safely removed.

Here’s why:

The previous `.filter(d => /^\d+$/.test(d))` already ensures that only strings containing digits only (e.g., "123") are passed to `.map(...)`.

`parseInt("123", 10)` will always return a valid number (123), not NaN, when the input is purely numeric.

Therefore, checking `!Number.isNaN(shard)` after parsing is unnecessary — it's dead code that doesn't affect the result.

The cleanup removes an unnecessary `filter()` step that was guarding against a case that cannot occur due to the previous regex check. It simplifies the code while keeping the same functionality.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
