### PR TITLE
fix(jest-resolver): Allow core ESM modules to be mocked with prefix

### DIFF
--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -41,7 +41,7 @@ exports[`moduleNameMapper wrong array configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:1117:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:1121:17)
       at Object.require (index.js:10:1)
       at Object.require (__tests__/index.js:10:20)"
 `;
@@ -71,7 +71,7 @@ exports[`moduleNameMapper wrong configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:1117:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:1121:17)
       at Object.require (index.js:10:1)
       at Object.require (__tests__/index.js:10:20)"
 `;

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -50,7 +50,7 @@ Ran all test suites matching native-esm.test.js."
 
 exports[`runs test with native mock ESM 1`] = `
 "Test Suites: 1 passed, 1 total
-Tests:       3 passed, 3 total
+Tests:       4 passed, 4 total
 Snapshots:   0 total
 Time:        <<REPLACED>>
 Ran all test suites matching native-esm-mocks.test.js."

--- a/e2e/native-esm/__tests__/native-esm-mocks.test.js
+++ b/e2e/native-esm/__tests__/native-esm-mocks.test.js
@@ -30,6 +30,15 @@ test('can mock transitive module', async () => {
   expect(importedMock.foo).toBe('bar');
 });
 
+test('can mock transitive builtin module', async () => {
+  jestObject.unstable_mockModule('node:fs', () => ({foo: 'bar'}));
+
+  const importedMock = await import('../fsReexport.js');
+
+  expect(Object.keys(importedMock)).toEqual(['foo']);
+  expect(importedMock.foo).toBe('bar');
+});
+
 test('can unmock module', async () => {
   jestObject.unstable_mockModule('../index.js', () => ({
     double: () => 1000,

--- a/e2e/native-esm/fsReexport.js
+++ b/e2e/native-esm/fsReexport.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export * from 'node:fs';

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -652,7 +652,7 @@ export default class Resolver {
     options: ResolveModuleConfig,
   ): Promise<string | null> {
     if (this.isCoreModule(moduleName)) {
-      return moduleName;
+      return this.normalizeCoreModuleSpecifier(moduleName);
     }
     if (moduleName.startsWith('data:')) {
       return moduleName;
@@ -742,6 +742,11 @@ export default class Resolver {
     moduleName: string,
     options?: Pick<ResolveModuleConfig, 'conditions'>,
   ): string | null {
+    // Strip node URL scheme from core modules imported using it
+    if (this.isCoreModule(moduleName)) {
+      return this.normalizeCoreModuleSpecifier(moduleName);
+    }
+
     const dirname = path.dirname(from);
 
     const {extensions, moduleDirectory, paths} = this._prepareForResolution(

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -742,7 +742,7 @@ export default class Resolver {
     moduleName: string,
     options?: Pick<ResolveModuleConfig, 'conditions'>,
   ): string | null {
-    // Strip node URL scheme from core modules imported using it
+    // Strip core module scheme if necessary.
     if (this.isCoreModule(moduleName)) {
       return this.normalizeCoreModuleSpecifier(moduleName);
     }


### PR DESCRIPTION
## Summary

I think this fixes https://github.com/jestjs/jest/issues/15690. I added a test which resembles the example there. It fails on the main branch but passes once the other changes are made.

When mocking an ESM module, jest stores the mock under a certain module ID. A different ID is used when the module is later imported asynchronously. This is related to https://github.com/jestjs/jest/pull/14297, which changed `_getAbsolutePath` and `resolveStubModuleNameAsync` without making the corresponding changes to `_getAbsolutePathAsync` and `resolveStubModuleName`.

## Test plan

See the test I added (`can mock transitive builtin module`).

Since I modified `resolveStubModuleName`, I also broke a different test (`resolveModule › custom resolver can resolve node modules`). But I *think* that test would be broken on `main` if it called `resolveModuleAsync` instead of `resolveModule`, and I don't understand https://github.com/jestjs/jest/pull/14297 well enough to fix it.