### PR TITLE
fix: handle `import`s after teardown same as `require`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - `[jest-runtime]` Load `.js` files with ESM syntax but no `"type":"module"` marker as native ESM ([#16050](https://github.com/jestjs/jest/pull/16050))
 - `[jest-runtime]` Fix deadlocks and double-evaluation in concurrent ESM and wasm imports ([#16050](https://github.com/jestjs/jest/pull/16050))
 - `[jest-runtime]` Fix error when `require()` is called after the Jest environment has been torn down ([#15951](https://github.com/jestjs/jest/pull/15951))
+- `[jest-runtime]` Fix missing error when `import()` is called after the Jest environment has been torn down ([#16080](https://github.com/jestjs/jest/pull/16080))
 
 ### Chore & Maintenance
 

--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -200,6 +200,9 @@ export const replaceTime = (str: string) =>
     .replaceAll(/\d*\.?\d+ m?s\b/g, '<<REPLACED>>')
     .replaceAll(', estimated <<REPLACED>>', '');
 
+export const replaceNodeVersion = (str: string) =>
+  str.replaceAll(/Node\.js v\d+\.\d+\.\d+/g, 'Node.js <<REPLACED>>');
+
 export const replaceJestBuildLineNumbers = (str: string) =>
   str.replaceAll(/([\w-]+\/build\/[^:\s]+:)\d+:\d+/g, '$1<<REPLACED>>');
 

--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -214,7 +214,9 @@ export const replaceJestBuildLineNumbers = (str: string) =>
 const repoRoot = path.resolve(__dirname, '..');
 
 export const replaceRepoRoot = (str: string) =>
-  str.replaceAll(repoRoot, '<<REPO_ROOT>>');
+  str
+    .replaceAll(repoRoot, '<<REPO_ROOT>>')
+    .replaceAll(repoRoot.replaceAll('\\', '/'), '<<REPO_ROOT>>');
 
 // Since Jest does not guarantee the order of tests we'll sort the output.
 export const sortLines = (output: string) =>

--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -195,16 +195,26 @@ export const copyDir = (src: string, dest: string) => {
 export const replaceSeed = (str: string) =>
   str.replaceAll(/Seed: {8}(-?\d+)/g, 'Seed:       <<REPLACED>>');
 
-export const replaceTime = (str: string) =>
+const replaceTime = (str: string) =>
   str
     .replaceAll(/\d*\.?\d+ m?s\b/g, '<<REPLACED>>')
     .replaceAll(', estimated <<REPLACED>>', '');
 
-export const replaceNodeVersion = (str: string) =>
-  str.replaceAll(/Node\.js v\d+\.\d+\.\d+/g, 'Node.js <<REPLACED>>');
+export const replaceNodeInfo = (str: string) =>
+  str
+    .replaceAll(/[^\n]*node:internal\/[^\n]*\n?/g, '')
+    .replaceAll(/Node\.js v\d+\.\d+\.\d+/g, 'Node.js <<REPLACED>>');
 
 export const replaceJestBuildLineNumbers = (str: string) =>
-  str.replaceAll(/([\w-]+\/build\/[^:\s]+:)\d+:\d+/g, '$1<<REPLACED>>');
+  str.replaceAll(
+    /([^:\s]*[\w-]+\/build\/[^:\s]+:)\d+(?::\d+)?/g,
+    '$1<<REPLACED>>',
+  );
+
+const repoRoot = path.resolve(__dirname, '..');
+
+export const replaceRepoRoot = (str: string) =>
+  str.replaceAll(repoRoot, '<<REPO_ROOT>>');
 
 // Since Jest does not guarantee the order of tests we'll sort the output.
 export const sortLines = (output: string) =>

--- a/e2e/Utils.ts
+++ b/e2e/Utils.ts
@@ -15,6 +15,7 @@ import {
   sync as spawnSync,
 } from 'execa';
 import * as fs from 'graceful-fs';
+import slash from 'slash';
 import which from 'which';
 import type {Config} from '@jest/types';
 
@@ -207,7 +208,7 @@ export const replaceNodeInfo = (str: string) =>
 
 export const replaceJestBuildLineNumbers = (str: string) =>
   str.replaceAll(
-    /([^:\s]*[\w-]+\/build\/[^:\s]+:)\d+(?::\d+)?/g,
+    /([^:\s]*[\w-]+[/\\]build[/\\][^:\s]+:)\d+(?::\d+)?/g,
     '$1<<REPLACED>>',
   );
 
@@ -216,7 +217,7 @@ const repoRoot = path.resolve(__dirname, '..');
 export const replaceRepoRoot = (str: string) =>
   str
     .replaceAll(repoRoot, '<<REPO_ROOT>>')
-    .replaceAll(repoRoot.replaceAll('\\', '/'), '<<REPO_ROOT>>');
+    .replaceAll(/<<REPO_ROOT>>[^\s()"']+/g, p => slash(p));
 
 // Since Jest does not guarantee the order of tests we'll sort the output.
 export const sortLines = (output: string) =>

--- a/e2e/__tests__/__snapshots__/importAfterTeardown.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/importAfterTeardown.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`prints useful error for imports after test is done w/ \`waitForUnhandledRejections\` 1`] = `
 "FAIL __tests__/lateImport.test.mjs
-  ✕ import after done (<<REPLACED>>)
+  ✕ import after done
 
   ● import after done
 
@@ -17,24 +17,13 @@ exports[`prints useful error for imports after test is done w/ \`waitForUnhandle
       13 | });
 
       at _esmDynamicImport (../../packages/jest-runtime/build/index.js:<<REPLACED>>)
-      at Timeout._onTimeout (__tests__/lateImport.test.mjs:10:22)
-
-Test Suites: 1 failed, 1 total
-Tests:       1 failed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites."
+      at Timeout._onTimeout (__tests__/lateImport.test.mjs:10:22)"
 `;
 
 exports[`prints useful error for imports after test is done w/o \`waitForUnhandledRejections\` 1`] = `
 "PASS __tests__/lateImport.test.mjs
   ✓ import after done
 
-Test Suites: 1 passed, 1 total
-Tests:       1 passed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites.
 
 ReferenceError: You are trying to \`import\` a file after the Jest environment has been torn down. From __tests__/lateImport.test.mjs.
 
@@ -47,15 +36,13 @@ ReferenceError: You are trying to \`import\` a file after the Jest environment h
       13 | });
 
       at Timeout._onTimeout (__tests__/lateImport.test.mjs:10:22)
-node:internal/vm/module:531
-      throw new ERR_VM_MODULE_NOT_MODULE();
+<<REPO_ROOT>>/packages/jest-runtime/build/index.js:<<REPLACED>>
+      throw new ReferenceError('You are trying to \`import\` a file after the Jest environment has been torn down.');
             ^
 
-Error: Provided module is not an instance of Module
-    at importModuleDynamicallyWrapper (node:internal/vm/module:531:13)
-    at processTicksAndRejections (node:internal/process/task_queues:104:5) {
-  code: 'ERR_VM_MODULE_NOT_MODULE'
-}
+ReferenceError: You are trying to \`import\` a file after the Jest environment has been torn down.
+    at _esmDynamicImport (<<REPO_ROOT>>/packages/jest-runtime/build/index.js:<<REPLACED>>)
+    at Timeout._onTimeout (<<REPO_ROOT>>/e2e/import-after-teardown/__tests__/lateImport.test.mjs:10:22)
 
 Node.js <<REPLACED>>"
 `;

--- a/e2e/__tests__/__snapshots__/importAfterTeardown.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/importAfterTeardown.test.ts.snap
@@ -1,0 +1,61 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`prints useful error for imports after test is done w/ \`waitForUnhandledRejections\` 1`] = `
+"FAIL __tests__/lateImport.test.mjs
+  ✕ import after done (<<REPLACED>>)
+
+  ● import after done
+
+    ReferenceError: You are trying to \`import\` a file after the Jest environment has been torn down.
+
+       8 | test('import after done', () => {
+       9 |   setTimeout(async () => {
+    > 10 |     const {double} = await import('../double.mjs');
+         |                      ^
+      11 |     expect(double(5)).toBe(10);
+      12 |   }, 0);
+      13 | });
+
+      at _esmDynamicImport (../../packages/jest-runtime/build/index.js:<<REPLACED>>)
+      at Timeout._onTimeout (__tests__/lateImport.test.mjs:10:22)
+
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
+`;
+
+exports[`prints useful error for imports after test is done w/o \`waitForUnhandledRejections\` 1`] = `
+"PASS __tests__/lateImport.test.mjs
+  ✓ import after done
+
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+
+ReferenceError: You are trying to \`import\` a file after the Jest environment has been torn down. From __tests__/lateImport.test.mjs.
+
+       8 | test('import after done', () => {
+       9 |   setTimeout(async () => {
+    > 10 |     const {double} = await import('../double.mjs');
+         |                      ^
+      11 |     expect(double(5)).toBe(10);
+      12 |   }, 0);
+      13 | });
+
+      at Timeout._onTimeout (__tests__/lateImport.test.mjs:10:22)
+node:internal/vm/module:531
+      throw new ERR_VM_MODULE_NOT_MODULE();
+            ^
+
+Error: Provided module is not an instance of Module
+    at importModuleDynamicallyWrapper (node:internal/vm/module:531:13)
+    at processTicksAndRejections (node:internal/process/task_queues:104:5) {
+  code: 'ERR_VM_MODULE_NOT_MODULE'
+}
+
+Node.js <<REPLACED>>"
+`;

--- a/e2e/__tests__/__snapshots__/importAfterTeardown.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/importAfterTeardown.test.ts.snap
@@ -6,7 +6,7 @@ exports[`prints useful error for imports after test is done w/ \`waitForUnhandle
 
   ● import after done
 
-    ReferenceError: You are trying to \`import\` a file after the Jest environment has been torn down.
+    ReferenceError: You are trying to \`import\` a file outside of the scope of the test code.
 
        8 | test('import after done', () => {
        9 |   setTimeout(async () => {

--- a/e2e/__tests__/__snapshots__/requireAfterTeardown.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/requireAfterTeardown.test.ts.snap
@@ -1,7 +1,12 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`prints useful error for requires after test is done w/ \`waitForUnhandledRejections\` 1`] = `
-"    ReferenceError: You are trying to \`require\` a file outside of the scope of the test code.
+"FAIL __tests__/lateRequire.test.js
+  ✕ require after done (<<REPLACED>>)
+
+  ● require after done
+
+    ReferenceError: You are trying to \`require\` a file outside of the scope of the test code.
 
        9 | test('require after done', () => {
       10 |   setTimeout(() => {
@@ -9,11 +14,29 @@ exports[`prints useful error for requires after test is done w/ \`waitForUnhandl
          |                    ^
       12 |
       13 |     expect(double(5)).toBe(10);
-      14 |   }, 0);"
+      14 |   }, 0);
+
+      at Runtime._execModule (../../packages/jest-runtime/build/index.js:<<REPLACED>>)
+      at Timeout.require [as _onTimeout] (__tests__/lateRequire.test.js:11:20)
+
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
 `;
 
 exports[`prints useful error for requires after test is done w/o \`waitForUnhandledRejections\` 1`] = `
-"ReferenceError: You are trying to \`require\` a file after the Jest environment has been torn down. From __tests__/lateRequire.test.js.
+"PASS __tests__/lateRequire.test.js
+  ✓ require after done
+
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+
+ReferenceError: You are trying to \`require\` a file after the Jest environment has been torn down. From __tests__/lateRequire.test.js.
 
        9 | test('require after done', () => {
       10 |   setTimeout(() => {
@@ -21,5 +44,14 @@ exports[`prints useful error for requires after test is done w/o \`waitForUnhand
          |                    ^
       12 |
       13 |     expect(double(5)).toBe(10);
-      14 |   }, 0);"
+      14 |   }, 0);
+
+      at Timeout._onTimeout (__tests__/lateRequire.test.js:11:20)
+/Users/simen/repos/jest/e2e/require-after-teardown/__tests__/lateRequire.test.js:12
+    expect(double(5)).toBe(10);
+           ^
+
+[TypeError: double is not a function]
+
+Node.js <<REPLACED>>"
 `;

--- a/e2e/__tests__/__snapshots__/requireAfterTeardown.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/requireAfterTeardown.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`prints useful error for requires after test is done w/ \`waitForUnhandledRejections\` 1`] = `
 "FAIL __tests__/lateRequire.test.js
-  ✕ require after done (<<REPLACED>>)
+  ✕ require after done
 
   ● require after done
 
@@ -17,24 +17,13 @@ exports[`prints useful error for requires after test is done w/ \`waitForUnhandl
       14 |   }, 0);
 
       at Runtime._execModule (../../packages/jest-runtime/build/index.js:<<REPLACED>>)
-      at Timeout.require [as _onTimeout] (__tests__/lateRequire.test.js:11:20)
-
-Test Suites: 1 failed, 1 total
-Tests:       1 failed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites."
+      at Timeout.require [as _onTimeout] (__tests__/lateRequire.test.js:11:20)"
 `;
 
 exports[`prints useful error for requires after test is done w/o \`waitForUnhandledRejections\` 1`] = `
 "PASS __tests__/lateRequire.test.js
   ✓ require after done
 
-Test Suites: 1 passed, 1 total
-Tests:       1 passed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites.
 
 ReferenceError: You are trying to \`require\` a file after the Jest environment has been torn down. From __tests__/lateRequire.test.js.
 
@@ -47,7 +36,7 @@ ReferenceError: You are trying to \`require\` a file after the Jest environment 
       14 |   }, 0);
 
       at Timeout._onTimeout (__tests__/lateRequire.test.js:11:20)
-/Users/simen/repos/jest/e2e/require-after-teardown/__tests__/lateRequire.test.js:12
+<<REPO_ROOT>>/e2e/require-after-teardown/__tests__/lateRequire.test.js:12
     expect(double(5)).toBe(10);
            ^
 

--- a/e2e/__tests__/__snapshots__/requireAfterTeardownJasmine.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/requireAfterTeardownJasmine.test.ts.snap
@@ -1,7 +1,16 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`prints useful error for requires after test is done 1`] = `
-"ReferenceError: You are trying to \`require\` a file after the Jest environment has been torn down. From __tests__/lateRequire.test.js.
+"PASS __tests__/lateRequire.test.js
+  ✓ require after done
+
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+
+ReferenceError: You are trying to \`require\` a file after the Jest environment has been torn down. From __tests__/lateRequire.test.js.
 
        9 | test('require after done', () => {
       10 |   setTimeout(() => {
@@ -9,11 +18,29 @@ exports[`prints useful error for requires after test is done 1`] = `
          |                    ^
       12 |
       13 |     expect(double(5)).toBe(10);
-      14 |   }, 0);"
+      14 |   }, 0);
+
+      at Timeout.require [as _onTimeout] (__tests__/lateRequire.test.js:11:20)
+/Users/simen/repos/jest/e2e/require-after-teardown/__tests__/lateRequire.test.js:12
+    expect(double(5)).toBe(10);
+           ^
+
+[TypeError: double is not a function]
+
+Node.js <<REPLACED>>"
 `;
 
 exports[`prints useful error for requires after test is done 2`] = `
-"ReferenceError: You are trying to \`require\` a file after the Jest environment has been torn down. From __tests__/lateRequire.test.js.
+"PASS __tests__/lateRequire.test.js
+  ✓ require after done (<<REPLACED>>)
+
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites.
+
+ReferenceError: You are trying to \`require\` a file after the Jest environment has been torn down. From __tests__/lateRequire.test.js.
 
        9 | test('require after done', () => {
       10 |   setTimeout(() => {
@@ -21,5 +48,14 @@ exports[`prints useful error for requires after test is done 2`] = `
          |                    ^
       12 |
       13 |     expect(double(5)).toBe(10);
-      14 |   }, 0);"
+      14 |   }, 0);
+
+      at Timeout.require [as _onTimeout] (__tests__/lateRequire.test.js:11:20)
+/Users/simen/repos/jest/e2e/require-after-teardown/__tests__/lateRequire.test.js:12
+    expect(double(5)).toBe(10);
+           ^
+
+[TypeError: double is not a function]
+
+Node.js <<REPLACED>>"
 `;

--- a/e2e/__tests__/__snapshots__/requireAfterTeardownJasmine.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/requireAfterTeardownJasmine.test.ts.snap
@@ -4,11 +4,6 @@ exports[`prints useful error for requires after test is done 1`] = `
 "PASS __tests__/lateRequire.test.js
   ✓ require after done
 
