### PR TITLE
docs: fix various typos in documentation

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1546,7 +1546,7 @@ There are times where you only want Jest to search in a single sub-directory (su
 
 :::info
 
-While `rootDir` is mostly used as a token to be re-used in other configuration options, `roots` is used by the internals of Jest to locate **test files and source files**. This applies also when searching for manual mocks for modules from `node_modules` (`__mocks__` will need to live in one of the `roots`).
+While `rootDir` is mostly used as a token to be reused in other configuration options, `roots` is used by the internals of Jest to locate **test files and source files**. This applies also when searching for manual mocks for modules from `node_modules` (`__mocks__` will need to live in one of the `roots`).
 
 By default, `roots` has a single entry `<rootDir>` but there are cases where you may want to have multiple roots within one project, for example `roots: ["<rootDir>/src/", "<rootDir>/tests/"]`.
 

--- a/website/versioned_docs/version-29.7/Configuration.md
+++ b/website/versioned_docs/version-29.7/Configuration.md
@@ -1573,7 +1573,7 @@ There are times where you only want Jest to search in a single sub-directory (su
 
 :::info
 
-While `rootDir` is mostly used as a token to be re-used in other configuration options, `roots` is used by the internals of Jest to locate **test files and source files**. This applies also when searching for manual mocks for modules from `node_modules` (`__mocks__` will need to live in one of the `roots`).
+While `rootDir` is mostly used as a token to be reused in other configuration options, `roots` is used by the internals of Jest to locate **test files and source files**. This applies also when searching for manual mocks for modules from `node_modules` (`__mocks__` will need to live in one of the `roots`).
 
 By default, `roots` has a single entry `<rootDir>` but there are cases where you may want to have multiple roots within one project, for example `roots: ["<rootDir>/src/", "<rootDir>/tests/"]`.
 

--- a/website/versioned_docs/version-30.0/Configuration.md
+++ b/website/versioned_docs/version-30.0/Configuration.md
@@ -1591,7 +1591,7 @@ There are times where you only want Jest to search in a single sub-directory (su
 
 :::info
 
-While `rootDir` is mostly used as a token to be re-used in other configuration options, `roots` is used by the internals of Jest to locate **test files and source files**. This applies also when searching for manual mocks for modules from `node_modules` (`__mocks__` will need to live in one of the `roots`).
+While `rootDir` is mostly used as a token to be reused in other configuration options, `roots` is used by the internals of Jest to locate **test files and source files**. This applies also when searching for manual mocks for modules from `node_modules` (`__mocks__` will need to live in one of the `roots`).
 
 By default, `roots` has a single entry `<rootDir>` but there are cases where you may want to have multiple roots within one project, for example `roots: ["<rootDir>/src/", "<rootDir>/tests/"]`.
 


### PR DESCRIPTION
Fixes minor typos across the codebase (e.g. 're-used' -> 'reused', 'dependant' -> 'dependent').