### PR TITLE
chore(website): fix flipped card on firefox

### DIFF
--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -107,6 +107,7 @@ div.jest-card-front,
   height: 100%;
   border-radius: 15px;
   backface-visibility: hidden;
+  transform: rotateX(0deg);
   pointer-events: none;
   display: flex;
   justify-content: center;
@@ -126,7 +127,7 @@ div.jest-card-back {
   background-size: 20px;
   border: 5px solid #c2a813;
   backface-visibility: hidden;
-  transform: rotateY(180deg) translateZ(1px);
+  transform: rotateX(0deg) rotateY(180deg) translateZ(1px);
 }
 
 div.jest-card-running {


### PR DESCRIPTION
## Summary

Fix flipping cards CSS animation issue on Jest homepage.
The issue happened in Firefox browser:

### Before

<img width="1280" height="965" alt="jest-card--before" src="https://github.com/user-attachments/assets/614c0684-b2e6-49e2-890d-4bd8c7a79ebd" />

### After

<img width="1280" height="965" alt="jest-card--after" src="https://github.com/user-attachments/assets/ef2bb9a6-f316-4a46-867a-383f1659df65" />

---

## Why This Issue Happening?

https://stackoverflow.com/a/32421734

> This bug has been [acknowledged by Mozilla](https://bugzilla.mozilla.org/show_bug.cgi?id=1201471).
> The fix is to add `transform: rotateX(0deg)` to the front and back objects.

Adding `backface-visiblity: hidden` on the container makes the back unresponsive in Chrome, hence that fix should be avoided.

---

No changes in Jest package itself, so I don't put anything on `CHANGELOG.md`