### PR TITLE
docs: Update `snapshotSerializers` Docs

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,6 +7,7 @@ Please report security issues **privately** using GitHub’s **Report a vulnerab
 **Do not** file public GitHub issues for security problems.
 
 When reporting, please include:
+
 - Affected project/repo and version(s)
 - Impact and component(s) involved
 - Reproduction steps or PoC (if available)
@@ -19,6 +20,7 @@ If the project acknowledges your report but does not provide any further respons
 ## Coordination & Disclosure
 
 We follow coordinated vulnerability disclosure:
+
 - We will acknowledge your report, assess impact, and work on a fix.
 - We aim to provide status updates at reasonable intervals until resolution.
 - We will publish a security advisory (and **CVE via the OpenJS CNA when applicable**) once a fix or mitigation is available. We credit reporters by default unless you request otherwise.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1826,7 +1826,7 @@ const plugin: Plugin = {
 
   test(val): boolean {
     return val && Object.prototype.hasOwnProperty.call(val, 'foo');
-  }
+  },
 };
 
 export default plugin;

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1804,16 +1804,32 @@ A list of paths to snapshot serializer modules Jest should use for snapshot test
 
 Jest has default serializers for built-in JavaScript types, HTML elements (Jest 20.0.0+), ImmutableJS (Jest 20.0.0+) and for React elements. See [snapshot test tutorial](TutorialReactNative.md#snapshot-test) for more information.
 
-```js title="custom-serializer.js"
+```js tab title="custom-serializer.js"
 module.exports = {
   serialize(val, config, indentation, depth, refs, printer) {
-    return `Pretty foo: ${printer(val.foo)}`;
+    return `Pretty foo: ${printer(val.foo, config, indentation, depth, refs)}`;
   },
 
   test(val) {
     return val && Object.prototype.hasOwnProperty.call(val, 'foo');
   },
 };
+```
+
+```ts tab title="custom-serializer.ts"
+import type {Plugin} from 'pretty-format';
+
+const plugin: Plugin = {
+  serialize(val, config, indentation, depth, refs, printer): string {
+    return `Pretty foo: ${printer(val.foo, config, indentation, depth, refs)}`;
+  },
+
+  test(val): boolean {
+    return val && Object.prototype.hasOwnProperty.call(val, 'foo');
+  }
+};
+
+export default plugin;
 ```
 
 `printer` is a function that serializes a value using existing plugins.
@@ -1833,7 +1849,7 @@ module.exports = config;
 import type {Config} from 'jest';
 
 const config: Config = {
-  snapshotSerializers: ['path/to/custom-serializer.js'],
+  snapshotSerializers: ['path/to/custom-serializer.ts'],
 };
 
 export default config;

--- a/website/versioned_docs/version-29.7/Configuration.md
+++ b/website/versioned_docs/version-29.7/Configuration.md
@@ -1787,16 +1787,32 @@ A list of paths to snapshot serializer modules Jest should use for snapshot test
 
 Jest has default serializers for built-in JavaScript types, HTML elements (Jest 20.0.0+), ImmutableJS (Jest 20.0.0+) and for React elements. See [snapshot test tutorial](TutorialReactNative.md#snapshot-test) for more information.
 
-```js title="custom-serializer.js"
+```js tab title="custom-serializer.js"
 module.exports = {
   serialize(val, config, indentation, depth, refs, printer) {
-    return `Pretty foo: ${printer(val.foo)}`;
+    return `Pretty foo: ${printer(val.foo, config, indentation, depth, refs)}`;
   },
 
   test(val) {
     return val && Object.prototype.hasOwnProperty.call(val, 'foo');
   },
 };
+```
+
+```ts tab title="custom-serializer.ts"
+import type {Plugin} from 'pretty-format';
+
+const plugin: Plugin = {
+  serialize(val, config, indentation, depth, refs, printer): string {
+    return `Pretty foo: ${printer(val.foo, config, indentation, depth, refs)}`;
+  },
+
+  test(val): boolean {
+    return val && Object.prototype.hasOwnProperty.call(val, 'foo');
+  }
+};
+
+export default plugin;
 ```
 
 `printer` is a function that serializes a value using existing plugins.
@@ -1816,7 +1832,7 @@ module.exports = config;
 import type {Config} from 'jest';
 
 const config: Config = {
-  snapshotSerializers: ['path/to/custom-serializer.js'],
+  snapshotSerializers: ['path/to/custom-serializer.ts'],
 };
 
 export default config;

--- a/website/versioned_docs/version-29.7/Configuration.md
+++ b/website/versioned_docs/version-29.7/Configuration.md
@@ -1809,7 +1809,7 @@ const plugin: Plugin = {
 
   test(val): boolean {
     return val && Object.prototype.hasOwnProperty.call(val, 'foo');
-  }
+  },
 };
 
 export default plugin;

