### PR TITLE
Fix Docs after breaking change

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1522,21 +1522,14 @@ const config: Config = {
 export default config;
 ```
 
-By combining `defaultResolver` and `packageFilter` we can implement a `package.json` "pre-processor" that allows us to change how the default resolver will resolve modules. For example, imagine we want to use the field `"module"` if it is present, otherwise fallback to `"main"`:
+By passing a `mainFields` option to `defaultResolver` we can implement a `package.json` "pre-processor" that allows us to change how the default resolver will resolve modules. For example, imagine we want to use the field `"module"` if it is present, otherwise fallback to `"main"`:
 
 ```js
 module.exports = (path, options) => {
   // Call the defaultResolver, so we leverage its cache, error handling, etc.
   return options.defaultResolver(path, {
     ...options,
-    // Use packageFilter to process parsed `package.json` before the resolution (see https://www.npmjs.com/package/resolve#resolveid-opts-cb)
-    packageFilter: pkg => {
-      return {
-        ...pkg,
-        // Alter the value of `main` before resolving the package
-        main: pkg.module || pkg.main,
-      };
-    },
+    mainFields: ['module', 'main'],
   });
 };
 ```


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

Please remember to update CHANGELOG.md at the root of the project if you have not done so
^ is this necessary for docs-only changes? 

## Summary

This simple PR fixes the docs. There seems to be a non-documented breaking change where the `packageFilter` property was removed, or at least it doesn't work anymore for me. 
The solution that helped me was described in this PR by @vovkasm : 

https://github.com/jestjs/jest/pull/15679/files#r2153120470

So I decided to create a PR since I wasted 30 minutes on this and maybe I can save someone from spending more time on it :-) 

## Test plan

This is just a docs change.
