### PR TITLE
fix(jest-reporters): apply global coverage threshold to unmatched pattern files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - `[jest-config]` Allow `collectCoverage` and `coverageProvider` in project config without a validation warning ([#16132](https://github.com/jestjs/jest/pull/16132))
 - `[jest-config]` Project config validator now emits "is not supported in an individual project configuration" instead of "probably a typing mistake" for known global-only options ([#16132](https://github.com/jestjs/jest/pull/16132))
 - `[jest-environment-node]` Fix `--localstorage-file` warning on Node 25+ ([#16086](https://github.com/jestjs/jest/pull/16086))
+- `[jest-reporters]` Apply global coverage threshold to unmatched pattern files in addition to glob/path thresholds ([#16137](https://github.com/jestjs/jest/pull/16137))
 - `[jest-runtime]` Resolve `expect` and `@jest/expect` from the internal module registry so test-file imports share the same `JestAssertionError` as the global `expect` ([#16130](https://github.com/jestjs/jest/pull/16130))
 - `[jest-runtime]` Improve CJS-from-ESM interop: `__esModule`/Babel default unwrap, broader named-export coverage, and shared CJS singleton across importers ([#16050](https://github.com/jestjs/jest/pull/16050))
 - `[jest-runtime]` Load `.js` files with ESM syntax but no `"type":"module"` marker as native ESM ([#16050](https://github.com/jestjs/jest/pull/16050))

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -392,7 +392,11 @@ For more information about the options object shape refer to `CoverageReporterWi
 
 Default: `undefined`
 
-This will be used to configure minimum threshold enforcement for coverage results. Thresholds can be specified as `global`, as a [glob](https://github.com/isaacs/node-glob#glob-primer), and as a directory or file path. If thresholds aren't met, jest will fail. Thresholds specified as a positive number are taken to be the minimum percentage required. Thresholds specified as a negative number represent the maximum number of uncovered entities allowed.
+This will be used to configure minimum threshold enforcement for coverage results. Thresholds can be specified as `global`, as a [glob](https://github.com/isaacs/node-glob#glob-primer), and as a directory or file path. If thresholds aren't met, jest will fail.
+
+- If a threshold is set to a **positive** number, it will be interpreted as the **minimum** percentage of coverage required.
+
+- If a threshold is set to a **negative** number, it will be treated as the **maximum** number of uncovered items allowed.
 
 For example, with the following configuration jest will fail if there is less than 80% branch, line, and function coverage, or if there are more than 10 uncovered statements:
 
@@ -402,9 +406,13 @@ const {defineConfig} = require('jest');
 module.exports = defineConfig({
   coverageThreshold: {
     global: {
+      // Requires 80% branch coverage
       branches: 80,
+      // Requires 80% function coverage
       functions: 80,
+      // Requires 80% line coverage
       lines: 80,
+      // Require that no more than 10 statements are uncovered
       statements: -10,
     },
   },
@@ -417,18 +425,48 @@ import {defineConfig} from 'jest';
 export default defineConfig({
   coverageThreshold: {
     global: {
+      // Requires 80% branch coverage
       branches: 80,
+      // Requires 80% function coverage
       functions: 80,
+      // Requires 80% line coverage
       lines: 80,
+      // Require that no more than 10 statements are uncovered
       statements: -10,
     },
   },
 });
 ```
 
-If globs or paths are specified alongside `global`, coverage data for matching paths will be subtracted from overall coverage and thresholds will be applied independently. Thresholds for globs are applied to all files matching the glob. If the file specified by path is not found, an error is returned.
+#### coverageThreshold.global.lines [number]
 
-For example, with the following configuration:
+Global threshold for lines.
+
+#### coverageThreshold.global.functions [number]
+
+Global threshold for functions.
+
+#### coverageThreshold.global.statements [number]
+
+Global threshold for statements.
+
+#### coverageThreshold.global.branches [number]
+
+Global threshold for branches.
+
+#### coverageThreshold[glob-pattern] \[object]
+
+Default: `undefined`
+
+Sets thresholds for files matching the [glob](https://github.com/isaacs/node-glob#glob-primer) pattern. This allows you to enforce a high global standard while also setting specific thresholds for critical files or directories.
+
+:::info
+
+When globs or paths are defined together with a global threshold, Jest applies each threshold independently — specific patterns use their own limits, while the global threshold applies to files not matched by any pattern. If all files are matched by path or glob patterns, the global threshold falls back to applying against all covered files.
+
+If the file specified by path is not found, an error is returned.
+
+:::
 
 ```js tab title="jest.config.js"
 const {defineConfig} = require('jest');
@@ -488,10 +526,10 @@ export default defineConfig({
 
 Jest will fail if:
 
-- The `./src/components` directory has less than 40% branch or statement coverage.
+- The `./src/components` directory has less than 40% branch/statement coverage.
 - One of the files matching the `./src/reducers/**/*.js` glob has less than 90% statement coverage.
 - The `./src/api/very-important-module.js` file has less than 100% coverage.
-- Every remaining file combined has less than 50% coverage (`global`).
+- All files that are not matched by `./src/components`, `./src/reducers/**/*.js`, or `./src/api/very-important-module.js` have less than 50% coverage (`global`).
 
 ### `dependencyExtractor` \[string]
 

--- a/e2e/__tests__/__snapshots__/coverageThreshold.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/coverageThreshold.test.ts.snap
@@ -1,13 +1,6 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
-exports[`excludes tests matched by path threshold groups from global group 1`] = `
-"PASS __tests__/banana.test.js
-  ✓ banana
-
-Jest: "global" coverage threshold for lines (100%) not met: 0%"
-`;
-
-exports[`excludes tests matched by path threshold groups from global group 2`] = `
+exports[`exits with 1 if coverage threshold of matched paths is not met independently from global threshold 1`] = `
 "Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
 Snapshots:   0 total
@@ -15,14 +8,34 @@ Time:        <<REPLACED>>
 Ran all test suites."
 `;
 
-exports[`excludes tests matched by path threshold groups from global group: stdout 1`] = `
-"-----------|---------|----------|---------|---------|-------------------
-File       | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
------------|---------|----------|---------|---------|-------------------
-All files  |      50 |      100 |      50 |      50 |                   
- apple.js  |       0 |      100 |       0 |       0 | 1-2               
- banana.js |     100 |      100 |     100 |     100 |                   
------------|---------|----------|---------|---------|-------------------"
+exports[`exits with 1 if coverage threshold of matched paths is not met independently from global threshold: stdout 1`] = `
+"------------|---------|----------|---------|---------|-------------------
+File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+------------|---------|----------|---------|---------|-------------------
+All files   |      75 |       50 |     100 |      75 |                   
+ product.js |      75 |       50 |     100 |      75 | 6                 
+------------|---------|----------|---------|---------|-------------------"
+`;
+
+exports[`exits with 1 if coverage threshold of the rest of non matched paths is not met 1`] = `
+"Test Suites: 5 passed, 5 total
+Tests:       5 passed, 5 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
+`;
+
+exports[`exits with 1 if coverage threshold of the rest of non matched paths is not met: stdout 1`] = `
+"------------|---------|----------|---------|---------|-------------------
+File        | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
+------------|---------|----------|---------|---------|-------------------
+All files   |   91.66 |       50 |     100 |   91.66 |                   
+ product.js |      75 |       50 |     100 |      75 | 6                 
+ sum-01.js  |     100 |      100 |     100 |     100 |                   
+ sum-02.js  |     100 |      100 |     100 |     100 |                   
+ sum-03.js  |     100 |      100 |     100 |     100 |                   
+ sum-04.js  |     100 |      100 |     100 |     100 |                   
+------------|---------|----------|---------|---------|-------------------"
 `;
 
 exports[`exits with 0 if global threshold group is not found in coverage data: stdout 1`] = `
@@ -38,7 +51,7 @@ exports[`exits with 1 if coverage threshold is not met 1`] = `
 "PASS __tests__/a-banana.js
   ✓ banana
 
-Jest: "global" coverage threshold for lines (90%) not met: 50%"
+Jest: Coverage for lines (50%) does not meet "global" threshold (90%)"
 `;
 
 exports[`exits with 1 if coverage threshold is not met 2`] = `
@@ -86,9 +99,9 @@ exports[`file is matched by all path and glob threshold groups 1`] = `
 "PASS __tests__/banana.test.js
   ✓ banana
 
-Jest: "./" coverage threshold for lines (100%) not met: 50%
-Jest: "<<FULL_PATH_TO_BANANA_JS>>" coverage threshold for lines (100%) not met: 50%
-Jest: "./banana.js" coverage threshold for lines (100%) not met: 50%"
+Jest: Coverage for lines (50%) does not meet "./" threshold (100%)
+Jest: Coverage for lines (50%) does not meet "<<FULL_PATH_TO_BANANA_JS>>" threshold (100%)
+Jest: Coverage for lines (50%) does not meet "./banana.js" threshold (100%)"
 `;
 
 exports[`file is matched by all path and glob threshold groups 2`] = `

--- a/e2e/__tests__/coverageThreshold.test.ts
+++ b/e2e/__tests__/coverageThreshold.test.ts
@@ -129,38 +129,103 @@ test('exits with 0 if global threshold group is not found in coverage data', () 
   expect(stdout).toMatchSnapshot('stdout');
 });
 
-test('excludes tests matched by path threshold groups from global group', () => {
+test('exits with 1 if coverage threshold of the rest of non matched paths is not met', () => {
   const pkgJson = {
     jest: {
       collectCoverage: true,
       collectCoverageFrom: ['**/*.js'],
       coverageThreshold: {
-        'banana.js': {
-          lines: 100,
+        '**/*.js': {
+          branches: 50,
+          functions: 50,
+          lines: 50,
+          statements: 50,
         },
         global: {
-          lines: 100,
+          // When **/*.js matches all files, no files are bucketed to global
+          // (subtraction leaves nothing). Fallback uses all files (~85% aggregate).
+          // Threshold must exceed ~85% to trigger failure.
+          branches: 90,
+          functions: 90,
+          lines: 90,
+          statements: 90,
         },
       },
+      testRegex: '.*\\.test\\.js$',
     },
   };
-
   writeFiles(DIR, {
-    '__tests__/banana.test.js': `
-      const banana = require('../banana.js');
-      test('banana', () => expect(banana()).toBe(3));
-    `,
-    'apple.js': `
-      module.exports = () => {
-        return 1 + 2;
-      };
-    `,
-    'banana.js': `
-      module.exports = () => {
-        return 1 + 2;
-      };
-    `,
     'package.json': JSON.stringify(pkgJson, null, 2),
+    'product.js': `
+      function product(a, b) {
+      // let's simulate 50% branch coverage (both branches do the same thing)
+        if (a > 0) {
+          return a * b;
+        } else {
+          return a * b;
+        }
+      }
+
+      module.exports = product;
+    `,
+    'product.test.js': `
+      test('multiplies 2 * 3 to equal 6', () => {
+        const sum = require('./product');
+        expect(sum(2, 3)).toBe(6);
+      });
+    `,
+    'sum-01.js': `
+      function sum(a, b) {
+        return a + b;
+      }
+
+      module.exports = sum;
+    `,
+    'sum-01.test.js': `
+      test('adds 1 + 2 to equal 3', () => {
+        const sum = require('./sum-01');
+        expect(sum(1, 2)).toBe(3);
+      });
+    `,
+    'sum-02.js': `
+      function sum(a, b) {
+        return a + b;
+      }
+
+      module.exports = sum;
+    `,
+    'sum-02.test.js': `
+      test('adds 1 + 2 to equal 3', () => {
+        const sum = require('./sum-02');
+        expect(sum(1, 2)).toBe(3);
+      });
+    `,
+    'sum-03.js': `
+      function sum(a, b) {
+        return a + b;
+      }
+
+      module.exports = sum;
+    `,
+    'sum-03.test.js': `
+      test('adds 1 + 2 to equal 3', () => {
+        const sum = require('./sum-03');
+        expect(sum(1, 2)).toBe(3);
+      });
+    `,
+    'sum-04.js': `
+      function sum(a, b) {
+        return a + b;
+      }
+
+      module.exports = sum;
+    `,
+    'sum-04.test.js': `
+      test('adds 1 + 2 to equal 3', () => {
+        const sum = require('./sum-04');
+        expect(sum(1, 2)).toBe(3);
+      });
+    `,
   });
 
   const {stdout, stderr, exitCode} = runJest(
@@ -171,7 +236,62 @@ test('excludes tests matched by path threshold groups from global group', () => 
   const {rest, summary} = extractSummary(stderr);
 
   expect(exitCode).toBe(1);
-  expect(rest).toMatchSnapshot();
+  expect(rest).toContain(
+    'Jest: Coverage for branches (50%) does not meet "global" threshold (90%)',
+  );
+  expect(summary).toMatchSnapshot();
+  expect(stdout).toMatchSnapshot('stdout');
+});
+
+test('exits with 1 if coverage threshold of matched paths is not met independently from global threshold', () => {
+  const pkgJson = {
+    jest: {
+      collectCoverage: true,
+      collectCoverageFrom: ['**/*.js'],
+      coverageThreshold: {
+        global: {
+          lines: 70,
+        },
+        'product.js': {
+          lines: 80,
+        },
+      },
+      testRegex: '.*\\.test\\.js$',
+    },
+  };
+  writeFiles(DIR, {
+    'package.json': JSON.stringify(pkgJson, null, 2),
+    'product.js': `
+      function product(a, b) {
+      // let's simulate 50% branch coverage (both branches do the same thing)
+        if (a > 0) {
+          return a * b;
+        } else {
+          return a * b;
+        }
+      }
+
+      module.exports = product;
+    `,
+    'product.test.js': `
+      test('multiplies 2 * 3 to equal 6', () => {
+        const sum = require('./product');
+        expect(sum(2, 3)).toBe(6);
+      });
+    `,
+  });
+
+  const {stdout, stderr, exitCode} = runJest(
+    DIR,
+    ['--coverage', '--ci=false'],
+    {stripAnsi: true},
+  );
+  const {rest, summary} = extractSummary(stderr);
+
+  expect(exitCode).toBe(1);
+  expect(rest).toContain(
+    'Jest: Coverage for lines (75%) does not meet "product.js" threshold (80%)',
+  );
   expect(summary).toMatchSnapshot();
   expect(stdout).toMatchSnapshot('stdout');
 });

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -249,7 +249,7 @@ export default class CoverageReporter extends BaseReporter {
               }
             } else if (actual < threshold) {
               errors.push(
-                `Jest: "${name}" coverage threshold for ${key} (${threshold}%) not met: ${actual}%`,
+                `Jest: Coverage for ${key} (${actual}%) does not meet "${name}" threshold (${threshold}%)`,
               );
             }
           }
@@ -273,6 +273,11 @@ export default class CoverageReporter extends BaseReporter {
         const pathOrGlobMatches = thresholdGroups.reduce<
           Array<[string, string]>
         >((agg, thresholdGroup) => {
+          // Skip 'global' here as it will be handled separately for all files
+          if (thresholdGroup === THRESHOLD_GROUP_TYPES.GLOBAL) {
+            return agg;
+          }
+
           // Preserve trailing slash, but not required if root dir
           // See https://github.com/jestjs/jest/issues/12703
           const resolvedThresholdGroup = path.resolve(thresholdGroup);
@@ -333,6 +338,12 @@ export default class CoverageReporter extends BaseReporter {
         return files;
       }, []);
 
+      // Mark global threshold group if it exists
+      if (thresholdGroups.includes(THRESHOLD_GROUP_TYPES.GLOBAL)) {
+        groupTypeByThresholdGroup[THRESHOLD_GROUP_TYPES.GLOBAL] =
+          THRESHOLD_GROUP_TYPES.GLOBAL;
+      }
+
       const getFilesInThresholdGroup = (thresholdGroup: string) =>
         coveredFilesSortedIntoThresholdGroup
           .filter(fileAndGroup => fileAndGroup[1] === thresholdGroup)
@@ -363,8 +374,11 @@ export default class CoverageReporter extends BaseReporter {
       for (const thresholdGroup of thresholdGroups) {
         switch (groupTypeByThresholdGroup[thresholdGroup]) {
           case THRESHOLD_GROUP_TYPES.GLOBAL: {
+            const globalFiles = getFilesInThresholdGroup(
+              THRESHOLD_GROUP_TYPES.GLOBAL,
+            );
             const coverage = combineCoverage(
-              getFilesInThresholdGroup(THRESHOLD_GROUP_TYPES.GLOBAL),
+              globalFiles.length > 0 ? globalFiles : coveredFiles,
             );
             if (coverage) {
               errors = [

--- a/packages/jest-reporters/src/__tests__/CoverageReporter.test.js
+++ b/packages/jest-reporters/src/__tests__/CoverageReporter.test.js
@@ -309,7 +309,9 @@ describe('onRunComplete', () => {
             statements: 100,
           },
           global: {
-            statements: 100,
+            // All files matched by path thresholds → globalFiles empty → fallback to coveredFiles
+            // Aggregate coverage ~50.5%, so threshold ≤50% passes
+            statements: 50,
           },
         },
       },
@@ -322,6 +324,37 @@ describe('onRunComplete', () => {
     await testReporter.onRunComplete(new Set(), {}, mockAggResults);
 
     expect(testReporter.getLastError()).toBeUndefined();
+  });
+
+  test(`getLastError() returns error when global threshold group
+   is empty because PATH and GLOB threshold groups have matched all the
+    files but global threshold exceeds aggregate coverage.`, async () => {
+    const testReporter = new CoverageReporter(
+      {
+        collectCoverage: true,
+        coverageThreshold: {
+          './path-test-files/': {
+            statements: 50,
+          },
+          './path-test/': {
+            statements: 100,
+          },
+          global: {
+            // All files matched by path thresholds → globalFiles empty → fallback to coveredFiles
+            // Aggregate coverage ~50.5% < 100% → error
+            statements: 100,
+          },
+        },
+      },
+      {
+        maxWorkers: 2,
+      },
+    );
+    testReporter.log = jest.fn();
+
+    await testReporter.onRunComplete(new Set(), {}, mockAggResults);
+
+    expect(testReporter.getLastError()).toBeDefined();
   });
 
   test('getLastError() returns undefined when file and directory path threshold groups overlap', async () => {

--- a/packages/jest-reporters/src/__tests__/CoverageReporter.test.js
+++ b/packages/jest-reporters/src/__tests__/CoverageReporter.test.js
@@ -326,9 +326,7 @@ describe('onRunComplete', () => {
     expect(testReporter.getLastError()).toBeUndefined();
   });
 
-  test(`getLastError() returns error when global threshold group
-   is empty because PATH and GLOB threshold groups have matched all the
-    files but global threshold exceeds aggregate coverage.`, async () => {
+  test('getLastError() returns error when global threshold group is empty because PATH and GLOB threshold groups have matched all the files but global threshold exceeds aggregate coverage.', async () => {
     const testReporter = new CoverageReporter(
       {
         collectCoverage: true,


### PR DESCRIPTION
## Summary

- Inspired by Vitest way of displaying coverage
- Fixes #5427

## Test plan

- Added e2e tests for coverage threshold behavior with unmatched files
- Updated existing snapshot tests