### PR TITLE
Per-file @jest/globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## main
 
+### Fixes
+
+- `[jest-runtime]` Importing from `@jest/globals` in more than one file no longer breaks relative paths ([#15772](https://github.com/jestjs/jest/issues/15772))
+
 ## 30.0.5
 
 ### Features

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -588,13 +588,14 @@ export default class Runtime {
     const registry = this._isolatedModuleRegistry ?? this._esmoduleRegistry;
 
     if (specifier === '@jest/globals') {
-      const fromCache = registry.get('@jest/globals');
+      const globalsIdentifier = `@jest/globals/${referencingIdentifier}`;
+      const fromCache = registry.get(globalsIdentifier);
 
       if (fromCache) {
         return fromCache;
       }
       const globals = this.getGlobalsForEsm(referencingIdentifier, context);
-      registry.set('@jest/globals', globals);
+      registry.set(globalsIdentifier, globals);
 
       return globals;
     }


### PR DESCRIPTION
## Summary

This fixes #15772 by giving each import of @jest/globals its own synthetic module.

My assumption is that making extra @jest/globals objects won't be a problem because @jest/globals will not have many imports from a single test suite and that Jest objects are relatively cheap to construct. If either of these assumptions is wrong, let me know.

If this approach seems reasonable, I can see about adding test coverage.

## Test plan

I tested against https://github.com/joshkel/jest-globals-bug and confirmed that the bug went away.

Fixes #15772