### PR TITLE
Shorter output for reference errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## main
 
+### Features
+
+- `[jest-runtime]` Reduce redundant ReferenceError messages
+
 ## 30.0.5
 
 ### Features

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
@@ -75,8 +75,7 @@ exports[`formatStackTrace should properly handle string causes 1`] = `
 
     Cause:
     string cause
-<dim></intensity>
-<dim></intensity>
+
 "
 `;
 

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -242,6 +242,10 @@ const removeInternalStackEntries = (
   let pathCounter = 0;
 
   return lines.filter(line => {
+    if (!line) {
+      return false;
+    }
+
     if (ANONYMOUS_FN_IGNORE.test(line)) {
       return false;
     }
@@ -368,17 +372,18 @@ export function formatStackTrace(
     }
   }
 
-  const stacktrace = lines
-    .filter(Boolean)
-    .map(
-      line =>
-        STACK_INDENT + formatPath(trimPaths(line), config, relativeTestPath),
-    )
-    .join('\n');
+  const stacktrace =
+    lines.length === 0
+      ? ''
+      : `\n${lines
+          .map(
+            line =>
+              STACK_INDENT +
+              formatPath(trimPaths(line), config, relativeTestPath),
+          )
+          .join('\n')}`;
 
-  return renderedCallsite
-    ? `${renderedCallsite}\n${stacktrace}`
-    : `\n${stacktrace}`;
+  return renderedCallsite + stacktrace;
 }
 
 type FailedResults = Array<{

--- a/packages/jest-reporters/src/__tests__/__snapshots__/GitHubActionsReporter.test.ts.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/GitHubActionsReporter.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`annotations logs error annotation when a test has reference error 1`] = `
 Array [
   "
-::error file=/user/project/__tests__/example.test.js,line=25,title=example test::ReferenceError: abc is not defined%0A%0A    at Object.abc (__tests__/example.test.js:25:12)
+::error file=/user/project/__tests__/example.test.js,line=25,title=example test::ReferenceError: abc is not defined%0A    at Object.abc (__tests__/example.test.js:25:12)
 ",
 ]
 `;
@@ -11,7 +11,7 @@ Array [
 exports[`annotations logs error annotation when an expectation fails to pass 1`] = `
 Array [
   "
-::error file=/user/project/__tests__/example.test.js,line=20,title=example test::expect(received).toBe(expected) // Object.is equality%0A%0AExpected: 1%0AReceived: 10%0A%0A    at Object.toBe (__tests__/example.test.js:20:14)
+::error file=/user/project/__tests__/example.test.js,line=20,title=example test::expect(received).toBe(expected) // Object.is equality%0A%0AExpected: 1%0AReceived: 10%0A    at Object.toBe (__tests__/example.test.js:20:14)
 ",
 ]
 `;
@@ -19,7 +19,7 @@ Array [
 exports[`annotations logs error annotation when test is wrapped in describe block 1`] = `
 Array [
   "
-::error file=/user/project/__tests__/example.test.js,line=20,title=describe › example test::expect(received).toBe(expected) // Object.is equality%0A%0AExpected: 1%0AReceived: 10%0A%0A    at Object.toBe (__tests__/example.test.js:20:14)
+::error file=/user/project/__tests__/example.test.js,line=20,title=describe › example test::expect(received).toBe(expected) // Object.is equality%0A%0AExpected: 1%0AReceived: 10%0A    at Object.toBe (__tests__/example.test.js:20:14)
 ",
 ]
 `;
@@ -28,12 +28,12 @@ exports[`annotations logs warning annotation before logging errors when test res
 Array [
   Array [
     "
-::warning file=/user/project/__tests__/example.test.js,line=19,title=RETRY 1: example test::expect(received).toBeFalsy()%0A%0AReceived: true%0A%0A    at Object.toBeFalsy (__tests__/example.test.js:19:20)
+::warning file=/user/project/__tests__/example.test.js,line=19,title=RETRY 1: example test::expect(received).toBeFalsy()%0A%0AReceived: true%0A    at Object.toBeFalsy (__tests__/example.test.js:19:20)
 ",
   ],
   Array [
     "
-::error file=/user/project/__tests__/example.test.js,line=19,title=example test::expect(received).toBeFalsy()%0A%0AReceived: true%0A%0A    at Object.toBeFalsy (__tests__/example.test.js:19:20)
+::error file=/user/project/__tests__/example.test.js,line=19,title=example test::expect(received).toBeFalsy()%0A%0AReceived: true%0A    at Object.toBeFalsy (__tests__/example.test.js:19:20)
 ",
   ],
 ]

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -213,6 +213,7 @@ export default class Runtime {
   private readonly cjsConditions: Array<string>;
   private isTornDown = false;
   private isInsideTestCode: boolean | undefined;
+  private readonly loggedReferenceErrors = new Set<string>();
 
   constructor(
     config: Config.ProjectConfig,
@@ -2461,11 +2462,14 @@ export default class Runtime {
 
     const {message, stack} = separateMessageFromStack(originalStack);
 
-    console.error(
-      `\n${message}\n${formatStackTrace(stack, this._config, {
-        noStackTrace: false,
-      })}`,
-    );
+    const stackTrace = formatStackTrace(stack, this._config, {
+      noStackTrace: false,
+    });
+    const formattedMessage = `\n${message}${stackTrace ? `\n${stackTrace}` : ''}`;
+    if (!this.loggedReferenceErrors.has(formattedMessage)) {
+      console.error(formattedMessage);
+      this.loggedReferenceErrors.add(formattedMessage);
+    }
   }
 
   private constructInjectedModuleParameters(): Array<string> {


### PR DESCRIPTION
Because imports are processed asynchronously, an error within one import causes the test runtime to abort and be torn down, which causes the other imports to log numerous redundant errors. Because these errors have no stack traces, they're even more verbose than necessary, with lots of blank lines.

<details>
<summary>
Sample output for one of my projects:
</summary>

```
(node:57692) ExperimentalWarning: VM Modules is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
FAIL lib packages/lib/src/plots/__tests__/timelineChart.test.ts
  ● Test suite failed to run

    Cannot find module './chartJs/controller.polar.js' from 'src/plots/chartJsInit.ts'

      at Resolver._throwModNotFoundError (../../node_modules/jest-resolve/build/index.js:863:11)


ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.


Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.45 s
Ran all test suites matching src/plots/__tests__/timelineChart.test.ts.

ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.



ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.


```
</details>

To address this, I added logic to suppress redundant errors and to only include stack trace newlines if a stack trace is present.

<details>
<summary>
Sample output after this change:
</summary>

```
 FAIL   lib  src/plots/__tests__/timelineChart.test.ts
  ● Test suite failed to run

    Cannot find module './chartJs/controller.polar.js' from 'src/plots/chartJsInit.ts'

      at Resolver._throwModNotFoundError (../../node_modules/jest-resolve/build/index.js:864:11)

ReferenceError: You are trying to `import` a file after the Jest environment has been torn down. From src/plots/__tests__/timelineChart.test.ts.
Test Suites: 1 failed, 1 total
Tests:       0 total
Snapshots:   0 total
Time:        0.514 s
```
</details>
