### PR TITLE
chore: update TSTyche to v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "strip-json-comments": "^3.1.1",
     "tempy": "^1.0.1",
     "ts-node": "^10.5.0",
-    "tstyche": "^5.0.0",
+    "tstyche": "^6.0.2",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.38.0",
     "webpack": "^5.68.0",

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -208,7 +208,9 @@ describe('jest.fn()', () => {
         expect(b).type.toBe<number | undefined>();
         return false;
       }),
-    ).type.toBe<Mock<(this: Date, a: string, b?: number | undefined) => boolean>>();
+    ).type.toBe<
+      Mock<(this: Date, a: string, b?: number | undefined) => boolean>
+    >();
 
     expect(mockFn.mockImplementation).type.not.toBeCallableWith(
       (a: number) => false,
@@ -235,7 +237,9 @@ describe('jest.fn()', () => {
         expect(b).type.toBe<number | undefined>();
         return false;
       }),
-    ).type.toBe<Mock<(this: Date, a: string, b?: number | undefined) => boolean>>();
+    ).type.toBe<
+      Mock<(this: Date, a: string, b?: number | undefined) => boolean>
+    >();
 
     expect(mockFn.mockImplementationOnce).type.not.toBeCallableWith(
       (a: number) => false,

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -125,7 +125,7 @@ describe('jest.fn()', () => {
 
   test('.getMockImplementation()', () => {
     expect(mockFn.getMockImplementation()).type.toBe<
-      ((a: string, b?: number | undefined) => boolean) | undefined
+      ((this: Date, a: string, b?: number | undefined) => boolean) | undefined
     >();
 
     expect(mockFn.getMockImplementation).type.not.toBeCallableWith('some-mock');
@@ -181,7 +181,7 @@ describe('jest.fn()', () => {
 
   test('.mockClear()', () => {
     expect(mockFn.mockClear()).type.toBe<
-      Mock<(a: string, b?: number | undefined) => boolean>
+      Mock<(this: Date, a: string, b?: number | undefined) => boolean>
     >();
 
     expect(mockFn.mockClear).type.not.toBeCallableWith('some-mock');
@@ -189,7 +189,7 @@ describe('jest.fn()', () => {
 
   test('.mockReset()', () => {
     expect(mockFn.mockReset()).type.toBe<
-      Mock<(a: string, b?: number | undefined) => boolean>
+      Mock<(this: Date, a: string, b?: number | undefined) => boolean>
     >();
 
     expect(mockFn.mockReset).type.not.toBeCallableWith('some-mock');
@@ -208,7 +208,7 @@ describe('jest.fn()', () => {
         expect(b).type.toBe<number | undefined>();
         return false;
       }),
-    ).type.toBe<Mock<(a: string, b?: number | undefined) => boolean>>();
+    ).type.toBe<Mock<(this: Date, a: string, b?: number | undefined) => boolean>>();
 
     expect(mockFn.mockImplementation).type.not.toBeCallableWith(
       (a: number) => false,
@@ -235,7 +235,7 @@ describe('jest.fn()', () => {
         expect(b).type.toBe<number | undefined>();
         return false;
       }),
-    ).type.toBe<Mock<(a: string, b?: number | undefined) => boolean>>();
+    ).type.toBe<Mock<(this: Date, a: string, b?: number | undefined) => boolean>>();
 
     expect(mockFn.mockImplementationOnce).type.not.toBeCallableWith(
       (a: number) => false,
@@ -258,7 +258,7 @@ describe('jest.fn()', () => {
 
   test('.mockName()', () => {
     expect(mockFn.mockName('mockedFunction')).type.toBe<
-      Mock<(a: string, b?: number | undefined) => boolean>
+      Mock<(this: Date, a: string, b?: number | undefined) => boolean>
     >();
 
     expect(mockFn.mockName).type.not.toBeCallableWith(123);
@@ -267,7 +267,7 @@ describe('jest.fn()', () => {
 
   test('.mockReturnThis()', () => {
     expect(mockFn.mockReturnThis()).type.toBe<
-      Mock<(a: string, b?: number | undefined) => boolean>
+      Mock<(this: Date, a: string, b?: number | undefined) => boolean>
     >();
 
     expect(mockFn.mockReturnThis).type.not.toBeCallableWith('this');
@@ -275,7 +275,7 @@ describe('jest.fn()', () => {
 
   test('.mockReturnValue()', () => {
     expect(mockFn.mockReturnValue(false)).type.toBe<
-      Mock<(a: string, b?: number | undefined) => boolean>
+      Mock<(this: Date, a: string, b?: number | undefined) => boolean>
     >();
 
     expect(mockFn.mockReturnValue).type.not.toBeCallableWith('true');
@@ -292,7 +292,7 @@ describe('jest.fn()', () => {
 
   test('.mockReturnValueOnce()', () => {
     expect(mockFn.mockReturnValueOnce(false)).type.toBe<
-      Mock<(a: string, b?: number | undefined) => boolean>
+      Mock<(this: Date, a: string, b?: number | undefined) => boolean>
     >();
     expect(mockFn.mockReturnValueOnce).type.not.toBeCallableWith('true');
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4480,7 +4480,7 @@ __metadata:
     strip-json-comments: "npm:^3.1.1"
     tempy: "npm:^1.0.1"
     ts-node: "npm:^10.5.0"
-    tstyche: "npm:^5.0.0"
+    tstyche: "npm:^6.0.2"
     typescript: "npm:^5.8.3"
     typescript-eslint: "npm:^8.38.0"
     webpack: "npm:^5.68.0"
@@ -21446,17 +21446,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tstyche@npm:^5.0.0":
-  version: 5.0.2
-  resolution: "tstyche@npm:5.0.2"
+"tstyche@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "tstyche@npm:6.0.2"
   peerDependencies:
-    typescript: ">=5.0"
+    typescript: ">=5.4"
   peerDependenciesMeta:
     typescript:
       optional: true
   bin:
-    tstyche: ./build/bin.js
-  checksum: 10/bbc11c2f7c5c1cbf4f848a9af1eef947cf9b2643491a59fb7dbaa903bb15bba620dad24904c3db6279f206a23599d97d47f9d9e00473c54f6bb9375a7dc26178
+    tstyche: ./dist/bin.js
+  checksum: 10/d739cefdf6c46d561535fa487c2348931c6075a8acbebf3f35bafe063f33114f3ce209cac5b66652113f46ad2e1a44589163914835fc59ea36d55b96e9428cfe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

This PR updates TSTyche to v6. Release notes: https://tstyche.org/releases/tstyche-6

As you can see in the diff, the implementation of `.type.toBe()` matcher now takes into account more details than before. (The mistakes I made earlier while writing the tests got caught. Yep... I am also impressed.)

## Test plan

Green CI.