### PR TITLE
fix: support custom reporters in legacy module path `$HOME/.node_libraries`

### DIFF
--- a/e2e/__tests__/customReporters.test.ts
+++ b/e2e/__tests__/customReporters.test.ts
@@ -179,4 +179,28 @@ describe('Custom Reporters Integration', () => {
     expect(stderr).toMatch(/ON_RUN_START_ERROR/);
     expect(exitCode).toBe(1);
   });
+
+  test('supports custom reporter stored in legacy module path, i.e. $HOME/.node_libraries', () => {
+    writeFiles(DIR, {
+      '__tests__/test.test.js': "test('test', () => {});",
+      'package.json': JSON.stringify({
+        jest: {
+          reporters: ['@org/custom-reporter'],
+        },
+      }),
+      'fakeHome/.node_libraries/@org/custom-reporter/index.js': `
+        export default class Reporter {
+          onRunStart() {
+            throw new Error('ON_RUN_START_ERROR');
+          }
+        };
+      `,
+    });
+
+    const {stderr, exitCode} = runJest(DIR, undefined, {
+      env: {HOME: path.resolve(DIR, 'fakeHome')},
+    });
+    expect(stderr).toMatch(/ON_RUN_START_ERROR/);
+    expect(exitCode).toBe(1);
+  });
 });

--- a/packages/jest-util/src/specialChars.ts
+++ b/packages/jest-util/src/specialChars.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-const isWindows = process.platform === 'win32';
+export const isWindows = process.platform === 'win32';
 
 export const ARROW = ' \u203A ';
 export const ICONS = {


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Closes #15779 

Fixes regression of reporter import behavior due to `unrs-resolver` migration and take historical global module path like `$HOME/.node_libraries` into account. 

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

- Green CI
- Confirmed from affected user.