-Test Suites: 1 passed, 1 total
-Tests:       1 passed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites.
 
 ReferenceError: You are trying to \`require\` a file after the Jest environment has been torn down. From __tests__/lateRequire.test.js.
 
@@ -21,7 +16,7 @@ ReferenceError: You are trying to \`require\` a file after the Jest environment 
       14 |   }, 0);
 
       at Timeout.require [as _onTimeout] (__tests__/lateRequire.test.js:11:20)
-/Users/simen/repos/jest/e2e/require-after-teardown/__tests__/lateRequire.test.js:12
+<<REPO_ROOT>>/e2e/require-after-teardown/__tests__/lateRequire.test.js:12
     expect(double(5)).toBe(10);
            ^
 
@@ -32,13 +27,8 @@ Node.js <<REPLACED>>"
 
 exports[`prints useful error for requires after test is done 2`] = `
 "PASS __tests__/lateRequire.test.js
-  ✓ require after done (<<REPLACED>>)
+  ✓ require after done
 
-Test Suites: 1 passed, 1 total
-Tests:       1 passed, 1 total
-Snapshots:   0 total
-Time:        <<REPLACED>>
-Ran all test suites.
 
 ReferenceError: You are trying to \`require\` a file after the Jest environment has been torn down. From __tests__/lateRequire.test.js.
 
@@ -51,7 +41,7 @@ ReferenceError: You are trying to \`require\` a file after the Jest environment 
       14 |   }, 0);
 
       at Timeout.require [as _onTimeout] (__tests__/lateRequire.test.js:11:20)
-/Users/simen/repos/jest/e2e/require-after-teardown/__tests__/lateRequire.test.js:12
+<<REPO_ROOT>>/e2e/require-after-teardown/__tests__/lateRequire.test.js:12
     expect(double(5)).toBe(10);
            ^
 

--- a/e2e/__tests__/importAfterTeardown.test.ts
+++ b/e2e/__tests__/importAfterTeardown.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {skipSuiteOnJasmine} from '@jest/test-utils';
+import runJest from '../runJest';
+import {
+  replaceJestBuildLineNumbers,
+  replaceNodeVersion,
+  replaceTime,
+} from '../Utils';
+
+skipSuiteOnJasmine();
+
+test('prints useful error for imports after test is done w/o `waitForUnhandledRejections`', () => {
+  const {stderr} = runJest('import-after-teardown', [], {
+    nodeOptions: '--experimental-vm-modules --no-warnings',
+  });
+
+  const normalized = replaceJestBuildLineNumbers(
+    replaceNodeVersion(replaceTime(stderr)),
+  );
+  expect(normalized).toMatchSnapshot();
+  expect(stderr).toContain('(__tests__/lateImport.test.mjs:10:');
+});
+
+test('prints useful error for imports after test is done w/ `waitForUnhandledRejections`', () => {
+  const {stderr} = runJest(
+    'import-after-teardown',
+    ['--waitForUnhandledRejections'],
+    {nodeOptions: '--experimental-vm-modules --no-warnings'},
+  );
+
+  const normalized = replaceJestBuildLineNumbers(
+    replaceNodeVersion(replaceTime(stderr)),
+  );
+  expect(normalized).toMatchSnapshot();
+  expect(stderr).toContain('(__tests__/lateImport.test.mjs:10:');
+});

--- a/e2e/__tests__/importAfterTeardown.test.ts
+++ b/e2e/__tests__/importAfterTeardown.test.ts
@@ -17,7 +17,7 @@ import {
 skipSuiteOnJasmine();
 
 test('prints useful error for imports after test is done w/o `waitForUnhandledRejections`', () => {
-  const {stderr} = runJest('import-after-teardown', [], {
+  const {exitCode, stderr} = runJest('import-after-teardown', [], {
     nodeOptions: '--experimental-vm-modules --no-warnings',
   });
 
@@ -25,12 +25,13 @@ test('prints useful error for imports after test is done w/o `waitForUnhandledRe
   const normalized = replaceRepoRoot(
     replaceJestBuildLineNumbers(replaceNodeInfo(rest)),
   );
