### PR TITLE
doc: update v30 migration guide for `jest.mock()` strictly case-sentitive path

### DIFF
--- a/docs/UpgradingToJest30.md
+++ b/docs/UpgradingToJest30.md
@@ -184,6 +184,22 @@ Some TypeScript types related to mock functions have been removed from the publi
 
 If you were using `jest.SpyInstance` (for instance, to annotate the return of `jest.spyOn`), you should update to using [`jest.Spied`](./MockFunctionAPI.md#jestspiedsource).
 
+### `jest.mock` only mock case-sensitive module filename   
+
+`jest.mock()` will only accept case-sensitive module path from now on. At best, this is an edge case since most users would follow OS filename pattern behavior. We recommend to use correctly named module path to avoid similar breakages in the future. 
+
+Old code (Jest 29):
+
+```js
+jest.mock('./path/to/FILENAME.js') # This works EVEN when you only have `filename.js`
+```
+
+New code (Jest 30):
+
+```js
+jest.mock('./path/to/filename.js') # This strictly works when you ONLY have `filename.js`
+```
+
 ## Module & Runtime Changes
 
 ### ESM Module Support and Internal Restructuring


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Closes #15847 

Update v30 migration guide on changed behavior of `jest.mock()` to only work with case-sensitive paths from now, unlike Jest 29.

The change behavior seems to originate at this [PR](https://github.com/jestjs/jest/pull/15619), starting from `30.0.0-beta.6`. 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

- [x] Green CI
- [x] Confirmed from local reproduction.
