### PR TITLE
chore(jest-core, jest-watcher): replace ansi-escapes with inline ANSI sequences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - `[docs]` Update V30 migration guide to notify users on `jest.mock()` work with case-sensitive path ([#15849](https://github.com/jestjs/jest/pull/15849))
 - `[deps]` Update to sinon/fake-timers v15
+- `[jest-core, jest-watcher]` Replace `ansi-escapes` with inline ANSI escape sequences via `jest-util` ([#XXXXX](https://github.com/jestjs/jest/pull/XXXXX))
 - Updated Twitter icon to match the latest brand guidelines.([#15868](https://github.com/jestjs/jest/pull/15869))
 - `[*]` Replace remaining micromatch uses with picomatch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - `[docs]` Update V30 migration guide to notify users on `jest.mock()` work with case-sensitive path ([#15849](https://github.com/jestjs/jest/pull/15849))
 - `[deps]` Update to sinon/fake-timers v15
-- `[jest-core, jest-watcher]` Replace `ansi-escapes` with inline ANSI escape sequences via `jest-util` ([#XXXXX](https://github.com/jestjs/jest/pull/XXXXX))
+- `[jest-core, jest-watcher]` Replace `ansi-escapes` with inline ANSI escape sequences via `jest-util` ([#15970](https://github.com/jestjs/jest/pull/15970))
 - Updated Twitter icon to match the latest brand guidelines.([#15868](https://github.com/jestjs/jest/pull/15869))
 - `[*]` Replace remaining micromatch uses with picomatch
 

--- a/package.json
+++ b/package.json
@@ -197,7 +197,6 @@
   "resolutions": {
     "@types/node": "18.x",
     "@types/react": "^18.2.21",
-    "ansi-escapes/type-fest": "^2.0.0",
     "babel-jest": "workspace:*",
     "jest": "workspace:*",
     "jest-environment-node": "workspace:*",

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -21,7 +21,6 @@
     "@jest/transform": "workspace:*",
     "@jest/types": "workspace:*",
     "@types/node": "*",
-    "ansi-escapes": "^4.3.2",
     "chalk": "^4.1.2",
     "ci-info": "^4.2.0",
     "exit-x": "^0.2.2",

--- a/packages/jest-core/src/FailedTestsInteractiveMode.ts
+++ b/packages/jest-core/src/FailedTestsInteractiveMode.ts
@@ -5,10 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
 import type {AggregatedResult, AssertionLocation} from '@jest/test-result';
-import {pluralize, specialChars} from 'jest-util';
+import {ansiEscapes, pluralize, specialChars} from 'jest-util';
 import {KEYS} from 'jest-watcher';
 
 type RunnerUpdateFunction = (failure?: AssertionLocation) => void;

--- a/packages/jest-core/src/SnapshotInteractiveMode.ts
+++ b/packages/jest-core/src/SnapshotInteractiveMode.ts
@@ -5,10 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
 import type {AggregatedResult, AssertionLocation} from '@jest/test-result';
-import {pluralize, specialChars} from 'jest-util';
+import {ansiEscapes, pluralize, specialChars} from 'jest-util';
 import {KEYS} from 'jest-watcher';
 
 const {ARROW, CLEAR} = specialChars;

--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -7,7 +7,6 @@
 
 import * as path from 'path';
 import type {WriteStream} from 'tty';
-import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
 import exit from 'exit-x';
 import slash from 'slash';
@@ -17,6 +16,7 @@ import type {Config} from '@jest/types';
 import type {IHasteMap as HasteMap} from 'jest-haste-map';
 import {formatExecError} from 'jest-message-util';
 import {
+  ansiEscapes,
   isInteractive,
   preRunMessage,
   requireOrImportModule,

--- a/packages/jest-util/src/ansiEscapes.ts
+++ b/packages/jest-util/src/ansiEscapes.ts
@@ -1,0 +1,26 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Inline ANSI escape sequences, replacing the ansi-escapes package.
+// These are standard VT100/ECMA-48 sequences.
+
+const ESC = '\u001B[';
+
+export const cursorUp = (n = 1): string => `${ESC}${n}A`;
+export const cursorDown = (n = 1): string => `${ESC}${n}B`;
+export const cursorTo = (x: number, y?: number): string =>
+  y == null ? `${ESC}${x + 1}G` : `${ESC}${y + 1};${x + 1}H`;
+export const cursorHide = `${ESC}?25l`;
+export const cursorShow = `${ESC}?25h`;
+export const cursorLeft = `${ESC}G`;
+
+const isTerminalApp = process.env.TERM_PROGRAM === 'Apple_Terminal';
+export const cursorSavePosition = isTerminalApp ? '\u001B7' : `${ESC}s`;
+export const cursorRestorePosition = isTerminalApp ? '\u001B8' : `${ESC}u`;
+
+export const eraseDown = `${ESC}J`;
+export const eraseLine = `${ESC}2K`;

--- a/packages/jest-util/src/index.ts
+++ b/packages/jest-util/src/index.ts
@@ -6,9 +6,11 @@
  */
 
 // need to do this for api-extractor: https://github.com/microsoft/rushstack/issues/2780
+import * as ansiEscapes from './ansiEscapes';
 import * as preRunMessage from './preRunMessage';
 import * as specialChars from './specialChars';
 
+export {ansiEscapes};
 export {default as clearLine} from './clearLine';
 export {default as createDirectory} from './createDirectory';
 export {default as ErrorWithStack} from './ErrorWithStack';

--- a/packages/jest-watcher/package.json
+++ b/packages/jest-watcher/package.json
@@ -17,7 +17,6 @@
     "@jest/test-result": "workspace:*",
     "@jest/types": "workspace:*",
     "@types/node": "*",
-    "ansi-escapes": "^4.3.2",
     "chalk": "^4.1.2",
     "emittery": "^0.13.1",
     "jest-util": "workspace:*",

--- a/packages/jest-watcher/src/PatternPrompt.ts
+++ b/packages/jest-watcher/src/PatternPrompt.ts
@@ -5,9 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
-import {specialChars} from 'jest-util';
+import {ansiEscapes, specialChars} from 'jest-util';
 import type Prompt from './lib/Prompt';
 import type {ScrollOptions} from './types';
 

--- a/packages/jest-watcher/src/lib/patternModeHelpers.ts
+++ b/packages/jest-watcher/src/lib/patternModeHelpers.ts
@@ -5,9 +5,9 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
 import stringLength from 'string-length';
+import {ansiEscapes} from 'jest-util';
 
 export function printPatternCaret(
   pattern: string,

--- a/yarn.lock
+++ b/yarn.lock
@@ -4261,7 +4261,6 @@ __metadata:
     "@jest/types": "workspace:*"
     "@types/graceful-fs": "npm:^4.1.9"
     "@types/node": "npm:*"
-    ansi-escapes: "npm:^4.3.2"
     chalk: "npm:^4.1.2"
     ci-info: "npm:^4.2.0"
     exit-x: "npm:^0.2.2"
@@ -14477,7 +14476,6 @@ __metadata:
     "@jest/test-result": "workspace:*"
     "@jest/types": "workspace:*"
     "@types/node": "npm:*"
-    ansi-escapes: "npm:^4.3.2"
     chalk: "npm:^4.1.2"
     emittery: "npm:^0.13.1"
     jest-util: "workspace:*"
@@ -21494,6 +21492,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^0.21.3":
+  version: 0.21.3
+  resolution: "type-fest@npm:0.21.3"
+  checksum: 10/f4254070d9c3d83a6e573bcb95173008d73474ceadbbf620dd32d273940ca18734dff39c2b2480282df9afe5d1675ebed5499a00d791758748ea81f61a38961f
+  languageName: node
+  linkType: hard
+
 "type-fest@npm:^0.6.0":
   version: 0.6.0
   resolution: "type-fest@npm:0.6.0"
@@ -21515,7 +21520,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"type-fest@npm:^2.0.0, type-fest@npm:^2.13.0, type-fest@npm:^2.5.0, type-fest@npm:^2.5.1":
+"type-fest@npm:^2.13.0, type-fest@npm:^2.5.0, type-fest@npm:^2.5.1":
   version: 2.19.0
   resolution: "type-fest@npm:2.19.0"
   checksum: 10/7bf9e8fdf34f92c8bb364c0af14ca875fac7e0183f2985498b77be129dc1b3b1ad0a6b3281580f19e48c6105c037fb966ad9934520c69c6434d17fd0af4eed78


### PR DESCRIPTION
## Summary

Replace the `ansi-escapes` package (which pulls in `type-fest` as a transitive dependency) with inline VT100/ECMA-48 escape sequences via a new `jest-util/ansiEscapes` module.

- Adds `packages/jest-util/src/ansiEscapes.ts` with the 10 escape sequences actually used: `cursorUp`, `cursorDown`, `cursorTo`, `cursorHide`, `cursorShow`, `cursorLeft`, `cursorSavePosition`, `cursorRestorePosition`, `eraseDown`, `eraseLine`
- Updates 5 consumer files in `jest-core` and `jest-watcher` to import from `jest-util` instead of `ansi-escapes`
- Removes `ansi-escapes` from `jest-core/package.json` and `jest-watcher/package.json`
- Removes the `ansi-escapes/type-fest` resolution workaround from root `package.json`

### Why

The `ansi-escapes` package depends on `type-fest`, which has historically caused TypeScript compatibility issues (see #13177, #13471). The repo has carried an `ansi-escapes/type-fest` resolution workaround since 2022. Since `jest-util` already contains inline ANSI utilities (`clearLine.ts`, `specialChars.ts`), adding the 10 escape sequences used by jest-core and jest-watcher is consistent and removes the need for the workaround.

### Context

This was previously attempted in #13471 (Oct 2022), where the concern was bloating `jest-util`. Since then, the repo has embraced similar dependency reduction patterns (e.g., #15922 replacing micromatch with picomatch, #15928 removing unused deps). The new module is 27 lines and follows the same pattern as existing `jest-util` terminal utilities.

## Test plan

- `yarn build:js` passes
- `yarn eslint` passes on all changed files
- `yarn constraints` passes
- `yarn dedupe --check` passes
- `yarn check-copyright-headers` passes
- All tests in `jest-core`, `jest-watcher`, and `jest-util` pass (excluding pre-existing snapshot failures on `main` unrelated to this change)