### PR TITLE
Fix duplicate "is" wording in jest-config displayName validation test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## main
 
+### Chore & Maintenance
+
+- `[jest-config]` Fix duplicate "is" wording in `displayName` validation test description
+
 ## 30.3.0
 
 ### Features

--- a/packages/jest-config/src/__tests__/__snapshots__/normalize.test.ts.snap
+++ b/packages/jest-config/src/__tests__/__snapshots__/normalize.test.ts.snap
@@ -10,7 +10,7 @@ exports[`displayName generates a default color for the runner jest-runner-tslint
 
 exports[`displayName generates a default color for the runner undefined 1`] = `"white"`;
 
-exports[`displayName should throw an error when displayName is is an empty object 1`] = `
+exports[`displayName should throw an error when displayName is an empty object 1`] = `
 "<red><bold><bold>● </intensity><bold>Validation Error</intensity>:</color>
 <red></color>
 <red>  Option "<bold>displayName</intensity>" must be of type:</color>

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -1780,7 +1780,7 @@ describe('Defaults', () => {
 describe('displayName', () => {
   test.each<{displayName: Config.DisplayName; description: string}>`
     displayName             | description
-    ${{}}                   | ${'is an empty object'}
+    ${{}}                   | ${'an empty object'}
     ${{name: 'hello'}}      | ${'missing color'}
     ${{color: 'green'}}     | ${'missing name'}
     ${{color: 2, name: []}} | ${'using invalid values'}


### PR DESCRIPTION

**Repo:** jestjs/jest (⭐ 44000)
**Type:** test
**Files changed:** 3
**Lines:** +6/-2

## What

The `displayName` validation test in `packages/jest-config/src/__tests__/normalize.test.ts` uses a `test.each` template that interpolates a `description` into the title via `displayName is $description`. One row supplied `'is an empty object'` as the description, producing the title `displayName is is an empty object` (and a snapshot key with the same duplicated word). This change drops the redundant `is ` from the row so the rendered test name reads naturally, and updates the matching snapshot key in `normalize.test.ts.snap`. A short CHANGELOG entry under `## main` is included.

## Why

Pure readability/quality improvement. The duplicated word shows up in test runner output and in the committed snapshot file, where it looks like a typo. The other rows in the same `test.each` table (`'missing color'`, `'missing name'`, `'using invalid values'`) all read correctly when prefixed with `is`, so the empty-object row is the inconsistent one. Fix is mechanical and risk-free.

## Testing

`yarn jest packages/jest-config/src/__tests__/normalize.test.ts` would re-run the affected describe block. The snapshot key was updated in lockstep with the new test title so the snapshot still matches; the actual snapshot body is unchanged. Did not run the suite locally (would require `yarn install` + `yarn build:js`, outside the time budget).

## Risk

Low — only touches a test description string, the corresponding snapshot key, and a changelog line. No runtime/library code touched.
