### PR TITLE
fix: support Date objects in jest.setSystemTime()

### DIFF
--- a/packages/jest-fake-timers/src/modernFakeTimers.ts
+++ b/packages/jest-fake-timers/src/modernFakeTimers.ts
@@ -152,7 +152,7 @@ export default class FakeTimers {
 
   setSystemTime(now?: number | Date): void {
     if (this._checkFakeTimers()) {
-      this._clock.setSystemTime(now);
+      this._clock.setSystemTime(now instanceof Date ? now.getTime() : now);
     }
   }
 


### PR DESCRIPTION
Fixes #16028

## Problem

`jest.useFakeTimers().setSystemTime(new Date(...))` throws:
```
TypeError: now should be milliseconds since UNIX epoch
```

This was introduced by `@sinonjs/fake-timers@15.3.0` which changed `setSystemTime` to only accept numeric timestamps. Jest passes `Date` objects directly without converting them.

## Fix

Convert `Date` objects to milliseconds via `.getTime()` before passing to the underlying `@sinonjs/fake-timers` clock. This is a one-line change in `modernFakeTimers.ts`.

## Type Safety

The TypeScript signature already declares `setSystemTime(now?: number | Date)` — so this fix aligns the runtime behavior with the declared types.