### PR TITLE
fix: update return type for check is primitive

### DIFF
--- a/packages/jest-get-type/src/index.ts
+++ b/packages/jest-get-type/src/index.ts
@@ -58,4 +58,7 @@ export function getType(value: unknown): ValueType {
   throw new Error(`value of unknown type: ${value}`);
 }
 
-export const isPrimitive = (value: unknown): boolean => Object(value) !== value;
+export const isPrimitive = (
+  value: unknown,
+): value is null | undefined | string | number | boolean | symbol | bigint =>
+  Object(value) !== value;


### PR DESCRIPTION
I updated return type for `isPrimitive` to enable type narrowing, improve type safety, and give the compiler more context during type checks
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->