--- a/website/versioned_docs/version-30.0/Configuration.md
+++ b/website/versioned_docs/version-30.0/Configuration.md
@@ -1833,7 +1833,7 @@ const plugin: Plugin = {
 
   test(val): boolean {
     return val && Object.prototype.hasOwnProperty.call(val, 'foo');
-  }
+  },
 };
 
 export default plugin;

--- a/website/versioned_docs/version-30.0/Configuration.md
+++ b/website/versioned_docs/version-30.0/Configuration.md
@@ -1811,16 +1811,32 @@ A list of paths to snapshot serializer modules Jest should use for snapshot test
 
 Jest has default serializers for built-in JavaScript types, HTML elements (Jest 20.0.0+), ImmutableJS (Jest 20.0.0+) and for React elements. See [snapshot test tutorial](TutorialReactNative.md#snapshot-test) for more information.
 
-```js title="custom-serializer.js"
+```js tab title="custom-serializer.js"
 module.exports = {
   serialize(val, config, indentation, depth, refs, printer) {
-    return `Pretty foo: ${printer(val.foo)}`;
+    return `Pretty foo: ${printer(val.foo, config, indentation, depth, refs)}`;
   },
 
   test(val) {
     return val && Object.prototype.hasOwnProperty.call(val, 'foo');
   },
 };
+```
+
+```ts tab title="custom-serializer.ts"
+import type {Plugin} from 'pretty-format';
+
+const plugin: Plugin = {
+  serialize(val, config, indentation, depth, refs, printer): string {
+    return `Pretty foo: ${printer(val.foo, config, indentation, depth, refs)}`;
+  },
+
+  test(val): boolean {
+    return val && Object.prototype.hasOwnProperty.call(val, 'foo');
+  }
+};
+
+export default plugin;
 ```
 
 `printer` is a function that serializes a value using existing plugins.
@@ -1840,7 +1856,7 @@ module.exports = config;
 import type {Config} from 'jest';
 
 const config: Config = {
-  snapshotSerializers: ['path/to/custom-serializer.js'],
+  snapshotSerializers: ['path/to/custom-serializer.ts'],
 };
 
 export default config;


### PR DESCRIPTION
## Summary

This pull request corrects the documentation for the `snapshotSerializers` configuration option. The current code example for a custom serializer is incorrect and causes a `TypeError` due to a discrepancy with the actual implementation.

- **Documentation:** https://jestjs.io/docs/configuration#snapshotserializers-arraystring
- **Implementation:** https://github.com/jestjs/jest/blob/v30.2.0/packages/pretty-format/src/types.ts#L58-L65

Running the example from the documentation results in the following error:

```
 FAIL  ./example.test.js
  ✕ example (21 ms)

  ● example

    TypeError: Cannot read properties of undefined (reading 'plugins')

      1 | module.exports = {
      2 |   serialize(val, config, indentation, depth, refs, printer) {
    > 3 |     return `Pretty foo: ${printer(val.foo)}`;
        |                           ^
      4 |   },
      5 |
      6 |   test(val) {

      at printer (node_modules/pretty-format/build/index.js:921:36)
      at Object.printer [as serialize] (custom-serializer.js:3:27)
      at printPlugin (node_modules/pretty-format/build/index.js:892:44)
      at format (node_modules/pretty-format/build/index.js:1028:16)
      at __EXTERNAL_MATCHER_TRAP__ (node_modules/expect/build/index.js:2240:22)
      at Object.throwingMatcher (node_modules/expect/build/index.js:2241:6)
      at Object.toMatchSnapshot (example.test.js:6:6)

Test Suites: 1 failed, 1 total
Tests:       1 failed, 1 total
Snapshots:   0 total
Time:        0.541 s, estimated 1 s
Ran all test suites.
```

This change updates the example to align with the implementation, providing a working code snippet for users.

## Test plan

The documentation site was built locally using `yarn start`. I have confirmed that the updated code example renders correctly on the configuration page in a web browser.