### PR TITLE
fix(jest-util): prevent infinite recursion in soft-delete setter for data properties

### DIFF
--- a/packages/jest-util/src/garbage-collection-utils.ts
+++ b/packages/jest-util/src/garbage-collection-utils.ts
@@ -161,9 +161,12 @@ function deleteProperty(obj: object, key: string | symbol): boolean {
     return Reflect.deleteProperty(obj, key);
   }
 
-  const originalGetter = descriptor.get ?? (() => descriptor.value);
-  const originalSetter =
-    descriptor.set ?? (value => Reflect.set(obj, key, value));
+  // For data properties, capture the value in a mutable cell so the setter can
+  // update it without calling Reflect.set, which would re-enter this accessor
+  // and cause infinite recursion (RangeError: Maximum call stack size exceeded).
+  let currentValue = descriptor.value;
+  const originalGetter = descriptor.get ?? (() => currentValue);
+  const originalSetter = descriptor.set ?? (value => { currentValue = value; });
 
   return Reflect.defineProperty(obj, key, {
     configurable: true,


### PR DESCRIPTION
## Problem

`globalsCleanup: 'soft'` (the default) wraps each property it tracks in a getter/setter that emits a deprecation warning on access. For data properties (the vast majority of cases), the setter fallback was:

```ts
const originalSetter =
  descriptor.set ?? (value => Reflect.set(obj, key, value));
```

By the time this fallback setter runs, `obj[key]` has already been replaced with the new accessor. So `Reflect.set(obj, key, value)` finds an accessor descriptor and invokes the new `set()` — which calls `originalSetter(value)` — which calls `Reflect.set` again. Infinite recursion until `RangeError: Maximum call stack size exceeded`.

This was reported in #16044 with a minimal reproduction:

```js
const obj = { foo: 'bar' };
const descriptor = Reflect.getOwnPropertyDescriptor(obj, 'foo');
const originalSetter = descriptor.set ?? (value => Reflect.set(obj, 'foo', value));
Reflect.defineProperty(obj, 'foo', {
  configurable: true,
  get() { return descriptor.value; },
  set(value) { return originalSetter(value); },
});
obj.foo = 'baz'; // RangeError: Maximum call stack size exceeded
```

## Fix

For data properties, capture the original value in a mutable closure variable (`currentValue`). The getter reads from it; the setter updates it directly — no `Reflect.set`, no re-entry:

```ts
let currentValue = descriptor.value;
const originalGetter = descriptor.get ?? (() => currentValue);
const originalSetter = descriptor.set ?? (value => { currentValue = value; });
```

Accessor properties (with an existing `get`/`set`) are unaffected — their original getter/setter are used as before.

Fixes #16044