### PR TITLE
Refresh security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,24 @@
+# Security Policy
+
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability within Jest, please submit a report via the GitHub's [Private Vulnerability Reporting](https://github.com/jestjs/jest/security/advisories) feature.
+Please report security issues **privately** using GitHub’s **Report a vulnerability** form on this repository (Security tab).
 
-All security vulnerabilities will be promptly addressed.
+**Do not** file public GitHub issues for security problems.
+
+When reporting, please include:
+- Affected project/repo and version(s)
+- Impact and component(s) involved
+- Reproduction steps or PoC (if available)
+- Your contact and preferred credit name
+
+If you do not receive an acknowledgement of your report within **6 business days**, or if you cannot find a private security contact for the project, you may **escalate to the OpenJS Foundation CNA** at `security@lists.openjsf.org`.
+
+If the project acknowledges your report but does not provide any further response or engagement within **14 days**, escalation is also appropriate.
+
+## Coordination & Disclosure
+
+We follow coordinated vulnerability disclosure:
+- We will acknowledge your report, assess impact, and work on a fix.
+- We aim to provide status updates at reasonable intervals until resolution.
+- We will publish a security advisory (and **CVE via the OpenJS CNA when applicable**) once a fix or mitigation is available. We credit reporters by default unless you request otherwise.


### PR DESCRIPTION
👋 Hi everyone! We’re @UlisesGascon and @RafaelGSS, working with the OpenJS Foundation as part of [the Alpha-Omega initiative](https://openjsf.org/blog/openjs-security-checkpoint-2025-so-far). Our focus is supporting OpenJS projects in strengthening their security posture. We can help with things like:

- Reviewing or creating security documentation (e.g., SECURITY.md, incident response plans...)
- Supporting vulnerability handling and escalation (reporting, triage, CVEs, disputes)
- Reviewing repo configurations and GitHub security settings
- Sharing best practices (e.g., OSSF Scorecard)
- Answering general questions on licenses, compliance, or incident response

:sparkles: We’re here as a resource for the Jest team and happy to collaborate on whatever is most useful for you. Looking forward to working together!


**References:**
- https://github.com/openjs-foundation/cross-project-council/pull/1588
- https://openjsf.org/blog/openjs-foundation-cna
- https://openjsf.org/blog/security-support-for-openjs-projects

**Important**

The policy suggests that reports should be submitted using the Report a Vulnerability feature. Since this option is currently unavailable, please [follow the instructions](https://docs.github.com/en/code-security/security-advisories/working-with-repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository)