### PR TITLE
chore(jest-util): replace p-limit with inline implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Chore & Maintenance
 
+- `[jest-changed-files, jest-circus, jest-jasmine2, jest-runner]` Replace `p-limit` with inline concurrency limiter in `jest-util`
 - `[docs]` Update V30 migration guide to notify users on `jest.mock()` work with case-sensitive path ([#15849](https://github.com/jestjs/jest/pull/15849))
 - `[deps]` Update to sinon/fake-timers v15
 - Updated Twitter icon to match the latest brand guidelines.([#15868](https://github.com/jestjs/jest/pull/15869))

--- a/e2e/__tests__/__snapshots__/testFailingJasmine.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/testFailingJasmine.test.ts.snap
@@ -46,7 +46,7 @@ FAIL __tests__/worksWithConcurrentMode.test.js
       15 |   });
       16 |
 
-      at concurrentFn.failing (../../packages/jest-jasmine2/build/index.js:311:17)
+      at concurrentFn.failing (../../packages/jest-jasmine2/build/index.js:310:17)
       at Suite.failing (__tests__/worksWithConcurrentMode.test.js:13:17)
       at Object.describe (__tests__/worksWithConcurrentMode.test.js:8:1)
 
@@ -80,7 +80,7 @@ FAIL __tests__/worksWithConcurrentOnlyMode.test.js
       15 |   });
       16 |
 
-      at concurrentFn.failing (../../packages/jest-jasmine2/build/index.js:311:17)
+      at concurrentFn.failing (../../packages/jest-jasmine2/build/index.js:310:17)
       at Suite.failing (__tests__/worksWithConcurrentOnlyMode.test.js:13:22)
       at Object.describe (__tests__/worksWithConcurrentOnlyMode.test.js:8:1)
 

