### PR TITLE
fix(jest-circus): handle undefined asyncError when test throws plain object

### DIFF
--- a/packages/jest-circus/src/formatNodeAssertErrors.ts
+++ b/packages/jest-circus/src/formatNodeAssertErrors.ts
@@ -52,12 +52,17 @@ const formatNodeAssertErrors = (
           error = asyncError;
         } else if (originalError.stack) {
           error = originalError;
-        } else {
+        } else if (asyncError) {
           error = asyncError;
 
           error.message =
             originalError.message ||
             `thrown: ${prettyFormat(originalError, {maxDepth: 3})}`;
+        } else {
+          error = new Error(
+            originalError.message ||
+              `thrown: ${prettyFormat(originalError, {maxDepth: 3})}`,
+          );
         }
       } else {
         error = errors;

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -433,9 +433,12 @@ const _getError = (
     return error;
   }
 
-  asyncError.message = `thrown: ${prettyFormat(error, {maxDepth: 3})}`;
+  if (asyncError) {
+    asyncError.message = `thrown: ${prettyFormat(error, {maxDepth: 3})}`;
+    return asyncError;
+  }
 
-  return asyncError;
+  return new Error(`thrown: ${prettyFormat(error, {maxDepth: 3})}`);
 };
 
 const getErrorStack = (error: Error): string =>


### PR DESCRIPTION
## Summary

When a test throws a plain object (not an Error instance) and the captured asyncError is undefined, jest-circus crashes with TypeError.

## Fix

This PR adds proper null checks in two locations:

1. formatNodeAssertErrors.ts - When assigning asyncError to error, check if asyncError exists first; if not, create a new Error

2. utils.ts (_getError) - When setting asyncError.message, check if asyncError exists first; if not, return a new Error

This allows jest-circus to properly handle cases like RxJS Observables that emit plain objects as errors (common in NestJS RpcException).

Fixes #15996