### PR TITLE
fix(snapshot-utils): replace Jest snapshot guide link from deprecated goo.gl link to fully canonical URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 
+- `[jest-snapshot-utils] Fix deprecated goo.gl snapshot guide link not getting replaced with fully canonical URL ([#15787](https://github.com/jestjs/jest/pull/15787))
 - `[jest-circus]` Fix `it.concurrent` not working with `describe.skip` ([#15765](https://github.com/jestjs/jest/pull/15765))
 - `[jest-snapshot]` Fix mangled inline snapshot updates when used with Prettier 3 and CRLF line endings
 - `[jest-runtime]` Importing from `@jest/globals` in more than one file no longer breaks relative paths ([#15772](https://github.com/jestjs/jest/issues/15772))

--- a/packages/jest-snapshot-utils/src/__tests__/utils.test.ts
+++ b/packages/jest-snapshot-utils/src/__tests__/utils.test.ts
@@ -171,9 +171,9 @@ test('getSnapshotData() throws for deprecated snapshot guide link', () => {
   expect(() => getSnapshotData(filename, update)).toThrow(
     `${chalk.red(
       `${chalk.red.bold('Outdated guide link')}: The guide link of this ` +
-          'snapshot file indicates that this project used deprecated Jest ' +
-          'snapshot guide link. ' +
-          'Please update all snapshots during this upgrade of Jest',
+        'snapshot file indicates that this project used deprecated Jest ' +
+        'snapshot guide link. ' +
+        'Please update all snapshots during this upgrade of Jest',
     )}\n\nExpected: ${SNAPSHOT_GUIDE_LINK}\n` +
       `Received: ${deprecatedGuideLink}`,
   );

--- a/packages/jest-snapshot-utils/src/__tests__/utils.test.ts
+++ b/packages/jest-snapshot-utils/src/__tests__/utils.test.ts
@@ -170,10 +170,8 @@ test('getSnapshotData() throws for deprecated snapshot guide link', () => {
 
   expect(() => getSnapshotData(filename, update)).toThrow(
     `${chalk.red(
-      `${chalk.red.bold('Outdated guide link')}: The guide link of this ` +
-        'snapshot file indicates that this project used deprecated Jest ' +
-        'snapshot guide link. ' +
-        'Please update all snapshots during this upgrade of Jest',
+      `${chalk.red.bold('Outdated guide link')}: The snapshot guide link is outdated.` +
+        'Please update all snapshots while upgrading of Jest',
     )}\n\nExpected: ${SNAPSHOT_GUIDE_LINK}\n` +
       `Received: ${deprecatedGuideLink}`,
   );

--- a/packages/jest-snapshot-utils/src/__tests__/utils.test.ts
+++ b/packages/jest-snapshot-utils/src/__tests__/utils.test.ts
@@ -157,6 +157,28 @@ test('getSnapshotData() throws for newer snapshot version', () => {
   );
 });
 
+test('getSnapshotData() throws for deprecated snapshot guide link', () => {
+  const deprecatedGuideLink = 'https://goo.gl/fbAQLP';
+  const filename = path.join(__dirname, 'old-snapshot.snap');
+  jest
+    .mocked(fs.readFileSync)
+    .mockReturnValue(
+      `// Jest Snapshot v1, ${deprecatedGuideLink}\n\n` +
+        'exports[`myKey`] = `<div>\n</div>`;\n',
+    );
+  const update = 'none';
+
+  expect(() => getSnapshotData(filename, update)).toThrow(
+    `${chalk.red(
+      `${chalk.red.bold('Outdated guide link')}: The guide link of this ` +
+          'snapshot file indicates that this project used deprecated Jest ' +
+          'snapshot guide link. ' +
+          'Please update all snapshots during this upgrade of Jest',
+    )}\n\nExpected: ${SNAPSHOT_GUIDE_LINK}\n` +
+      `Received: ${deprecatedGuideLink}`,
+  );
+});
+
 test('getSnapshotData() does not throw for when updating', () => {
   const filename = path.join(__dirname, 'old-snapshot.snap');
   jest

--- a/packages/jest-snapshot-utils/src/utils.ts
+++ b/packages/jest-snapshot-utils/src/utils.ts
@@ -77,10 +77,8 @@ const validateSnapshotHeader = (snapshotContents: string) => {
     return new Error(
       // eslint-disable-next-line prefer-template
       chalk.red(
-        `${chalk.red.bold('Outdated guide link')}: The guide link of this ` +
-          'snapshot file indicates that this project used deprecated Jest ' +
-          'snapshot guide link. ' +
-          'Please update all snapshots during this upgrade of Jest',
+        `${chalk.red.bold('Outdated guide link')}: The snapshot guide link is outdated.` +
+          'Please update all snapshots while upgrading of Jest',
       ) +
         '\n\n' +
         `Expected: ${SNAPSHOT_GUIDE_LINK}\n` +

--- a/packages/jest-snapshot-utils/src/utils.ts
+++ b/packages/jest-snapshot-utils/src/utils.ts
@@ -26,8 +26,8 @@ const writeSnapshotVersion = () =>
 
 const validateSnapshotHeader = (snapshotContents: string) => {
   const headerTest = SNAPSHOT_HEADER_REGEXP.exec(snapshotContents);
-  const version = headerTest && headerTest[1]
-  const guideLink = headerTest && headerTest[2]
+  const version = headerTest && headerTest[1];
+  const guideLink = headerTest && headerTest[2];
 
   if (!version) {
     return new Error(
@@ -73,7 +73,7 @@ const validateSnapshotHeader = (snapshotContents: string) => {
     );
   }
 
-  if (guideLink != SNAPSHOT_GUIDE_LINK) {
+  if (guideLink !== SNAPSHOT_GUIDE_LINK) {
     return new Error(
       // eslint-disable-next-line prefer-template
       chalk.red(
@@ -87,7 +87,7 @@ const validateSnapshotHeader = (snapshotContents: string) => {
         `Received: ${guideLink}`,
     );
   }
-  
+
   return null;
 };
 


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #15756 and resolves #15224 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

- [x] I've added unit test
- [x] I've used the development build of current branch to test out the replacement. See the video below


https://github.com/user-attachments/assets/2fc23da2-a829-4370-b764-14023fb8d672




