### PR TITLE
fix(jest-runtime): apply moduleNameMapper to require.resolve paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 - `[jest-runtime]` Fix error when `require()` is called after the Jest environment has been torn down ([#15951](https://github.com/jestjs/jest/pull/15951))
 - `[jest-runtime]` Fix missing error when `import()` is called after the Jest environment has been torn down ([#16080](https://github.com/jestjs/jest/pull/16080))
 - `[jest-runtime]` Fix virtual `unstable_mockModule` registrations not respected in ESM ([#16081](https://github.com/jestjs/jest/pull/16081))
+- `[jest-runtime]` Apply `moduleNameMapper` when resolving modules with `require.resolve()` and the `paths` option ([#16135](https://github.com/jestjs/jest/pull/16135))
 
 ### Chore & Maintenance
 

--- a/e2e/resolve-with-paths/__tests__/resolveWithPaths.test.js
+++ b/e2e/resolve-with-paths/__tests__/resolveWithPaths.test.js
@@ -40,3 +40,9 @@ test('throws module not found error if the module cannot be found from given pat
     expect.objectContaining({code: 'MODULE_NOT_FOUND'}),
   );
 });
+
+test('resolves moduleNameMapper with paths option', () => {
+  expect(require.resolve('@foo/js', {paths: [__dirname]})).toBe(
+    require.resolve('../js/index.js'),
+  );
+});

--- a/e2e/resolve-with-paths/js/index.js
+++ b/e2e/resolve-with-paths/js/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = 'mapped module';

--- a/e2e/resolve-with-paths/package.json
+++ b/e2e/resolve-with-paths/package.json
@@ -1,5 +1,8 @@
 {
   "jest": {
-    "testEnvironment": "node"
+    "testEnvironment": "node",
+    "moduleNameMapper": {
+      "^@foo/js$": "<rootDir>/js/index.js"
+    }
   }
 }

--- a/packages/jest-runtime/src/internals/__tests__/cjsRequire.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/cjsRequire.test.ts
@@ -42,6 +42,7 @@ function makeResolution(
     isCoreModule: jest.fn(() => false),
     resolveCjs: jest.fn(),
     resolveCjsFromDirIfExists: jest.fn(() => null),
+    resolveCjsStub: jest.fn(() => null),
     ...overrides,
   } as unknown as Resolution;
 }
@@ -168,6 +169,25 @@ describe('RequireBuilder', () => {
       expect(() => resolveVia(builder, 'foo', {paths: ['./a', './b']})).toThrow(
         Resolver.ModuleNotFoundError,
       );
+    });
+
+    test('resolves moduleNameMapper before walking options.paths', () => {
+      const resolveCjsStub = jest.fn(
+        (_from: string, _moduleName: string) => '/mapped.js',
+      );
+      const resolveCjsFromDirIfExists = jest.fn(() => null);
+      const builder = makeBuilder({
+        resolution: makeResolution({
+          resolveCjsFromDirIfExists,
+          resolveCjsStub,
+        }),
+      });
+
+      expect(resolveVia(builder, '@foo/js', {paths: ['./a']})).toBe(
+        '/mapped.js',
+      );
+      expect(resolveCjsStub).toHaveBeenCalledWith('/a/b/from.js', '@foo/js');
+      expect(resolveCjsFromDirIfExists).not.toHaveBeenCalled();
     });
 
     test('falls back to mock module when resolveCjs throws', () => {

--- a/packages/jest-runtime/src/internals/cjsRequire.ts
+++ b/packages/jest-runtime/src/internals/cjsRequire.ts
@@ -130,14 +130,22 @@ export class RequireBuilder {
         return module;
       }
     } else if (options.paths) {
+      const module = this.resolution.resolveCjsStub(from, moduleName);
+
+      if (module) {
+        return module;
+      }
+
       for (const searchPath of options.paths) {
         const absolutePath = path.resolve(from, '..', searchPath);
+
         // required to also resolve files without leading './' directly in the path
         const module = this.resolution.resolveCjsFromDirIfExists(
           absolutePath,
           moduleName,
           [absolutePath],
         );
+
         if (module) {
           return module;
         }


### PR DESCRIPTION
## Summary

This fixes `require.resolve()` when it is called with the `paths` option
and the requested module matches `moduleNameMapper`.

Before this change, `require.resolve('@foo/js')` could resolve through
`moduleNameMapper`, but `require.resolve('@foo/js', {paths: [...]})`
skipped that mapping path and only tried to resolve from the provided
paths.

This updates the `RequireBuilder.resolve()` path for `options.paths` to
check mapped CJS stubs before walking the provided search paths. If no
mapping is found, it keeps the existing `paths` resolution behavior.

Fixes #14601.

## Test plan

- `yarn jest packages/jest-runtime --runInBand`
- `yarn jest e2e/__tests__/resolveWithPaths.test.ts --runInBand`