### PR TITLE
chore(jest-changed-files): replace execa with native node:child_process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Chore & Maintenance
 
+- `[jest-changed-files]` Replace `execa` with native `node:child_process` ([#XXXXX](https://github.com/jestjs/jest/pull/XXXXX))
 - `[docs]` Update V30 migration guide to notify users on `jest.mock()` work with case-sensitive path ([#15849](https://github.com/jestjs/jest/pull/15849))
 - `[deps]` Update to sinon/fake-timers v15
 - Updated Twitter icon to match the latest brand guidelines.([#15868](https://github.com/jestjs/jest/pull/15869))

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -19,7 +19,6 @@
     "./package.json": "./package.json"
   },
   "dependencies": {
-    "execa": "^5.1.1",
     "jest-util": "workspace:*",
     "p-limit": "^3.1.0"
   },

--- a/packages/jest-changed-files/src/git.ts
+++ b/packages/jest-changed-files/src/git.ts
@@ -6,17 +6,23 @@
  *
  */
 
+import {execFile as execFileCb} from 'node:child_process';
+import {promisify} from 'node:util';
 import * as path from 'path';
-import execa from 'execa';
 import type {SCMAdapter} from './types';
+
+const execFile = promisify(execFileCb);
+
+const MAX_BUFFER = 100 * 1024 * 1024;
 
 const findChangedFilesUsingCommand = async (
   args: Array<string>,
   cwd: string,
 ): Promise<Array<string>> => {
-  const result = await execa('git', args, {cwd});
+  const result = await execFile('git', args, {cwd, maxBuffer: MAX_BUFFER});
 
   return result.stdout
+    .trimEnd()
     .split('\n')
     .filter(s => s !== '')
     .map(changedPath => path.resolve(cwd, changedPath));
@@ -98,9 +104,12 @@ const adapter: SCMAdapter = {
     const options = ['rev-parse', '--show-cdup'];
 
     try {
-      const result = await execa('git', options, {cwd});
+      const result = await execFile('git', options, {
+        cwd,
+        maxBuffer: MAX_BUFFER,
+      });
 
-      return path.resolve(cwd, result.stdout);
+      return path.resolve(cwd, result.stdout.trimEnd());
     } catch {
       return null;
     }

--- a/packages/jest-changed-files/src/hg.ts
+++ b/packages/jest-changed-files/src/hg.ts
@@ -6,9 +6,14 @@
  *
  */
 
+import {execFile as execFileCb} from 'node:child_process';
+import {promisify} from 'node:util';
 import * as path from 'path';
-import execa from 'execa';
 import type {SCMAdapter} from './types';
+
+const execFile = promisify(execFileCb);
+
+const MAX_BUFFER = 100 * 1024 * 1024;
 
 const env = {...process.env, HGPLAIN: '1'};
 
@@ -29,9 +34,14 @@ const adapter: SCMAdapter = {
     }
     args.push(...includePaths);
 
-    const result = await execa('hg', args, {cwd, env});
+    const result = await execFile('hg', args, {
+      cwd,
+      env,
+      maxBuffer: MAX_BUFFER,
+    });
 
     return result.stdout
+      .trimEnd()
       .split('\n')
       .filter(s => s !== '')
       .map(changedPath => path.resolve(cwd, changedPath));
@@ -39,9 +49,13 @@ const adapter: SCMAdapter = {
 
   getRoot: async cwd => {
     try {
-      const result = await execa('hg', ['root'], {cwd, env});
+      const result = await execFile('hg', ['root'], {
+        cwd,
+        env,
+        maxBuffer: MAX_BUFFER,
+      });
 
-      return result.stdout;
+      return result.stdout.trimEnd();
     } catch {
       return null;
     }

--- a/packages/jest-changed-files/src/sl.ts
+++ b/packages/jest-changed-files/src/sl.ts
@@ -6,9 +6,14 @@
  *
  */
 
+import {execFile as execFileCb, spawn} from 'node:child_process';
+import {promisify} from 'node:util';
 import * as path from 'path';
-import execa from 'execa';
 import type {SCMAdapter} from './types';
+
+const execFile = promisify(execFileCb);
+
+const MAX_BUFFER = 100 * 1024 * 1024;
 
 /**
  * Disable any configuration settings that might change Sapling's default output.
@@ -36,9 +41,14 @@ const adapter: SCMAdapter = {
     }
     args.push(...includePaths);
 
-    const result = await execa('sl', args, {cwd, env});
+    const result = await execFile('sl', args, {
+      cwd,
+      env,
+      maxBuffer: MAX_BUFFER,
+    });
 
     return result.stdout
+      .trimEnd()
       .split('\n')
       .filter(s => s !== '')
       .map(changedPath => path.resolve(cwd, changedPath));
@@ -50,21 +60,41 @@ const adapter: SCMAdapter = {
     }
 
     try {
-      const subprocess = execa('sl', ['root'], {cwd, env});
+      const result = await new Promise<{killed: boolean; stdout: string}>(
+        (resolve, reject) => {
+          const subprocess = spawn('sl', ['root'], {cwd, env});
+          let firstChunk = true;
+          let stdout = '';
 
-      // Check if we're calling sl (steam locomotive) instead of sl (sapling)
-      // by looking for the escape character in the first chunk of data.
-      if (subprocess.stdout) {
-        subprocess.stdout.once('data', (data: Buffer | string) => {
-          data = Buffer.isBuffer(data) ? data.toString() : data;
-          if (data.codePointAt(0) === 27) {
-            subprocess.cancel();
-            isSteamLocomotive = true;
-          }
-        });
-      }
+          subprocess.stdout.on('data', (data: Buffer) => {
+            const str = data.toString();
 
-      const result = await subprocess;
+            // Check if we're calling sl (steam locomotive) instead of
+            // sl (sapling) by looking for the escape character in the
+            // first chunk of data.
+            if (firstChunk) {
+              firstChunk = false;
+              if (str.codePointAt(0) === 27) {
+                subprocess.kill();
+                isSteamLocomotive = true;
+              }
+            }
+
+            stdout += str;
+          });
+
+          subprocess.on('close', code => {
+            if (code !== 0 && !subprocess.killed) {
+              reject(new Error(`Process sl exited with code ${code}`));
+            } else {
+              resolve({killed: subprocess.killed, stdout: stdout.trimEnd()});
+            }
+          });
+
+          subprocess.on('error', reject);
+        },
+      );
+
       if (result.killed && isSteamLocomotive) {
         return null;
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13869,7 +13869,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jest-changed-files@workspace:packages/jest-changed-files"
   dependencies:
-    execa: "npm:^5.1.1"
     jest-util: "workspace:*"
     p-limit: "npm:^3.1.0"
   languageName: unknown


### PR DESCRIPTION
## Summary

Replace `execa` v5 with native `node:child_process` APIs in `jest-changed-files`. execa v5 is pinned because v6+ is ESM-only, making it a good candidate for removal via native equivalents.

- `execFile` + `promisify` for `git.ts`, `hg.ts`, and `sl.ts` `findChangedFiles`
- `spawn` for `sl.ts` `getRoot` (requires stream access for steam locomotive detection)
- `maxBuffer` set to 100MB matching execa v5's default
- `.trimEnd()` compensates for execa's `stripFinalNewline` behavior
- Non-zero exit codes properly rejected in spawn handler

Removes `execa` and ~10 transitive dependencies from `jest-changed-files`.

## Test plan

- [x] `yarn jest e2e/__tests__/jestChangedFiles.test.ts` — 5 passed, 9 skipped (hg/sl not installed)
- [x] `yarn eslint packages/jest-changed-files/src` — clean
- [x] Prettier — clean
- [x] `yarn constraints` — pass
- [x] `yarn dedupe --check` — pass
- [x] Copyright headers — pass