### PR TITLE
Website: Fix link for migration to jest 28

### DIFF
--- a/website/blog/2022-04-25-jest-28.md
+++ b/website/blog/2022-04-25-jest-28.md
@@ -11,7 +11,7 @@ Additionally, as announced in the [Jest 27 blog post](/blog/2021/05/25/jest-27) 
 
 ## Breaking changes
 
-The list of breaking changes is long (and can be seen fully in the [changelog](https://github.com/jestjs/jest/blob/main/CHANGELOG.md#2800)), but for migration purposes, we've also written [a guide](/docs/28.x/upgrading-to-jest28) you can follow. Hopefully this makes the upgrade experience as frictionless as possible!
+The list of breaking changes is long (and can be seen fully in the [changelog](https://github.com/jestjs/jest/blob/main/CHANGELOG.md#2800)), but for migration purposes, we've also written [a guide](https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28/) you can follow. Hopefully this makes the upgrade experience as frictionless as possible!
 
 Main breaking changes likely to impact your migration are dropped support for Node 10 and 15 (but _not_ Node 12, which will be EOL in a few days) and some renamed configuration options.
 

--- a/website/blog/2022-08-25-jest-29.md
+++ b/website/blog/2022-08-25-jest-29.md
@@ -21,7 +21,7 @@ The only breaking changes that should be noticeable are:
 
 - `jest-environment-jsdom` has upgraded `jsdom` from v19 to v20
 
-There are certain changes to the types exposed by Jest, but probably (hopefully!) nothing that should impede the upgrade. Please see the [upgrade guide](/docs/upgrading-to-jest29) for more details.
+There are certain changes to the types exposed by Jest, but probably (hopefully!) nothing that should impede the upgrade. Please see the [upgrade guide](https://jest-archive-august-2023.netlify.app/docs/upgrading-to-jest29) for more details.
 
 That's it for breaking changes! Hopefully this means the upgrade path from Jest 28 is smooth. Please see the [changelog](https://github.com/jestjs/jest/blob/main/CHANGELOG.md#2900) for other changes.
 


### PR DESCRIPTION
## Summary

Replaces the [broken migration link](https://jestjs.io/docs/28.x/upgrading-to-jest28) referenced in the [jest 28 announcement blog post](https://jestjs.io/blog/2022/04/25/jest-28) with a link that still works: https://jest-archive-august-2023.netlify.app/docs/28.x/upgrading-to-jest28/

While the equivalent link in the jest 29 announcement post is not broken (yet), I imagine that it will probably become broken when jest 31 comes out, like happened with the jest 28 migration link. To avoid this, I updated its link to point to the same August 2023 archive subdomain on Netlify I used for the jest 28 link.

## Test plan

~~I did not test this locally, because it's quite hard to imagine that it would not work. If the maintainers do not share my confidence, I would be happy to do so when I get the chance.~~

I have verified that the changes were made as intended using the Netlify Deploy Preview.
