### PR TITLE
docs: Document getMockImplementation()

### DIFF
--- a/docs/MockFunctionAPI.md
+++ b/docs/MockFunctionAPI.md
@@ -19,6 +19,32 @@ import TOCInline from '@theme/TOCInline';
 
 ## Reference
 
+### `mockFn.getMockImplementation()`
+
+Returns the current implementation of the mock function set by [`mockImplementation()`](#mockfnmockimplementationfn). Returns `undefined` if no implementation has been set.
+
+```js tab
+const mockFn = jest.fn();
+
+mockFn.getMockImplementation(); // undefined
+
+mockFn.mockImplementation(() => 42);
+
+mockFn.getMockImplementation(); // () => 42
+```
+
+```ts tab
+import {jest} from '@jest/globals';
+
+const mockFn = jest.fn<() => number>();
+
+mockFn.getMockImplementation(); // undefined
+
+mockFn.mockImplementation(() => 42);
+
+mockFn.getMockImplementation(); // () => 42
+```
+
 ### `mockFn.getMockName()`
 
 Returns the mock name string set by calling [`.mockName()`](#mockfnmocknamename).


### PR DESCRIPTION
## Summary
`getMockImplementation()` was made a public method in commit 89119e403a in 2016 and in public TypeScript types since commit 95b94e84cf in 2020 but it was never documented. Closes #9735.

### Motivation
This method has become more necessary with Jest's support for ESM. Previously, you could extend manual mocks using jest.spyOn():

```js title="__mocks__/module.js"
// __mocks__/module.js
export function fn() { /* default mock implementation */ }
```

```js title="__tests__/module.test.js"
// __tests__/module.test.js
const originalFn = module.fn;
jest.spyOn(module, 'fn').mockImplementation((...args) => {
  // Add custom logic for the test here
  return originalFn(...args);
});
```

However, spyOn doesn't work with ESM because module object properties are read-only. The workaround is to use getMockImplementation():

```js title="__mocks__/module.js"
// __mocks__/module.js
export const fn = jest.fn(() => { /* default mock implementation */ });
```

```js title="__tests__/module.test.js"
// __tests__/module.test.js
const originalImpl = jest.mocked(module.fn).getMockImplementation();
jest.mocked(module.fn).mockImplementation((...args) => {
  // Add custom logic for the test here
  return originalImpl?.(...args);
});
```

## Test plan
1. Build and serve the docs locally: `cd website && yarn install && yarn fetchSupporters && yarn start`
2. Browse to http://localhost:3000/docs/next/mock-function-api#mockfngetmockimplementation