### PR TITLE
Update resolver docs

### DIFF
--- a/website/versioned_docs/version-30.0/Configuration.md
+++ b/website/versioned_docs/version-30.0/Configuration.md
@@ -1536,9 +1536,28 @@ module.exports = (path, options) => {
   // Call the defaultResolver, so we leverage its cache, error handling, etc.
   return options.defaultResolver(path, {
     ...options,
-    // See this `unrs-resolver` option: from https://github.com/unrs/unrs-resolver?tab=readme-ov-file#main-field
+    // `unrs-resolver` option: https://github.com/unrs/unrs-resolver#main-field
     mainFields: ['react-native', 'main'],
   });
+};
+```
+
+You can also use `defaultResolver` to implement a "pre-processor" that allows us to change how the default resolver will resolve modules. For example, suppose a TypeScript project needs to reference `.js` files at runtime but runs Jest on the `.ts` files.
+
+```js
+module.exports = (path, options) => {
+  // Dynamic imports within our codebase that reference .js need to reference
+  // .ts during tests.
+  if (
+    !options.basedir.includes('node_modules') &&
+    path.endsWith('.js') &&
+    (path.startsWith('../') || path.startsWith('./'))
+  ) {
+    path = path.replace(/\.js$/, '.ts');
+  }
+
+  // Call the defaultResolver, so we leverage its cache, error handling, etc.
+  return options.defaultResolver(path, options);
 };
 ```
 


### PR DESCRIPTION
## Summary

Update resolver docs. The `packageFilter` option to `defaultResolver` appears to have gone away as part of #15619. The versioned 30.0 docs were correctly updated, but the "Next" docs were not.

Shorten the URL comment to make it less likely to induce scrolling.

I also added another example of a resolver that I've found useful in my own project. Feedback/corrections welcome.

## Test plan

Reviewed the site locally

**Note**: The main jestjs.io site does not appear to have been updated from the repo; its https://jestjs.io/docs/configuration#resolver-string page still reflects `defaultResolver` and shows the last edit as June 10. (Compare with [Git history](https://github.com/jestjs/jest/commits/main/website/versioned_docs/version-30.0/Configuration.md).)