### PR TITLE
Fix running tests in US time zones

### DIFF
--- a/e2e/custom-reporters/reporters/AssertionCountsReporter.js
+++ b/e2e/custom-reporters/reporters/AssertionCountsReporter.js
@@ -18,12 +18,11 @@ class AssertionCountsReporter {
     }
   }
   onTestCaseResult(test, testCaseResult) {
-    const difference = new Date(
-      Date.now() - testCaseResult.startedAt,
-    ).getDate();
+    const difference = Date.now() - testCaseResult.startedAt;
+    const sameDay = difference >= 0 && difference < 24 * 60 * 60 * 1000;
     console.log(
       `onTestCaseResult: ${testCaseResult.title}, ` +
-        `started: ${difference === 1 ? 'today' : 'invalid'}, ` +
+        `started: ${sameDay ? 'today' : 'invalid'}, ` +
         `status: ${testCaseResult.status}, ` +
         `numExpectations: ${testCaseResult.numPassingAsserts}`,
     );


### PR DESCRIPTION
Tests within [e2e/\_\_tests\_\_/customReportersOnCircus.test.ts](https://github.com/jestjs/jest/blob/main/e2e/__tests__/customReportersOnCircus.test.ts) were reporting `started: invalid` for me, because `new Date(Date.now() - testCaseResult.startedAt).getDate()` evaluated to 31 (i.e., Dec 31 1969) instead of 1 (Jan 1 1970 midnight UTC).

The intention is apparently to verify that the tests' startedAt is a valid timestamp, so I revised it accordingly.

The tests that I'm modifying were added in #15145.