--- a/packages/jest-changed-files/package.json
+++ b/packages/jest-changed-files/package.json
@@ -20,8 +20,7 @@
   },
   "dependencies": {
     "execa": "^5.1.1",
-    "jest-util": "workspace:*",
-    "p-limit": "^3.1.0"
+    "jest-util": "workspace:*"
   },
   "engines": {
     "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"

--- a/packages/jest-changed-files/src/index.ts
+++ b/packages/jest-changed-files/src/index.ts
@@ -6,8 +6,7 @@
  *
  */
 
-import pLimit from 'p-limit';
-import {isNonNullable} from 'jest-util';
+import {isNonNullable, pLimit} from 'jest-util';
 import git from './git';
 import hg from './hg';
 import sl from './sl';

--- a/packages/jest-circus/package.json
+++ b/packages/jest-circus/package.json
@@ -35,7 +35,6 @@
     "jest-runtime": "workspace:*",
     "jest-snapshot": "workspace:*",
     "jest-util": "workspace:*",
-    "p-limit": "^3.1.0",
     "pretty-format": "workspace:*",
     "pure-rand": "^7.0.0",
     "slash": "^3.0.0",

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -6,10 +6,9 @@
  */
 
 import {AsyncLocalStorage} from 'async_hooks';
-import pLimit from 'p-limit';
 import {jestExpect} from '@jest/expect';
 import type {Circus, Global} from '@jest/types';
-import {invariant} from 'jest-util';
+import {invariant, pLimit} from 'jest-util';
 import shuffleArray, {
   type RandomNumberGenerator,
   rngBuilder,

--- a/packages/jest-jasmine2/package.json
+++ b/packages/jest-jasmine2/package.json
@@ -34,7 +34,6 @@
     "jest-runtime": "workspace:*",
     "jest-snapshot": "workspace:*",
     "jest-util": "workspace:*",
-    "p-limit": "^3.1.0",
     "pretty-format": "workspace:*"
   },
   "devDependencies": {

--- a/packages/jest-jasmine2/src/jasmineAsyncInstall.ts
+++ b/packages/jest-jasmine2/src/jasmineAsyncInstall.ts
@@ -12,9 +12,8 @@
 
 import co from 'co';
 import isGeneratorFn from 'is-generator-fn';
-import pLimit from 'p-limit';
 import type {Config, Global} from '@jest/types';
-import {isPromise} from 'jest-util';
+import {type LimitFunction, isPromise, pLimit} from 'jest-util';
 import isError from './isError';
 import type Spec from './jasmine/Spec';
 import type {DoneFn, QueueableFn} from './queueRunner';
@@ -197,7 +196,7 @@ function makeConcurrent(
     timeout?: number,
   ) => Spec,
   env: Jasmine['currentEnv_'],
-  mutex: ReturnType<typeof pLimit>,
+  mutex: LimitFunction,
 ): Global.ItConcurrentBase {
   const concurrentFn = function (
     specName: Global.TestNameLike,

--- a/packages/jest-runner/package.json
+++ b/packages/jest-runner/package.json
@@ -39,7 +39,6 @@
     "jest-util": "workspace:*",
     "jest-watcher": "workspace:*",
     "jest-worker": "workspace:*",
-    "p-limit": "^3.1.0",
     "source-map-support": "0.5.13"
   },
   "devDependencies": {

--- a/packages/jest-runner/src/index.ts
+++ b/packages/jest-runner/src/index.ts
@@ -7,14 +7,13 @@
 
 import chalk from 'chalk';
 import Emittery from 'emittery';
-import pLimit from 'p-limit';
 import type {
   Test,
   TestEvents,
   TestFileEvent,
   TestResult,
 } from '@jest/test-result';
-import {deepCyclicCopy} from 'jest-util';
+import {deepCyclicCopy, pLimit} from 'jest-util';
 import type {TestWatcher} from 'jest-watcher';
 import {
   type JestWorkerFarm,

--- a/packages/jest-util/src/index.ts
+++ b/packages/jest-util/src/index.ts
@@ -29,6 +29,8 @@ export {default as tryRealpath} from './tryRealpath';
 export {default as requireOrImportModule} from './requireOrImportModule';
 export {default as invariant} from './invariant';
 export {default as isNonNullable} from './isNonNullable';
+export {default as pLimit} from './pLimit';
+export type {LimitFunction} from './pLimit';
 export {
   type DeletionMode,
   canDeleteProperties,

--- a/packages/jest-util/src/pLimit.ts
+++ b/packages/jest-util/src/pLimit.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Inline concurrency limiter, replacing the `p-limit` package.
+
+export type LimitFunction = <T>(fn: () => Promise<T>) => Promise<T>;
+
+export default function pLimit(concurrency: number): LimitFunction {
+  const queue: Array<() => void> = [];
+  let active = 0;
+
+  const next = (): void => {
+    if (queue.length > 0 && active < concurrency) {
+      active++;
+      queue.shift()!();
+    }
+  };
+
+  return <T>(fn: () => Promise<T>): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      const run = (): void => {
+        fn().then(
+          (val: T) => {
+            resolve(val);
+            active--;
+            next();
+          },
+          (error: unknown) => {
+            reject(error);
+            active--;
+            next();
+          },
+        );
+      };
+
+      if (active < concurrency) {
+        active++;
+        run();
+      } else {
+        queue.push(run);
+      }
+    });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -13871,7 +13871,6 @@ __metadata:
   dependencies:
     execa: "npm:^5.1.1"
     jest-util: "workspace:*"
-    p-limit: "npm:^3.1.0"
   languageName: unknown
   linkType: soft
 
@@ -13901,7 +13900,6 @@ __metadata:
     jest-runtime: "workspace:*"
     jest-snapshot: "workspace:*"
     jest-util: "workspace:*"
-    p-limit: "npm:^3.1.0"
     pretty-format: "workspace:*"
     pure-rand: "npm:^7.0.0"
     slash: "npm:^3.0.0"
@@ -14101,7 +14099,6 @@ __metadata:
     jest-runtime: "workspace:*"
     jest-snapshot: "workspace:*"
     jest-util: "workspace:*"
-    p-limit: "npm:^3.1.0"
     pretty-format: "workspace:*"
   languageName: unknown
   linkType: soft
@@ -14284,7 +14281,6 @@ __metadata:
     jest-util: "workspace:*"
     jest-watcher: "workspace:*"
     jest-worker: "workspace:*"
-    p-limit: "npm:^3.1.0"
     source-map-support: "npm:0.5.13"
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
## Summary

Replace the `p-limit` package (and its transitive `yocto-queue` dependency) with a ~30-line inline concurrency limiter in `jest-util`. The implementation covers the exact API surface Jest uses: `pLimit(n)` returning a function that queues async work with bounded concurrency.

**Packages updated:**
- `jest-changed-files` — process-spawning mutex (concurrency 5)
- `jest-circus` — concurrent test limiter
- `jest-jasmine2` — concurrent test limiter
- `jest-runner` — in-band and parallel test run limiters

The e2e test fixture (`e2e/transform/transform-runner/runner.ts`) still uses `p-limit` directly from the root devDependencies, which is appropriate for a test fixture.

## Test plan
- [x] `yarn build:js` compiles cleanly
- [x] ESLint clean on all changed files
- [x] Prettier clean on all changed files
- [x] `yarn constraints` passes
- [x] `yarn dedupe --check` passes