+  expect(exitCode).toBe(1);
   expect(normalized).toMatchSnapshot();
   expect(stderr).toContain('(__tests__/lateImport.test.mjs:10:');
 });
 
 test('prints useful error for imports after test is done w/ `waitForUnhandledRejections`', () => {
-  const {stderr} = runJest(
+  const {exitCode, stderr} = runJest(
     'import-after-teardown',
     ['--waitForUnhandledRejections'],
     {nodeOptions: '--experimental-vm-modules --no-warnings'},
@@ -40,6 +41,7 @@ test('prints useful error for imports after test is done w/ `waitForUnhandledRej
   const normalized = replaceRepoRoot(
     replaceJestBuildLineNumbers(replaceNodeInfo(rest)),
   );
+  expect(exitCode).toBe(1);
   expect(normalized).toMatchSnapshot();
   expect(stderr).toContain('(__tests__/lateImport.test.mjs:10:');
 });

--- a/e2e/__tests__/importAfterTeardown.test.ts
+++ b/e2e/__tests__/importAfterTeardown.test.ts
@@ -8,9 +8,10 @@
 import {skipSuiteOnJasmine} from '@jest/test-utils';
 import runJest from '../runJest';
 import {
+  extractSummary,
   replaceJestBuildLineNumbers,
-  replaceNodeVersion,
-  replaceTime,
+  replaceNodeInfo,
+  replaceRepoRoot,
 } from '../Utils';
 
 skipSuiteOnJasmine();
@@ -20,8 +21,9 @@ test('prints useful error for imports after test is done w/o `waitForUnhandledRe
     nodeOptions: '--experimental-vm-modules --no-warnings',
   });
 
-  const normalized = replaceJestBuildLineNumbers(
-    replaceNodeVersion(replaceTime(stderr)),
+  const {rest} = extractSummary(stderr);
+  const normalized = replaceRepoRoot(
+    replaceJestBuildLineNumbers(replaceNodeInfo(rest)),
   );
   expect(normalized).toMatchSnapshot();
   expect(stderr).toContain('(__tests__/lateImport.test.mjs:10:');
@@ -34,8 +36,9 @@ test('prints useful error for imports after test is done w/ `waitForUnhandledRej
     {nodeOptions: '--experimental-vm-modules --no-warnings'},
   );
 
-  const normalized = replaceJestBuildLineNumbers(
-    replaceNodeVersion(replaceTime(stderr)),
+  const {rest} = extractSummary(stderr);
+  const normalized = replaceRepoRoot(
+    replaceJestBuildLineNumbers(replaceNodeInfo(rest)),
   );
   expect(normalized).toMatchSnapshot();
   expect(stderr).toContain('(__tests__/lateImport.test.mjs:10:');

--- a/e2e/__tests__/requireAfterTeardown.test.ts
+++ b/e2e/__tests__/requireAfterTeardown.test.ts
@@ -7,15 +7,21 @@
 
 import {skipSuiteOnJasmine} from '@jest/test-utils';
 import runJest from '../runJest';
+import {
+  replaceJestBuildLineNumbers,
+  replaceNodeVersion,
+  replaceTime,
+} from '../Utils';
 
 skipSuiteOnJasmine();
 
 test('prints useful error for requires after test is done w/o `waitForUnhandledRejections`', () => {
   const {stderr} = runJest('require-after-teardown');
 
-  const interestingLines = stderr.split('\n').slice(9, 18).join('\n');
-
-  expect(interestingLines).toMatchSnapshot();
+  const normalized = replaceJestBuildLineNumbers(
+    replaceNodeVersion(replaceTime(stderr)),
+  );
+  expect(normalized).toMatchSnapshot();
   expect(stderr).toContain('(__tests__/lateRequire.test.js:11:20)');
 });
 
@@ -24,8 +30,9 @@ test('prints useful error for requires after test is done w/ `waitForUnhandledRe
     '--waitForUnhandledRejections',
   ]);
 
-  const interestingLines = stderr.split('\n').slice(5, 14).join('\n');
-
-  expect(interestingLines).toMatchSnapshot();
+  const normalized = replaceJestBuildLineNumbers(
+    replaceNodeVersion(replaceTime(stderr)),
+  );
+  expect(normalized).toMatchSnapshot();
   expect(stderr).toContain('(__tests__/lateRequire.test.js:11:20)');
 });

--- a/e2e/__tests__/requireAfterTeardown.test.ts
+++ b/e2e/__tests__/requireAfterTeardown.test.ts
@@ -17,18 +17,19 @@ import {
 skipSuiteOnJasmine();
 
 test('prints useful error for requires after test is done w/o `waitForUnhandledRejections`', () => {
-  const {stderr} = runJest('require-after-teardown');
+  const {exitCode, stderr} = runJest('require-after-teardown');
 
   const {rest} = extractSummary(stderr);
   const normalized = replaceRepoRoot(
     replaceJestBuildLineNumbers(replaceNodeInfo(rest)),
   );
+  expect(exitCode).toBe(1);
   expect(normalized).toMatchSnapshot();
   expect(stderr).toContain('(__tests__/lateRequire.test.js:11:20)');
 });
 
 test('prints useful error for requires after test is done w/ `waitForUnhandledRejections`', () => {
-  const {stderr} = runJest('require-after-teardown', [
+  const {exitCode, stderr} = runJest('require-after-teardown', [
     '--waitForUnhandledRejections',
   ]);
 
@@ -36,6 +37,7 @@ test('prints useful error for requires after test is done w/ `waitForUnhandledRe
   const normalized = replaceRepoRoot(
     replaceJestBuildLineNumbers(replaceNodeInfo(rest)),
   );
+  expect(exitCode).toBe(1);
   expect(normalized).toMatchSnapshot();
   expect(stderr).toContain('(__tests__/lateRequire.test.js:11:20)');
 });

--- a/e2e/__tests__/requireAfterTeardown.test.ts
+++ b/e2e/__tests__/requireAfterTeardown.test.ts
@@ -8,9 +8,10 @@
 import {skipSuiteOnJasmine} from '@jest/test-utils';
 import runJest from '../runJest';
 import {
+  extractSummary,
   replaceJestBuildLineNumbers,
-  replaceNodeVersion,
-  replaceTime,
+  replaceNodeInfo,
+  replaceRepoRoot,
 } from '../Utils';
 
 skipSuiteOnJasmine();
@@ -18,8 +19,9 @@ skipSuiteOnJasmine();
 test('prints useful error for requires after test is done w/o `waitForUnhandledRejections`', () => {
   const {stderr} = runJest('require-after-teardown');
 
-  const normalized = replaceJestBuildLineNumbers(
-    replaceNodeVersion(replaceTime(stderr)),
+  const {rest} = extractSummary(stderr);
+  const normalized = replaceRepoRoot(
+    replaceJestBuildLineNumbers(replaceNodeInfo(rest)),
   );
   expect(normalized).toMatchSnapshot();
   expect(stderr).toContain('(__tests__/lateRequire.test.js:11:20)');
@@ -30,8 +32,9 @@ test('prints useful error for requires after test is done w/ `waitForUnhandledRe
     '--waitForUnhandledRejections',
   ]);
 
-  const normalized = replaceJestBuildLineNumbers(
-    replaceNodeVersion(replaceTime(stderr)),
+  const {rest} = extractSummary(stderr);
+  const normalized = replaceRepoRoot(
+    replaceJestBuildLineNumbers(replaceNodeInfo(rest)),
   );
   expect(normalized).toMatchSnapshot();
   expect(stderr).toContain('(__tests__/lateRequire.test.js:11:20)');

--- a/e2e/__tests__/requireAfterTeardownJasmine.test.ts
+++ b/e2e/__tests__/requireAfterTeardownJasmine.test.ts
@@ -7,6 +7,11 @@
 
 import {skipSuiteOnJestCircus} from '@jest/test-utils';
 import runJest from '../runJest';
+import {
+  replaceJestBuildLineNumbers,
+  replaceNodeVersion,
+  replaceTime,
+} from '../Utils';
 
 skipSuiteOnJestCircus();
 
@@ -17,8 +22,9 @@ test.each`
 `('prints useful error for requires after test is done', ({jestArgs}) => {
   const {stderr} = runJest('require-after-teardown', jestArgs);
 
-  const interestingLines = stderr.split('\n').slice(9, 18).join('\n');
-
-  expect(interestingLines).toMatchSnapshot();
+  const normalized = replaceJestBuildLineNumbers(
+    replaceNodeVersion(replaceTime(stderr)),
+  );
+  expect(normalized).toMatchSnapshot();
   expect(stderr).toContain('(__tests__/lateRequire.test.js:11:20)');
 });

--- a/e2e/__tests__/requireAfterTeardownJasmine.test.ts
+++ b/e2e/__tests__/requireAfterTeardownJasmine.test.ts
@@ -8,9 +8,10 @@
 import {skipSuiteOnJestCircus} from '@jest/test-utils';
 import runJest from '../runJest';
 import {
+  extractSummary,
   replaceJestBuildLineNumbers,
-  replaceNodeVersion,
-  replaceTime,
+  replaceNodeInfo,
+  replaceRepoRoot,
 } from '../Utils';
 
 skipSuiteOnJestCircus();
@@ -22,8 +23,9 @@ test.each`
 `('prints useful error for requires after test is done', ({jestArgs}) => {
   const {stderr} = runJest('require-after-teardown', jestArgs);
 
-  const normalized = replaceJestBuildLineNumbers(
-    replaceNodeVersion(replaceTime(stderr)),
+  const {rest} = extractSummary(stderr);
+  const normalized = replaceRepoRoot(
+    replaceJestBuildLineNumbers(replaceNodeInfo(rest)),
   );
   expect(normalized).toMatchSnapshot();
   expect(stderr).toContain('(__tests__/lateRequire.test.js:11:20)');

--- a/e2e/import-after-teardown/__tests__/lateImport.test.mjs
+++ b/e2e/import-after-teardown/__tests__/lateImport.test.mjs
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+test('import after done', () => {
+  setTimeout(async () => {
+    const {double} = await import('../double.mjs');
+    expect(double(5)).toBe(10);
+  }, 0);
+});

--- a/e2e/import-after-teardown/double.mjs
+++ b/e2e/import-after-teardown/double.mjs
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export function double(input) {
+  return input * 2;
+}

--- a/e2e/import-after-teardown/package.json
+++ b/e2e/import-after-teardown/package.json
@@ -1,0 +1,6 @@
+{
+  "jest": {
+    "testEnvironment": "node",
+    "transform": {}
+  }
+}

--- a/packages/jest-runtime/src/__tests__/runtime_esm_cjs_interop.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_cjs_interop.test.ts
@@ -15,11 +15,7 @@
 //     packages/jest-runtime/src/__tests__/runtime_esm_cjs_interop.test.ts
 
 import * as path from 'path';
-
-// SyntheticModule is only available when --experimental-vm-modules is active.
-const {SyntheticModule} = require('vm') as typeof import('vm');
-const vmAvailable = typeof SyntheticModule === 'function';
-const itVm = vmAvailable ? it : it.skip;
+import {testWithVmEsm} from '@jest/test-utils';
 
 const ROOT_DIR = path.join(__dirname, 'test_esm_interop_root');
 const FROM = path.join(ROOT_DIR, 'test.js');
@@ -34,7 +30,7 @@ describe('Runtime loadCjsAsEsm', () => {
     createRuntime = require('createRuntime');
   });
 
-  itVm(
+  testWithVmEsm(
     'unwraps __esModule CJS default export instead of returning the whole exports object',
     async () => {
       const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
@@ -47,7 +43,7 @@ describe('Runtime loadCjsAsEsm', () => {
     },
   );
 
-  itVm('does not expose __esModule sentinel as a named export', async () => {
+  testWithVmEsm('does not expose __esModule sentinel as a named export', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
       FROM,
@@ -56,7 +52,7 @@ describe('Runtime loadCjsAsEsm', () => {
     expect(Object.keys(m.namespace)).not.toContain('__esModule');
   });
 
-  itVm(
+  testWithVmEsm(
     'exposes named exports alongside default for __esModule CJS',
     async () => {
       const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
@@ -68,7 +64,7 @@ describe('Runtime loadCjsAsEsm', () => {
     },
   );
 
-  itVm('uses the full module.exports as default for plain CJS', async () => {
+  testWithVmEsm('uses the full module.exports as default for plain CJS', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
       FROM,
@@ -80,7 +76,7 @@ describe('Runtime loadCjsAsEsm', () => {
     });
   });
 
-  itVm('exposes named exports from plain CJS module.exports keys', async () => {
+  testWithVmEsm('exposes named exports from plain CJS module.exports keys', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
       FROM,
@@ -90,7 +86,7 @@ describe('Runtime loadCjsAsEsm', () => {
     expect(m.namespace.double(10)).toBe(20);
   });
 
-  itVm(
+  testWithVmEsm(
     'shares singleton state across multiple ESM importers of the same CJS module',
     async () => {
       const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
@@ -114,7 +110,7 @@ describe('Runtime loadCjsAsEsm SyntaxError fallback', () => {
     createRuntime = require('createRuntime');
   });
 
-  itVm(
+  testWithVmEsm(
     'loads a .js file with ESM syntax that has no "type":"module" marker',
     async () => {
       const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});

--- a/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
@@ -284,12 +284,15 @@ describe('Runtime sync ESM graph - require(esm)', () => {
     expect(ns.valueC).toBe('c');
   });
 
-  testWithSyncEsm('returns the same namespace on repeat require()', async () => {
-    const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
-    const first = runtime.requireModule(FROM, './a.mjs');
-    const second = runtime.requireModule(FROM, './a.mjs');
-    expect(first).toBe(second);
-  });
+  testWithSyncEsm(
+    'returns the same namespace on repeat require()',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const first = runtime.requireModule(FROM, './a.mjs');
+      const second = runtime.requireModule(FROM, './a.mjs');
+      expect(first).toBe(second);
+    },
+  );
 
   testWithSyncEsm(
     'throws ERR_REQUIRE_ASYNC_MODULE when the file uses top-level await',
@@ -393,17 +396,23 @@ describe('Runtime sync ESM graph - require(esm)', () => {
     },
   );
 
-  testWithSyncEsm('require()s an ESM file that pulls in a CJS dep', async () => {
-    const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
-    const ns = runtime.requireModule(FROM, './import-cjs-dep.mjs');
-    expect(ns.cjsValue).toBe('from-cjs');
-  });
+  testWithSyncEsm(
+    'require()s an ESM file that pulls in a CJS dep',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const ns = runtime.requireModule(FROM, './import-cjs-dep.mjs');
+      expect(ns.cjsValue).toBe('from-cjs');
+    },
+  );
 
-  testWithSyncEsm('require()s an ESM file importing @jest/globals', async () => {
-    const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
-    const ns = runtime.requireModule(FROM, './import-jest-globals.mjs');
-    expect(ns.hasJest).toBe(true);
-  });
+  testWithSyncEsm(
+    'require()s an ESM file importing @jest/globals',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const ns = runtime.requireModule(FROM, './import-jest-globals.mjs');
+      expect(ns.hasJest).toBe(true);
+    },
+  );
 
   testWithSyncEsm('require()s an ESM file importing a JSON dep', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});

--- a/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
@@ -7,9 +7,9 @@
 
 import * as path from 'path';
 
-import {SourceTextModule, SyntheticModule} from 'vm';
-const vmAvailable = typeof SyntheticModule === 'function';
-const itVm = vmAvailable ? it : it.skip;
+import {SourceTextModule} from 'vm';
+import {testWithVmEsm} from '@jest/test-utils';
+
 const syncCoreAvailable =
   // @ts-expect-error - hasAsyncGraph is in Node v24.9+, not yet typed
   typeof SourceTextModule?.prototype.hasAsyncGraph === 'function';
@@ -36,7 +36,7 @@ describe('Runtime sync ESM graph', () => {
     createRuntime = require('createRuntime');
   });
 
-  itVm('evaluates a diamond + cycle graph in correct order', async () => {
+  testWithVmEsm('evaluates a diamond + cycle graph in correct order', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
       FROM,
@@ -48,7 +48,7 @@ describe('Runtime sync ESM graph', () => {
     expect(m.namespace.peekA()).toBe('a');
   });
 
-  itVm(
+  testWithVmEsm(
     'caches modules so repeated imports return the same namespace',
     async () => {
       const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
@@ -64,7 +64,7 @@ describe('Runtime sync ESM graph', () => {
     },
   );
 
-  itVm(
+  testWithVmEsm(
     'falls back to async evaluate when the graph contains top-level await',
     async () => {
       const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
@@ -77,7 +77,7 @@ describe('Runtime sync ESM graph', () => {
     },
   );
 
-  itVm('resolves data: URI specifiers in the sync graph', async () => {
+  testWithVmEsm('resolves data: URI specifiers in the sync graph', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
       FROM,
@@ -86,7 +86,7 @@ describe('Runtime sync ESM graph', () => {
     expect(m.namespace.dataValue).toBe(99);
   });
 
-  itVm('resolves @jest/globals in the sync graph', async () => {
+  testWithVmEsm('resolves @jest/globals in the sync graph', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
       FROM,
@@ -95,7 +95,7 @@ describe('Runtime sync ESM graph', () => {
     expect(m.namespace.hasJest).toBe(true);
   });
 
-  itVm('decodes base64-encoded data: URI specifiers', async () => {
+  testWithVmEsm('decodes base64-encoded data: URI specifiers', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
       FROM,
@@ -104,7 +104,7 @@ describe('Runtime sync ESM graph', () => {
     expect(m.namespace.base64Value).toBe('b64');
   });
 
-  itVm('imports JSON files as ESM', async () => {
+  testWithVmEsm('imports JSON files as ESM', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
       FROM,
@@ -113,7 +113,7 @@ describe('Runtime sync ESM graph', () => {
     expect(m.namespace.data).toEqual({answer: 42, label: 'json'});
   });
 
-  itVm('imports core node modules through the ESM graph', async () => {
+  testWithVmEsm('imports core node modules through the ESM graph', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
       FROM,
@@ -123,7 +123,7 @@ describe('Runtime sync ESM graph', () => {
     expect(typeof m.namespace.nodePath.join).toBe('function');
   });
 
-  itVm('exposes import.meta.url for the loaded module', async () => {
+  testWithVmEsm('exposes import.meta.url for the loaded module', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
       FROM,
@@ -134,7 +134,7 @@ describe('Runtime sync ESM graph', () => {
     );
   });
 
-  itVm('pulls a CJS dependency into the sync ESM graph', async () => {
+  testWithVmEsm('pulls a CJS dependency into the sync ESM graph', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
       FROM,
@@ -143,7 +143,7 @@ describe('Runtime sync ESM graph', () => {
     expect(m.namespace.cjsValue).toBe('from-cjs');
   });
 
-  itVm('imports a wasm module via data: URI', async () => {
+  testWithVmEsm('imports a wasm module via data: URI', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
       FROM,
@@ -154,7 +154,7 @@ describe('Runtime sync ESM graph', () => {
     expect(Object.keys(m.namespace.wasmMod)).toEqual([]);
   });
 
-  itVm('treats a query suffix as a separate cache entry', async () => {
+  testWithVmEsm('treats a query suffix as a separate cache entry', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const plain = (await runtime.unstable_importModule(FROM, './a.mjs')) as any;
     const queried = (await runtime.unstable_importModule(
@@ -166,7 +166,7 @@ describe('Runtime sync ESM graph', () => {
     expect(queried.namespace.fromA).toEqual(plain.namespace.fromA);
   });
 
-  itVm('supports dynamic import() from inside an ESM module', async () => {
+  testWithVmEsm('supports dynamic import() from inside an ESM module', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
       FROM,
@@ -182,7 +182,7 @@ describe('Runtime sync ESM graph - mocks and isolation', () => {
     createRuntime = require('createRuntime');
   });
 
-  itVm('replaces a module with a sync mock factory', async () => {
+  testWithVmEsm('replaces a module with a sync mock factory', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     runtime.setModuleMock(FROM, './mock-target.mjs', () => ({
       greeting: 'mocked-sync',
@@ -194,7 +194,7 @@ describe('Runtime sync ESM graph - mocks and isolation', () => {
     expect(m.namespace.greeting).toBe('mocked-sync');
   });
 
-  itVm('replaces a module with an async mock factory', async () => {
+  testWithVmEsm('replaces a module with an async mock factory', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     runtime.setModuleMock(FROM, './mock-target.mjs', async () => ({
       greeting: 'mocked-async',
@@ -206,7 +206,7 @@ describe('Runtime sync ESM graph - mocks and isolation', () => {
     expect(m.namespace.greeting).toBe('mocked-async');
   });
 
-  itVm('isolateModulesAsync gives a fresh ESM namespace', async () => {
+  testWithVmEsm('isolateModulesAsync gives a fresh ESM namespace', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
 
     const before = (await runtime.unstable_importModule(
@@ -238,14 +238,14 @@ describe('Runtime sync ESM graph - error surfacing', () => {
     createRuntime = require('createRuntime');
   });
 
-  itVm('rejects when a specifier cannot be resolved', async () => {
+  testWithVmEsm('rejects when a specifier cannot be resolved', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     await expect(
       runtime.unstable_importModule(FROM, './does-not-exist.mjs'),
     ).rejects.toThrow('Cannot find module');
   });
 
-  itVm('surfaces errors thrown by a mock factory', async () => {
+  testWithVmEsm('surfaces errors thrown by a mock factory', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     runtime.setModuleMock(FROM, './mock-target.mjs', () => {
       throw new Error('factory boom');

--- a/packages/jest-runtime/src/__tests__/runtime_jest_fn.js
+++ b/packages/jest-runtime/src/__tests__/runtime_jest_fn.js
@@ -8,6 +8,8 @@
 
 'use strict';
 
+const {testWithVmEsm} = require('@jest/test-utils');
+
 let createRuntime;
 
 describe('Runtime', () => {
@@ -99,6 +101,60 @@ describe('Runtime', () => {
         ),
       );
     });
+  });
+
+  describe('import() after environment torn down', () => {
+    const originalExitCode = process.exitCode;
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      process.exitCode = originalExitCode;
+    });
+
+    testWithVmEsm(
+      'should log error, set exit code, and throw when import() is called after teardown',
+      async () => {
+        const runtime = await createRuntime(__filename);
+        jest.spyOn(console, 'error').mockImplementation(() => {});
+
+        runtime.teardown();
+
+        await expect(
+          runtime._esmDynamicImport('RegularModule', {
+            context: runtime._environment.getVmContext(),
+            identifier: __filename,
+          }),
+        ).rejects.toThrow(
+          'You are trying to `import` a file after the Jest environment has been torn down.',
+        );
+
+        expect(process.exitCode).toBe(1);
+        expect(console.error).toHaveBeenCalledWith(
+          expect.stringContaining(
+            'You are trying to `import` a file after the Jest environment has been torn down.',
+          ),
+        );
+      },
+    );
+
+    testWithVmEsm(
+      'should throw when import() is called outside of test code scope',
+      async () => {
+        const runtime = await createRuntime(__filename);
+
+        runtime.enterTestCode();
+        runtime.leaveTestCode();
+
+        await expect(
+          runtime._esmDynamicImport('RegularModule', {
+            context: runtime._environment.getVmContext(),
+            identifier: __filename,
+          }),
+        ).rejects.toThrow(
+          'You are trying to `import` a file outside of the scope of the test code.',
+        );
+      },
+    );
   });
 
   describe('jest.isolateModules', () => {

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -3579,7 +3579,7 @@ export default class Runtime {
     );
     if (this.testState === 'betweenTests') {
       throw new ReferenceError(
-        'You are trying to `import` a file after the Jest environment has been torn down.',
+        'You are trying to `import` a file outside of the scope of the test code.',
       );
     }
     if (this.testState === 'tornDown') {

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -346,8 +346,8 @@ export default class Runtime {
   private jestGlobals?: JestGlobals;
   private readonly esmConditions: Array<string>;
   private readonly cjsConditions: Array<string>;
-  private isTornDown = false;
-  private isInsideTestCode: boolean | undefined;
+  private testState: 'loading' | 'inTest' | 'betweenTests' | 'tornDown' =
+    'loading';
   private readonly loggedReferenceErrors = new Set<string>();
 
   constructor(
@@ -565,14 +565,14 @@ export default class Runtime {
     rootQuery: string,
     mode: SyncEsmMode,
   ): ESModule | null {
-    if (this.isTornDown) {
+    if (this.testState === 'tornDown') {
       this._logFormattedReferenceError(
         'You are trying to `import` a file after the Jest environment has been torn down.',
       );
       process.exitCode = 1;
       return null;
     }
-    if (this.isInsideTestCode === false && !supportsDynamicImport) {
+    if (this.testState === 'betweenTests' && !supportsDynamicImport) {
       throw new ReferenceError(
         'You are trying to `import` a file outside of the scope of the test code.',
       );
@@ -1381,7 +1381,7 @@ export default class Runtime {
     referencingIdentifier: string,
     context: VMContext,
   ): Promise<T> {
-    if (this.isTornDown) {
+    if (this.testState === 'tornDown') {
       this._logFormattedReferenceError(
         'You are trying to `import` a file after the Jest environment has been torn down.',
       );
@@ -1389,7 +1389,7 @@ export default class Runtime {
       // @ts-expect-error -- exiting
       return;
     }
-    if (this.isInsideTestCode === false && !supportsDynamicImport) {
+    if (this.testState === 'betweenTests' && !supportsDynamicImport) {
       throw new ReferenceError(
         'You are trying to `import` a file outside of the scope of the test code.',
       );
@@ -1497,7 +1497,7 @@ export default class Runtime {
   }
 
   private async linkAndEvaluateModule(module: VMModule): Promise<VMModule> {
-    if (this.isTornDown) {
+    if (this.testState === 'tornDown') {
       this._logFormattedReferenceError(
         'You are trying to `import` a file after the Jest environment has been torn down.',
       );
@@ -1505,7 +1505,7 @@ export default class Runtime {
       // @ts-expect-error: exiting early
       return;
     }
-    if (this.isInsideTestCode === false && !supportsDynamicImport) {
+    if (this.testState === 'betweenTests' && !supportsDynamicImport) {
       throw new ReferenceError(
         'You are trying to `import` a file outside of the scope of the test code.',
       );
@@ -2051,7 +2051,7 @@ export default class Runtime {
   }
 
   requireModuleOrMock<T = unknown>(from: string, moduleName: string): T {
-    if (this.isTornDown) {
+    if (this.testState === 'tornDown') {
       this._logFormattedReferenceError(
         'You are trying to `require` a file after the Jest environment has been torn down.',
       );
@@ -2294,11 +2294,11 @@ export default class Runtime {
   }
 
   enterTestCode(): void {
-    this.isInsideTestCode = true;
+    this.testState = 'inTest';
   }
 
   leaveTestCode(): void {
-    this.isInsideTestCode = false;
+    this.testState = 'betweenTests';
   }
 
   teardown(): void {
@@ -2330,7 +2330,7 @@ export default class Runtime {
     this._v8CoverageInstrumenter = undefined;
     this._moduleImplementation = undefined;
 
-    this.isTornDown = true;
+    this.testState = 'tornDown';
   }
 
   private _resolveCjsModule(from: string, to: string | undefined) {
@@ -2440,14 +2440,14 @@ export default class Runtime {
     from: string | null,
     moduleName?: string,
   ) {
-    if (this.isTornDown) {
+    if (this.testState === 'tornDown') {
       this._logFormattedReferenceError(
         'You are trying to `require` a file after the Jest environment has been torn down.',
       );
       process.exitCode = 1;
       return;
     }
-    if (this.isInsideTestCode === false && !supportsDynamicImport) {
+    if (this.testState === 'betweenTests' && !supportsDynamicImport) {
       throw new ReferenceError(
         'You are trying to `require` a file outside of the scope of the test code.',
       );
@@ -3234,7 +3234,7 @@ export default class Runtime {
     };
     const _getFakeTimers = () => {
       if (
-        this.isTornDown ||
+        this.testState === 'tornDown' ||
         !(this._environment.fakeTimers || this._environment.fakeTimersModern)
       ) {
         this._logFormattedReferenceError(
@@ -3242,7 +3242,7 @@ export default class Runtime {
         );
         process.exitCode = 1;
       }
-      if (this.isInsideTestCode === false) {
+      if (this.testState === 'betweenTests') {
         throw new ReferenceError(
           'You are trying to access a property or method of the Jest environment outside of the scope of the test code.',
         );
@@ -3361,7 +3361,7 @@ export default class Runtime {
       },
       getSeed: () => this._globalConfig.seed,
       getTimerCount: () => _getFakeTimers().getTimerCount(),
-      isEnvironmentTornDown: () => this.isTornDown,
+      isEnvironmentTornDown: () => this.testState === 'tornDown',
       isMockFunction: this._moduleMocker.isMockFunction,
       isolateModules,
       isolateModulesAsync,
@@ -3577,6 +3577,19 @@ export default class Runtime {
       runtimeSupportsVmModules,
       'You need to run with a version of node that supports ES Modules in the VM API. See https://jestjs.io/docs/ecmascript-modules',
     );
+    if (this.testState === 'betweenTests') {
+      throw new ReferenceError(
+        'You are trying to `import` a file after the Jest environment has been torn down.',
+      );
+    }
+    if (this.testState === 'tornDown') {
+      this._logFormattedReferenceError(
+        'You are trying to `import` a file after the Jest environment has been torn down.',
+      );
+      process.exitCode = 1;
+      // @ts-expect-error -- exiting
+      return;
+    }
     const dyn = await this.resolveModule<VMModule>(
       specifier,
       referencingModule.identifier,

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -3587,8 +3587,9 @@ export default class Runtime {
         'You are trying to `import` a file after the Jest environment has been torn down.',
       );
       process.exitCode = 1;
-      // @ts-expect-error -- exiting
-      return;
+      throw new ReferenceError(
+        'You are trying to `import` a file after the Jest environment has been torn down.',
+      );
     }
     const dyn = await this.resolveModule<VMModule>(
       specifier,

--- a/packages/test-utils/src/ConditionalTest.ts
+++ b/packages/test-utils/src/ConditionalTest.ts
@@ -7,6 +7,7 @@
 
 /* eslint-disable jest/no-focused-tests */
 
+import {SyntheticModule} from 'node:vm';
 import * as semver from 'semver';
 import {describe, test} from '@jest/globals';
 
@@ -28,6 +29,13 @@ export function skipSuiteOnJestCircus(): void {
       console.warn('[SKIP] Does not work on jest-circus');
     });
   }
+}
+
+export function testWithVmEsm(
+  ...args: Parameters<typeof test>
+): ReturnType<typeof test> {
+  const fn = typeof SyntheticModule === 'function' ? test : test.skip;
+  return fn(...args);
 }
 
 export function onNodeVersions(

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -9,9 +9,10 @@ export {alignedAnsiStyleSerializer} from './alignedAnsiStyleSerializer';
 
 export {
   isJestJasmineRun,
+  testWithVmEsm,
+  onNodeVersions,
   skipSuiteOnJasmine,
   skipSuiteOnJestCircus,
-  onNodeVersions,
 } from './ConditionalTest';
 
 export {makeGlobalConfig, makeProjectConfig} from './config';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

#15951 made me realize we don't have the same error for `import` as `require`.

Needed another boolean, so refactored to a state union

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Tests added.
