### PR TITLE
fix: bring back moduleResolution Node10 when registering ts-node

### DIFF
--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -10,7 +10,6 @@ import {isNativeError} from 'util/types';
 import * as fs from 'graceful-fs';
 import parseJson from 'parse-json';
 import stripJsonComments from 'strip-json-comments';
-import * as ts from 'typescript';
 import type {Config} from '@jest/types';
 import {extract, parse} from 'jest-docblock';
 import {interopRequireDefault, requireOrImportModule} from 'jest-util';
@@ -174,9 +173,15 @@ async function registerTsLoader(loader: TsLoaderModule): Promise<TsLoader> {
 
       return tsLoader.register({
         compilerOptions: {
-          module: ts.server.protocol.ModuleKind.CommonJS,
-          moduleResolution: ts.server.protocol.ModuleResolutionKind.Node10,
-        } satisfies ts.server.protocol.CompilerOptions,
+          /**
+           * Define both `module` and `moduleResolution` at the same time!
+           * We're overriding user's tsconfig here, so if we only specify
+           * `module` without the `moduleResolution`, we can get an incompatible
+           * pair that causes a TypeScript compiler configuration error.
+           */
+          module: 'commonjs',
+          moduleResolution: 'node10',
+        },
         moduleTypes: {
           '**': 'cjs',
         },

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -10,6 +10,7 @@ import {isNativeError} from 'util/types';
 import * as fs from 'graceful-fs';
 import parseJson from 'parse-json';
 import stripJsonComments from 'strip-json-comments';
+import * as ts from 'typescript';
 import type {Config} from '@jest/types';
 import {extract, parse} from 'jest-docblock';
 import {interopRequireDefault, requireOrImportModule} from 'jest-util';
@@ -173,8 +174,9 @@ async function registerTsLoader(loader: TsLoaderModule): Promise<TsLoader> {
 
       return tsLoader.register({
         compilerOptions: {
-          module: 'CommonJS',
-        },
+          module: ts.server.protocol.ModuleKind.CommonJS,
+          moduleResolution: ts.server.protocol.ModuleResolutionKind.Node10,
+        } satisfies ts.server.protocol.CompilerOptions,
         moduleTypes: {
           '**': 'cjs',
         },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This is a re-introduction of changes done in #14739 after they were accidentally rolled back in #15190.

~This time I decided to import the values directly from the `typescript` package instead of hardcoding them.~

> 
> ~`ts.server.protocol.ModuleKind` is not `ts.ModuleKind`.~
>
> ~The former enum I used here contains strings used in the `tsconfig.json` files, whereas the latter (that's suggested to be auto-imported by the IDE) contains flag-like numbers that are used internally by the compiler.~


~Addition of `satisfies ts.server.protocol.CompilerOptions` gives IDE hints to what other properties can be set inside the the `compilerOptions` object, in case we wanted to modify it in the future.~

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

TBD