### PR TITLE
Handle empty stack

### DIFF
--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -439,7 +439,9 @@ const _getError = (
 };
 
 const getErrorStack = (error: Error): string =>
-  typeof error.stack === 'string' ? error.stack : error.message;
+  typeof error.stack === 'string' && error.stack !== ''
+    ? error.stack
+    : error.message;
 
 export const addErrorToEachTestUnderDescribe = (
   describeBlock: Circus.DescribeBlock,


### PR DESCRIPTION
## Summary

Under unclear circumstances, errors may be generated with empty stack traces.  Falling back to the error message in that case is preferable to displaying nothing.

## Test plan

Tested locally against a test suite with SQLite errors with no stack traces
