### PR TITLE
ci: declare explicit token permissions in reusable workflows

### DIFF
--- a/.github/workflows/pkg-pr-new.yml
+++ b/.github/workflows/pkg-pr-new.yml
@@ -8,6 +8,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+  pull-requests: write # to comment with pkg.pr.new publish results
+
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/prepare-cache.yml
+++ b/.github/workflows/prepare-cache.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   prepare-yarn-cache:
     name: Prepare yarn cache for ${{ inputs.os }}

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -7,6 +7,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   test:
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
## Summary
- add explicit `permissions` to reusable CI workflows used by Node CI and nightly CI
- set `contents: read` for cache/test reusable workflows that only need checkout access
- set `contents: read` and `pull-requests: write` for `pkg-pr-new` so publish comment behavior remains intact

## Why
Several workflows relied on implicit default `GITHUB_TOKEN` scopes. Declaring explicit least-privilege permissions makes required access clear and avoids overbroad defaults.

## Validation
- reviewed each workflow for required token usage
- confirmed no job steps requiring broader repository write permissions
