### PR TITLE
fix(runtime): user can use dynamic import in code when running tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## main
 
+## Fixes
+
+- `[jest-runtime]` Fix issue where user cannot utilize dynamic import despite specifying `--experimental-vm-modules` Node option ([#15842](https://github.com/jestjs/jest/pull/15842))
+
 ## 30.2.0
 
 ### Chore & Maintenance

--- a/e2e/__tests__/nativeEsmTypescript.test.ts
+++ b/e2e/__tests__/nativeEsmTypescript.test.ts
@@ -17,6 +17,6 @@ test('runs TS test with native ESM', () => {
 
   expect(exitCode).toBe(0);
 
-  expect(json.numTotalTests).toBe(2);
-  expect(json.numPassedTests).toBe(2);
+  expect(json.numTotalTests).toBe(3);
+  expect(json.numPassedTests).toBe(3);
 });

--- a/e2e/native-esm-typescript/__tests__/double.test.ts
+++ b/e2e/native-esm-typescript/__tests__/double.test.ts
@@ -14,3 +14,8 @@ test('test double', () => {
 test('test import.meta', () => {
   expect(typeof import.meta.url).toBe('string');
 });
+
+// Source: https://github.com/jestjs/jest/issues/15823
+test('test double with dynamic import', () => {
+  expect(double(2)).toBe(4);
+});

--- a/e2e/native-esm-typescript/__tests__/double.test.ts
+++ b/e2e/native-esm-typescript/__tests__/double.test.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {double} from '../double';
+import {double, doubleWithDynamicImport} from '../double';
 
 test('test double', () => {
   expect(double(2)).toBe(4);
@@ -17,5 +17,5 @@ test('test import.meta', () => {
 
 // Source: https://github.com/jestjs/jest/issues/15823
 test('test double with dynamic import', () => {
-  expect(double(2)).toBe(4);
+  expect(doubleWithDynamicImport(2)).toBe(4);
 });

--- a/e2e/native-esm-typescript/double.ts
+++ b/e2e/native-esm-typescript/double.ts
@@ -8,3 +8,9 @@
 export function double(num: number): number {
   return num * 2;
 }
+
+export function doubleWithDynamicImport(
+  num: number,
+): typeof import('./doubleType') {
+  return (num * 2) as typeof import('./doubleType');
+}

--- a/e2e/native-esm-typescript/doubleType.ts
+++ b/e2e/native-esm-typescript/doubleType.ts
@@ -1,0 +1,1 @@
+export type Double = number;

--- a/e2e/native-esm-typescript/doubleType.ts
+++ b/e2e/native-esm-typescript/doubleType.ts
@@ -1,1 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 export type Double = number;

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -64,6 +64,7 @@ import {
 } from './helpers';
 
 const esmIsAvailable = typeof SourceTextModule === 'function';
+const supportsDynamicImport = esmIsAvailable;
 
 const dataURIRegex =
   /^data:(?<mime>text\/javascript|application\/json|application\/wasm)(?:;(?<encoding>charset=utf-8|base64))?,(?<code>.*)$/;
@@ -580,7 +581,7 @@ export default class Runtime {
       // @ts-expect-error -- exiting
       return;
     }
-    if (this.isInsideTestCode === false) {
+    if (this.isInsideTestCode === false && !supportsDynamicImport) {
       throw new ReferenceError(
         'You are trying to `import` a file outside of the scope of the test code.',
       );
@@ -742,7 +743,7 @@ export default class Runtime {
       process.exitCode = 1;
       return;
     }
-    if (this.isInsideTestCode === false) {
+    if (this.isInsideTestCode === false && !supportsDynamicImport) {
       throw new ReferenceError(
         'You are trying to `import` a file outside of the scope of the test code.',
       );
@@ -1563,7 +1564,7 @@ export default class Runtime {
       process.exitCode = 1;
       return;
     }
-    if (this.isInsideTestCode === false) {
+    if (this.isInsideTestCode === false && !supportsDynamicImport) {
       throw new ReferenceError(
         'You are trying to `import` a file outside of the scope of the test code.',
       );
@@ -2466,7 +2467,9 @@ export default class Runtime {
     const stackTrace = formatStackTrace(stack, this._config, {
       noStackTrace: false,
     });
-    const formattedMessage = `\n${message}${stackTrace ? `\n${stackTrace}` : ''}`;
+    const formattedMessage = `\n${message}${
+      stackTrace ? `\n${stackTrace}` : ''
+    }`;
     if (!this.loggedReferenceErrors.has(formattedMessage)) {
       console.error(formattedMessage);
       this.loggedReferenceErrors.add(formattedMessage);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Resolves #15823

When user specifies feature flag to enable ESM support from Node.js runtime, `jest-runtime` should tolerate dynamic imports. I've verified that tests added in #14110 are still holding so the extended condition should ideally fix referred issue within an acceptable impact radius.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

- Green CI
- Confirmation from affected user
