### PR TITLE
chore(jest-util): replace `slash` with inline implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 
 - `[docs]` Update V30 migration guide to notify users on `jest.mock()` work with case-sensitive path ([#15849](https://github.com/jestjs/jest/pull/15849))
 - `[deps]` Update to sinon/fake-timers v15
-- `[jest-util]` Replace `slash` package with inline implementation ([#XXXXX](https://github.com/jestjs/jest/pull/XXXXX))
+- `[jest-util]` Replace `slash` package with inline implementation ([#15971](https://github.com/jestjs/jest/pull/15971))
 - Updated Twitter icon to match the latest brand guidelines.([#15868](https://github.com/jestjs/jest/pull/15869))
 - `[*]` Replace remaining micromatch uses with picomatch
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 - `[docs]` Update V30 migration guide to notify users on `jest.mock()` work with case-sensitive path ([#15849](https://github.com/jestjs/jest/pull/15849))
 - `[deps]` Update to sinon/fake-timers v15
+- `[jest-util]` Replace `slash` package with inline implementation ([#XXXXX](https://github.com/jestjs/jest/pull/XXXXX))
 - Updated Twitter icon to match the latest brand guidelines.([#15868](https://github.com/jestjs/jest/pull/15869))
 - `[*]` Replace remaining micromatch uses with picomatch
 

--- a/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/moduleNameMapper.test.ts.snap
@@ -41,7 +41,7 @@ exports[`moduleNameMapper wrong array configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:1117:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:1109:17)
       at Object.require (index.js:10:1)
       at Object.require (__tests__/index.js:10:20)"
 `;
@@ -71,7 +71,7 @@ exports[`moduleNameMapper wrong configuration 1`] = `
       12 | module.exports = () => 'test';
       13 |
 
-      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:1117:17)
+      at createNoMappedModuleFoundError (../../packages/jest-resolve/build/index.js:1109:17)
       at Object.require (index.js:10:1)
       at Object.require (__tests__/index.js:10:20)"
 `;

--- a/e2e/__tests__/__snapshots__/requireMissingExt.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/requireMissingExt.test.ts.snap
@@ -26,7 +26,7 @@ exports[`shows a proper error from deep requires 1`] = `
       12 | test('dummy', () => {
       13 |   expect(1).toBe(1);
 
-      at Resolver._throwModNotFoundError (../../packages/jest-resolve/build/index.js:863:11)
+      at Resolver._throwModNotFoundError (../../packages/jest-resolve/build/index.js:855:11)
       at Object.<anonymous> (node_modules/discord.js/src/index.js:21:12)
       at Object.require (__tests__/test.js:10:1)"
 `;

--- a/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/resolveNoFileExtensions.test.ts.snap
@@ -37,7 +37,7 @@ exports[`show error message with matching files 1`] = `
         |                  ^
       9 |
 
-      at Resolver._throwModNotFoundError (../../packages/jest-resolve/build/index.js:863:11)
+      at Resolver._throwModNotFoundError (../../packages/jest-resolve/build/index.js:855:11)
       at Object.require (index.js:8:18)
       at Object.require (__tests__/test.js:8:11)"
 `;

--- a/e2e/__tests__/jest.config.js.test.ts
+++ b/e2e/__tests__/jest.config.js.test.ts
@@ -31,7 +31,7 @@ test('works with jest.config.js', () => {
 test('traverses directory tree up until it finds jest.config', () => {
   writeFiles(DIR, {
     '__tests__/a-banana.js': `
-    const slash = require('slash');
+    const slash = p => p.replaceAll('\\\\', '/');
     test('banana', () => expect(1).toBe(1));
     test('abc', () => console.log(slash(process.cwd())));
     `,

--- a/e2e/__tests__/jest.config.ts.test.ts
+++ b/e2e/__tests__/jest.config.ts.test.ts
@@ -71,7 +71,7 @@ test('works with tsconfig.json', () => {
 test('traverses directory tree up until it finds jest.config', () => {
   writeFiles(DIR, {
     '__tests__/a-giraffe.js': `
-    const slash = require('slash');
+    const slash = p => p.replaceAll('\\\\', '/');
     test('giraffe', () => expect(1).toBe(1));
     test('abc', () => console.log(slash(process.cwd())));
     `,

--- a/e2e/__tests__/jestChangedFiles.test.ts
+++ b/e2e/__tests__/jestChangedFiles.test.ts
@@ -9,7 +9,7 @@ import {tmpdir} from 'os';
 import * as path from 'path';
 import * as fs from 'graceful-fs';
 import * as semver from 'semver';
-import slash from 'slash';
+import {slash} from 'jest-util';
 import {findRepos, getChangedFilesForRoots} from 'jest-changed-files';
 import {
   cleanup,

--- a/e2e/__tests__/multipleConfigs.ts
+++ b/e2e/__tests__/multipleConfigs.ts
@@ -6,7 +6,7 @@
  */
 
 import * as path from 'path';
-import slash from 'slash';
+import {slash} from 'jest-util';
 import runJest from '../runJest';
 
 const MULTIPLE_CONFIGS_WARNING_TEXT = 'Multiple configurations found';

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "resolve": "^1.20.0",
     "rimraf": "^5.0.10",
     "semver": "^7.7.2",
-    "slash": "^3.0.0",
     "strip-json-comments": "^3.1.1",
     "tempy": "^1.0.1",
     "ts-node": "^10.5.0",

--- a/packages/babel-jest/package.json
+++ b/packages/babel-jest/package.json
@@ -26,7 +26,7 @@
     "babel-preset-jest": "workspace:*",
     "chalk": "^4.1.2",
     "graceful-fs": "^4.2.11",
-    "slash": "^3.0.0"
+    "jest-util": "workspace:*"
   },
   "devDependencies": {
     "@babel-8/core": "npm:@babel/core@8.0.0-beta.2",

--- a/packages/babel-jest/src/index.ts
+++ b/packages/babel-jest/src/index.ts
@@ -13,12 +13,12 @@ import type {
 } from '@babel/core';
 import chalk from 'chalk';
 import * as fs from 'graceful-fs';
-import slash from 'slash';
 import type {
   TransformOptions as JestTransformOptions,
   SyncTransformer,
   TransformerCreator,
 } from '@jest/transform';
+import {slash} from 'jest-util';
 import {
   transformSync as babelTransform,
   transformAsync as babelTransformAsync,

--- a/packages/babel-jest/tsconfig.json
+++ b/packages/babel-jest/tsconfig.json
@@ -7,5 +7,5 @@
   "include": ["./src/**/*"],
   "exclude": ["./**/__tests__/**/*"],
   // TODO: include `babel-preset-jest` if it's ever in TS even though we don't care about its types
-  "references": [{"path": "../jest-transform"}]
+  "references": [{"path": "../jest-transform"}, {"path": "../jest-util"}]
 }

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -38,7 +38,6 @@
     "p-limit": "^3.1.0",
     "pretty-format": "workspace:*",
     "pure-rand": "^7.0.0",
-    "slash": "^3.0.0",
     "stack-utils": "^2.0.6"
   },
   "devDependencies": {

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -9,7 +9,6 @@ import * as path from 'path';
 import co from 'co';
 import dedent from 'dedent';
 import isGeneratorFn from 'is-generator-fn';
-import slash from 'slash';
 import StackUtils from 'stack-utils';
 import type {Status, TestCaseResult} from '@jest/test-result';
 import type {Circus, Global} from '@jest/types';
@@ -19,6 +18,7 @@ import {
   formatTime,
   invariant,
   isPromise,
+  slash,
 } from 'jest-util';
 import {format as prettyFormat} from 'pretty-format';
 import {ROOT_DESCRIBE_BLOCK_NAME, getState} from './state';

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -56,7 +56,6 @@
     "jest-validate": "workspace:*",
     "parse-json": "^5.2.0",
     "pretty-format": "workspace:*",
-    "slash": "^3.0.0",
     "strip-json-comments": "^3.1.1"
   },
   "devDependencies": {

--- a/packages/jest-config/src/resolveConfigPath.ts
+++ b/packages/jest-config/src/resolveConfigPath.ts
@@ -8,7 +8,7 @@
 import * as path from 'path';
 import chalk from 'chalk';
 import * as fs from 'graceful-fs';
-import slash from 'slash';
+import {slash} from 'jest-util';
 import {ValidationError} from 'jest-validate';
 import {
   JEST_CONFIG_BASE_NAME,

--- a/packages/jest-console/package.json
+++ b/packages/jest-console/package.json
@@ -23,8 +23,7 @@
     "@types/node": "*",
     "chalk": "^4.1.2",
     "jest-message-util": "workspace:*",
-    "jest-util": "workspace:*",
-    "slash": "^3.0.0"
+    "jest-util": "workspace:*"
   },
   "devDependencies": {
     "@jest/test-utils": "workspace:*"

--- a/packages/jest-core/package.json
+++ b/packages/jest-core/package.json
@@ -39,8 +39,7 @@
     "jest-util": "workspace:*",
     "jest-validate": "workspace:*",
     "jest-watcher": "workspace:*",
-    "pretty-format": "workspace:*",
-    "slash": "^3.0.0"
+    "pretty-format": "workspace:*"
   },
   "devDependencies": {
     "@jest/test-sequencer": "workspace:*",

--- a/packages/jest-core/src/watch.ts
+++ b/packages/jest-core/src/watch.ts
@@ -10,7 +10,6 @@ import type {WriteStream} from 'tty';
 import ansiEscapes from 'ansi-escapes';
 import chalk from 'chalk';
 import exit from 'exit-x';
-import slash from 'slash';
 import {TestPathPatterns} from '@jest/pattern';
 import type {TestContext} from '@jest/test-result';
 import type {Config} from '@jest/types';
@@ -20,6 +19,7 @@ import {
   isInteractive,
   preRunMessage,
   requireOrImportModule,
+  slash,
   specialChars,
 } from 'jest-util';
 import {ValidationError} from 'jest-validate';

--- a/packages/jest-haste-map/package.json
+++ b/packages/jest-haste-map/package.json
@@ -33,8 +33,7 @@
   "devDependencies": {
     "@types/fb-watchman": "^2.0.5",
     "@types/graceful-fs": "^4.1.9",
-    "@types/picomatch": "^4.0.0",
-    "slash": "^3.0.0"
+    "@types/picomatch": "^4.0.0"
   },
   "optionalDependencies": {
     "fsevents": "^2.3.3"

--- a/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
+++ b/packages/jest-haste-map/src/crawlers/__tests__/node.test.js
@@ -35,7 +35,7 @@ jest.mock('child_process', () => ({
 }));
 
 jest.mock('graceful-fs', () => {
-  const slash = require('slash');
+  const slash = p => p.replaceAll('\\', '/');
   let mtime = 32;
   const size = 42;
   const stat = (path, callback) => {

--- a/packages/jest-message-util/package.json
+++ b/packages/jest-message-util/package.json
@@ -27,9 +27,9 @@
     "@types/stack-utils": "^2.0.3",
     "chalk": "^4.1.2",
     "graceful-fs": "^4.2.11",
+    "jest-util": "workspace:*",
     "picomatch": "^4.0.3",
     "pretty-format": "workspace:*",
-    "slash": "^3.0.0",
     "stack-utils": "^2.0.6"
   },
   "devDependencies": {

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -7,7 +7,7 @@
  */
 
 import {readFileSync} from 'graceful-fs';
-import slash from 'slash';
+import {slash} from 'jest-util';
 import tempy from 'tempy';
 import {
   formatExecError,

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -12,9 +12,9 @@ import {codeFrameColumns} from '@babel/code-frame';
 import chalk from 'chalk';
 import * as fs from 'graceful-fs';
 import picomatch from 'picomatch';
-import slash from 'slash';
 import StackUtils from 'stack-utils';
 import type {Config, TestResult} from '@jest/types';
+import {slash} from 'jest-util';
 import {format as prettyFormat} from 'pretty-format';
 import type {Frame} from './types';
 

--- a/packages/jest-message-util/tsconfig.json
+++ b/packages/jest-message-util/tsconfig.json
@@ -6,5 +6,9 @@
   },
   "include": ["./src/**/*"],
   "exclude": ["./**/__tests__/**/*"],
-  "references": [{"path": "../jest-types"}, {"path": "../jest-util"}, {"path": "../pretty-format"}]
+  "references": [
+    {"path": "../jest-types"},
+    {"path": "../jest-util"},
+    {"path": "../pretty-format"}
+  ]
 }

--- a/packages/jest-message-util/tsconfig.json
+++ b/packages/jest-message-util/tsconfig.json
@@ -6,5 +6,5 @@
   },
   "include": ["./src/**/*"],
   "exclude": ["./**/__tests__/**/*"],
-  "references": [{"path": "../jest-types"}, {"path": "../pretty-format"}]
+  "references": [{"path": "../jest-types"}, {"path": "../jest-util"}, {"path": "../pretty-format"}]
 }

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -34,7 +34,6 @@
     "jest-message-util": "workspace:*",
     "jest-util": "workspace:*",
     "jest-worker": "workspace:*",
-    "slash": "^3.0.0",
     "string-length": "^4.0.2",
     "v8-to-istanbul": "^9.0.1"
   },

--- a/packages/jest-reporters/src/formatTestPath.ts
+++ b/packages/jest-reporters/src/formatTestPath.ts
@@ -7,8 +7,8 @@
 
 import * as path from 'path';
 import chalk from 'chalk';
-import slash from 'slash';
 import type {Config} from '@jest/types';
+import {slash} from 'jest-util';
 import relativePath from './relativePath';
 
 export default function formatTestPath(

--- a/packages/jest-reporters/src/trimAndFormatPath.ts
+++ b/packages/jest-reporters/src/trimAndFormatPath.ts
@@ -7,8 +7,8 @@
 
 import * as path from 'path';
 import chalk from 'chalk';
-import slash from 'slash';
 import type {Config} from '@jest/types';
+import {slash} from 'jest-util';
 import relativePath from './relativePath';
 
 export default function trimAndFormatPath(

--- a/packages/jest-resolve/package.json
+++ b/packages/jest-resolve/package.json
@@ -25,7 +25,6 @@
     "jest-pnp-resolver": "^1.2.3",
     "jest-util": "workspace:*",
     "jest-validate": "workspace:*",
-    "slash": "^3.0.0",
     "unrs-resolver": "^1.7.11"
   },
   "devDependencies": {

--- a/packages/jest-resolve/src/ModuleNotFoundError.ts
+++ b/packages/jest-resolve/src/ModuleNotFoundError.ts
@@ -6,7 +6,7 @@
  */
 
 import * as path from 'path';
-import slash from 'slash';
+import {slash} from 'jest-util';
 
 export default class ModuleNotFoundError extends Error {
   public code = 'MODULE_NOT_FOUND';

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -8,9 +8,8 @@
 import {isBuiltin} from 'module';
 import * as path from 'path';
 import chalk from 'chalk';
-import slash from 'slash';
 import type {IModuleMap} from 'jest-haste-map';
-import {tryRealpath} from 'jest-util';
+import {slash, tryRealpath} from 'jest-util';
 import ModuleNotFoundError from './ModuleNotFoundError';
 import defaultResolver, {
   type AsyncResolver,

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -39,7 +39,6 @@
     "jest-resolve": "workspace:*",
     "jest-snapshot": "workspace:*",
     "jest-util": "workspace:*",
-    "slash": "^3.0.0",
     "strip-bom": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -11,7 +11,7 @@
 import {builtinModules, createRequire} from 'module';
 import * as path from 'path';
 import {pathToFileURL} from 'url';
-import slash from 'slash';
+import {slash} from 'jest-util';
 
 let createRuntime;
 

--- a/packages/jest-runtime/src/helpers.ts
+++ b/packages/jest-runtime/src/helpers.ts
@@ -7,8 +7,8 @@
 
 import * as path from 'path';
 import {glob} from 'glob';
-import slash from 'slash';
 import type {Config} from '@jest/types';
+import {slash} from 'jest-util';
 
 const OUTSIDE_JEST_VM_PROTOCOL = 'jest-main:';
 // String manipulation is easier here, fileURLToPath is only in newer Nodes,

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -18,7 +18,6 @@ import {
 import {parse as parseCjs} from 'cjs-module-lexer';
 import {CoverageInstrumenter, type V8Coverage} from 'collect-v8-coverage';
 import * as fs from 'graceful-fs';
-import slash from 'slash';
 import stripBOM from 'strip-bom';
 import type {
   Jest,
@@ -53,6 +52,7 @@ import {
   invariant,
   isNonNullable,
   protectProperties,
+  slash,
 } from 'jest-util';
 import {
   createOutsideJestVmPath,

--- a/packages/jest-test-sequencer/package.json
+++ b/packages/jest-test-sequencer/package.json
@@ -22,7 +22,7 @@
     "@jest/test-result": "workspace:*",
     "graceful-fs": "^4.2.11",
     "jest-haste-map": "workspace:*",
-    "slash": "^3.0.0"
+    "jest-util": "workspace:*"
   },
   "devDependencies": {
     "@jest/test-utils": "workspace:*",

--- a/packages/jest-test-sequencer/src/index.ts
+++ b/packages/jest-test-sequencer/src/index.ts
@@ -8,10 +8,10 @@
 import * as crypto from 'crypto';
 import * as path from 'path';
 import * as fs from 'graceful-fs';
-import slash from 'slash';
 import type {AggregatedResult, Test, TestContext} from '@jest/test-result';
 import type {Config} from '@jest/types';
 import HasteMap from 'jest-haste-map';
+import {slash} from 'jest-util';
 
 const FAIL = 0;
 const SUCCESS = 1;

--- a/packages/jest-test-sequencer/tsconfig.json
+++ b/packages/jest-test-sequencer/tsconfig.json
@@ -6,5 +6,9 @@
   },
   "include": ["./src/**/*"],
   "exclude": ["./**/__tests__/**/*"],
-  "references": [{"path": "../jest-haste-map"}, {"path": "../jest-test-result"}, {"path": "../jest-util"}]
+  "references": [
+    {"path": "../jest-haste-map"},
+    {"path": "../jest-test-result"},
+    {"path": "../jest-util"}
+  ]
 }

--- a/packages/jest-test-sequencer/tsconfig.json
+++ b/packages/jest-test-sequencer/tsconfig.json
@@ -6,5 +6,5 @@
   },
   "include": ["./src/**/*"],
   "exclude": ["./**/__tests__/**/*"],
-  "references": [{"path": "../jest-haste-map"}, {"path": "../jest-test-result"}]
+  "references": [{"path": "../jest-haste-map"}, {"path": "../jest-test-result"}, {"path": "../jest-util"}]
 }

--- a/packages/jest-transform/package.json
+++ b/packages/jest-transform/package.json
@@ -31,7 +31,6 @@
     "jest-regex-util": "workspace:*",
     "jest-util": "workspace:*",
     "pirates": "^4.0.7",
-    "slash": "^3.0.0",
     "write-file-atomic": "^5.0.1"
   },
   "devDependencies": {

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -14,7 +14,6 @@ import {fromSource as sourcemapFromSource} from 'convert-source-map';
 import stableStringify from 'fast-json-stable-stringify';
 import * as fs from 'graceful-fs';
 import {addHook} from 'pirates';
-import slash from 'slash';
 import {sync as writeFileAtomic} from 'write-file-atomic';
 import type {Config} from '@jest/types';
 import HasteMap from 'jest-haste-map';
@@ -23,6 +22,7 @@ import {
   invariant,
   isPromise,
   requireOrImportModule,
+  slash,
   tryRealpath,
 } from 'jest-util';
 import handlePotentialSyntaxError from './enhanceUnexpectedTokenMessage';

--- a/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
+++ b/packages/jest-transform/src/runtimeErrorsAndWarnings.ts
@@ -6,7 +6,7 @@
  */
 
 import chalk from 'chalk';
-import slash from 'slash';
+import {slash} from 'jest-util';
 
 const BULLET = '\u25CF ';
 const DOCUMENTATION_NOTE = `  ${chalk.bold(

--- a/packages/jest-util/src/index.ts
+++ b/packages/jest-util/src/index.ts
@@ -21,6 +21,7 @@ export {default as deepCyclicCopy} from './deepCyclicCopy';
 export {default as convertDescriptorToString} from './convertDescriptorToString';
 export {specialChars};
 export {default as replacePathSepForGlob} from './replacePathSepForGlob';
+export {default as slash} from './slash';
 export {default as globsToMatcher} from './globsToMatcher';
 export {preRunMessage};
 export {default as pluralize} from './pluralize';

--- a/packages/jest-util/src/slash.ts
+++ b/packages/jest-util/src/slash.ts
@@ -1,0 +1,11 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Replaces backslashes with forward slashes (equivalent to the `slash` package).
+export default function slash(path: string): string {
+  return path.replaceAll('\\', '/');
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4243,7 +4243,6 @@ __metadata:
     chalk: "npm:^4.1.2"
     jest-message-util: "workspace:*"
     jest-util: "workspace:*"
-    slash: "npm:^3.0.0"
   languageName: unknown
   linkType: soft
 
@@ -4280,7 +4279,6 @@ __metadata:
     jest-validate: "workspace:*"
     jest-watcher: "workspace:*"
     pretty-format: "workspace:*"
-    slash: "npm:^3.0.0"
   peerDependencies:
     node-notifier: ^8.0.1 || ^9.0.0 || ^10.0.0
   peerDependenciesMeta:
@@ -4476,7 +4474,6 @@ __metadata:
     resolve: "npm:^1.20.0"
     rimraf: "npm:^5.0.10"
     semver: "npm:^7.7.2"
-    slash: "npm:^3.0.0"
     strip-json-comments: "npm:^3.1.1"
     tempy: "npm:^1.0.1"
     ts-node: "npm:^10.5.0"
@@ -4534,7 +4531,6 @@ __metadata:
     jest-worker: "workspace:*"
     mock-fs: "npm:^5.5.0"
     node-notifier: "npm:^10.0.1"
-    slash: "npm:^3.0.0"
     string-length: "npm:^4.0.2"
     v8-to-istanbul: "npm:^9.0.1"
   peerDependencies:
@@ -4619,7 +4615,7 @@ __metadata:
     "@types/graceful-fs": "npm:^4.1.9"
     graceful-fs: "npm:^4.2.11"
     jest-haste-map: "workspace:*"
-    slash: "npm:^3.0.0"
+    jest-util: "workspace:*"
   languageName: unknown
   linkType: soft
 
@@ -4661,7 +4657,6 @@ __metadata:
     jest-regex-util: "workspace:*"
     jest-util: "workspace:*"
     pirates: "npm:^4.0.7"
-    slash: "npm:^3.0.0"
     write-file-atomic: "npm:^5.0.1"
   languageName: unknown
   linkType: soft
@@ -8132,7 +8127,7 @@ __metadata:
     babel-preset-jest: "workspace:*"
     chalk: "npm:^4.1.2"
     graceful-fs: "npm:^4.2.11"
-    slash: "npm:^3.0.0"
+    jest-util: "workspace:*"
   peerDependencies:
     "@babel/core": ^7.11.0 || ^8.0.0-0
   languageName: unknown
@@ -13904,7 +13899,6 @@ __metadata:
     p-limit: "npm:^3.1.0"
     pretty-format: "workspace:*"
     pure-rand: "npm:^7.0.0"
-    slash: "npm:^3.0.0"
     stack-utils: "npm:^2.0.6"
     tempy: "npm:^1.0.1"
   languageName: unknown
@@ -13966,7 +13960,6 @@ __metadata:
     parse-json: "npm:^5.2.0"
     pretty-format: "workspace:*"
     semver: "npm:^7.7.2"
-    slash: "npm:^3.0.0"
     strip-json-comments: "npm:^3.1.1"
     ts-node: "npm:^10.5.0"
     typescript: "npm:^5.8.3"
@@ -14073,7 +14066,6 @@ __metadata:
     jest-util: "workspace:*"
     jest-worker: "workspace:*"
     picomatch: "npm:^4.0.3"
-    slash: "npm:^3.0.0"
     walker: "npm:^1.0.8"
   dependenciesMeta:
     fsevents:
@@ -14153,9 +14145,9 @@ __metadata:
     "@types/stack-utils": "npm:^2.0.3"
     chalk: "npm:^4.1.2"
     graceful-fs: "npm:^4.2.11"
+    jest-util: "workspace:*"
     picomatch: "npm:^4.0.3"
     pretty-format: "workspace:*"
-    slash: "npm:^3.0.0"
     stack-utils: "npm:^2.0.6"
     tempy: "npm:^1.0.1"
   languageName: unknown
@@ -14250,7 +14242,6 @@ __metadata:
     jest-pnp-resolver: "npm:^1.2.3"
     jest-util: "workspace:*"
     jest-validate: "workspace:*"
-    slash: "npm:^3.0.0"
     unrs-resolver: "npm:^1.7.11"
     url: "npm:^0.11.4"
   languageName: unknown
@@ -14316,7 +14307,6 @@ __metadata:
     jest-resolve: "workspace:*"
     jest-snapshot: "workspace:*"
     jest-util: "workspace:*"
-    slash: "npm:^3.0.0"
     strip-bom: "npm:^4.0.0"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

Replace the `slash` package with an inline implementation in `jest-util`. The entire `slash` package is `path.replace(/\\/g, '/')` — a one-liner that doesn't need an external dependency.

- New `slash` function exported from `jest-util` (3 lines, uses `String.prototype.replaceAll`)
- Updated imports across all 20 consumer files (15 `.ts` source files, 3 `.js` test files, 2 e2e test fixtures)
- Removed `slash` from all 14 `package.json` dependency entries (13 packages + root)
- Added `jest-util` dependency to `babel-jest`, `jest-message-util`, and `@jest/test-sequencer` (which didn't previously depend on it)

Note: this does **not** touch `replacePathSepForGlob`, which is a different function that only replaces `path.sep` (preserving glob escape chars).

## Test plan

- [x] ESLint clean on all 20 modified source files
- [x] Prettier clean
- [x] `yarn constraints` passes
- [x] `yarn dedupe --check` passes
- [x] No remaining `from 'slash'` or `require('slash')` imports outside `node_modules`