### PR TITLE
docs: document expect.getState() and expect.setState() API

### DIFF
--- a/docs/ExpectAPI.md
+++ b/docs/ExpectAPI.md
@@ -1804,6 +1804,98 @@ it('transitions as expected', () => {
 });
 ```
 
+## Matcher State
+
+### `expect.getState()`
+
+Returns the current state of the `expect` module. This is useful for accessing test metadata inside `beforeEach`, `afterEach`, custom matchers, or any code that runs during a test.
+
+The state object contains the following properties:
+
+#### `currentTestName`
+
+The full name of the currently running test, including all parent `describe` block names separated by a space. For example:
+
+```js title="myTest.test.js"
+describe('my suite', () => {
+  describe('nested', () => {
+    beforeEach(() => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+
+    test('my test', () => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+  });
+});
+```
+
+```ts title="myTest.test.ts"
+describe('my suite', () => {
+  describe('nested', () => {
+    beforeEach(() => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+
+    test('my test', () => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+  });
+});
+```
+
+This is particularly useful for:
+
+- Naming screenshots in visual regression testing
+- Loading test-specific fixtures
+- Logging and debugging
+
+#### `testPath`
+
+The absolute path to the test file being executed.
+
+```js title="myTest.test.js"
+beforeEach(() => {
+  const {testPath} = expect.getState();
+  console.log(testPath); // '/path/to/project/myTest.test.js'
+});
+```
+
+```ts title="myTest.test.ts"
+beforeEach(() => {
+  const {testPath} = expect.getState();
+  console.log(testPath); // '/path/to/project/myTest.test.ts'
+});
+```
+
+#### `expand`
+
+A boolean indicating whether Jest was invoked with the `--expand` flag. This is the same value available as `this.expand` inside custom matchers.
+
+### `expect.setState(state)`
+
+Merges the provided object into the current matcher state. This is primarily used internally and inside custom matchers.
+
+```js title="myTest.test.js"
+expect.setState({key: 'value'});
+expect.getState().key; // 'value'
+```
+
+```ts title="myTest.test.ts"
+expect.setState({key: 'value'});
+expect.getState().key; // 'value'
+```
+
+:::caution
+
+Only set custom properties. Overwriting built-in state properties (such as `currentTestName`) may cause unexpected behavior.
+
+:::
+
 ## Serializable properties
 
 ### `SERIALIZABLE_PROPERTIES`

--- a/website/versioned_docs/version-29.7/ExpectAPI.md
+++ b/website/versioned_docs/version-29.7/ExpectAPI.md
@@ -1779,3 +1779,95 @@ it('transitions as expected', () => {
   expect(state).toMatchStateInlineSnapshot(`"done"`);
 });
 ```
+
+## Matcher State
+
+### `expect.getState()`
+
+Returns the current state of the `expect` module. This is useful for accessing test metadata inside `beforeEach`, `afterEach`, custom matchers, or any code that runs during a test.
+
+The state object contains the following properties:
+
+#### `currentTestName`
+
+The full name of the currently running test, including all parent `describe` block names separated by a space. For example:
+
+```js title="myTest.test.js"
+describe('my suite', () => {
+  describe('nested', () => {
+    beforeEach(() => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+
+    test('my test', () => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+  });
+});
+```
+
+```ts title="myTest.test.ts"
+describe('my suite', () => {
+  describe('nested', () => {
+    beforeEach(() => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+
+    test('my test', () => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+  });
+});
+```
+
+This is particularly useful for:
+
+- Naming screenshots in visual regression testing
+- Loading test-specific fixtures
+- Logging and debugging
+
+#### `testPath`
+
+The absolute path to the test file being executed.
+
+```js title="myTest.test.js"
+beforeEach(() => {
+  const {testPath} = expect.getState();
+  console.log(testPath); // '/path/to/project/myTest.test.js'
+});
+```
+
+```ts title="myTest.test.ts"
+beforeEach(() => {
+  const {testPath} = expect.getState();
+  console.log(testPath); // '/path/to/project/myTest.test.ts'
+});
+```
+
+#### `expand`
+
+A boolean indicating whether Jest was invoked with the `--expand` flag. This is the same value available as `this.expand` inside custom matchers.
+
+### `expect.setState(state)`
+
+Merges the provided object into the current matcher state. This is primarily used internally and inside custom matchers.
+
+```js title="myTest.test.js"
+expect.setState({key: 'value'});
+expect.getState().key; // 'value'
+```
+
+```ts title="myTest.test.ts"
+expect.setState({key: 'value'});
+expect.getState().key; // 'value'
+```
+
+:::caution
+
+Only set custom properties. Overwriting built-in state properties (such as `currentTestName`) may cause unexpected behavior.
+
+:::

--- a/website/versioned_docs/version-30.0/ExpectAPI.md
+++ b/website/versioned_docs/version-30.0/ExpectAPI.md
@@ -1804,6 +1804,98 @@ it('transitions as expected', () => {
 });
 ```
 
+## Matcher State
+
+### `expect.getState()`
+
+Returns the current state of the `expect` module. This is useful for accessing test metadata inside `beforeEach`, `afterEach`, custom matchers, or any code that runs during a test.
+
+The state object contains the following properties:
+
+#### `currentTestName`
+
+The full name of the currently running test, including all parent `describe` block names separated by a space. For example:
+
+```js title="myTest.test.js"
+describe('my suite', () => {
+  describe('nested', () => {
+    beforeEach(() => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+
+    test('my test', () => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+  });
+});
+```
+
+```ts title="myTest.test.ts"
+describe('my suite', () => {
+  describe('nested', () => {
+    beforeEach(() => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+
+    test('my test', () => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+  });
+});
+```
+
+This is particularly useful for:
+
+- Naming screenshots in visual regression testing
+- Loading test-specific fixtures
+- Logging and debugging
+
+#### `testPath`
+
+The absolute path to the test file being executed.
+
+```js title="myTest.test.js"
+beforeEach(() => {
+  const {testPath} = expect.getState();
+  console.log(testPath); // '/path/to/project/myTest.test.js'
+});
+```
+
+```ts title="myTest.test.ts"
+beforeEach(() => {
+  const {testPath} = expect.getState();
+  console.log(testPath); // '/path/to/project/myTest.test.ts'
+});
+```
+
+#### `expand`
+
+A boolean indicating whether Jest was invoked with the `--expand` flag. This is the same value available as `this.expand` inside custom matchers.
+
+### `expect.setState(state)`
+
+Merges the provided object into the current matcher state. This is primarily used internally and inside custom matchers.
+
+```js title="myTest.test.js"
+expect.setState({key: 'value'});
+expect.getState().key; // 'value'
+```
+
+```ts title="myTest.test.ts"
+expect.setState({key: 'value'});
+expect.getState().key; // 'value'
+```
+
+:::caution
+
+Only set custom properties. Overwriting built-in state properties (such as `currentTestName`) may cause unexpected behavior.
+
+:::
+
 ## Serializable properties
 
 ### `SERIALIZABLE_PROPERTIES`

--- a/website/versioned_docs/version-30.4/ExpectAPI.md
+++ b/website/versioned_docs/version-30.4/ExpectAPI.md
@@ -1804,6 +1804,98 @@ it('transitions as expected', () => {
 });
 ```
 
+## Matcher State
+
+### `expect.getState()`
+
+Returns the current state of the `expect` module. This is useful for accessing test metadata inside `beforeEach`, `afterEach`, custom matchers, or any code that runs during a test.
+
+The state object contains the following properties:
+
+#### `currentTestName`
+
+The full name of the currently running test, including all parent `describe` block names separated by a space. For example:
+
+```js title="myTest.test.js"
+describe('my suite', () => {
+  describe('nested', () => {
+    beforeEach(() => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+
+    test('my test', () => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+  });
+});
+```
+
+```ts title="myTest.test.ts"
+describe('my suite', () => {
+  describe('nested', () => {
+    beforeEach(() => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+
+    test('my test', () => {
+      const {currentTestName} = expect.getState();
+      console.log(currentTestName); // 'my suite nested my test'
+    });
+  });
+});
+```
+
+This is particularly useful for:
+
+- Naming screenshots in visual regression testing
+- Loading test-specific fixtures
+- Logging and debugging
+
+#### `testPath`
+
+The absolute path to the test file being executed.
+
+```js title="myTest.test.js"
+beforeEach(() => {
+  const {testPath} = expect.getState();
+  console.log(testPath); // '/path/to/project/myTest.test.js'
+});
+```
+
+```ts title="myTest.test.ts"
+beforeEach(() => {
+  const {testPath} = expect.getState();
+  console.log(testPath); // '/path/to/project/myTest.test.ts'
+});
+```
+
+#### `expand`
+
+A boolean indicating whether Jest was invoked with the `--expand` flag. This is the same value available as `this.expand` inside custom matchers.
+
+### `expect.setState(state)`
+
+Merges the provided object into the current matcher state. This is primarily used internally and inside custom matchers.
+
+```js title="myTest.test.js"
+expect.setState({key: 'value'});
+expect.getState().key; // 'value'
+```
+
+```ts title="myTest.test.ts"
+expect.setState({key: 'value'});
+expect.getState().key; // 'value'
+```
+
+:::caution
+
+Only set custom properties. Overwriting built-in state properties (such as `currentTestName`) may cause unexpected behavior.
+
+:::
+
 ## Serializable properties
 
 ### `SERIALIZABLE_PROPERTIES`


### PR DESCRIPTION
## Summary

Documents the previously undocumented `expect.getState()` and `expect.setState()` APIs in the Expect API reference.

This addresses a long-standing gap where users had to discover `expect.getState().currentTestName` through workarounds and community knowledge (see #7774). The documented properties are:

- **`currentTestName`** — full test name including describe blocks, useful for screenshot naming, fixture loading, and debugging
- **`testPath`** — absolute path to the current test file
- **`expand`** — whether `--expand` flag is active
- **`expect.setState(state)`** — merge custom properties into matcher state

Documentation added to:
- `docs/ExpectAPI.md` (next version)
- `website/versioned_docs/version-30.4/ExpectAPI.md`
- `website/versioned_docs/version-30.0/ExpectAPI.md`
- `website/versioned_docs/version-29.7/ExpectAPI.md`

All code examples provided in both JS and TS.

Related to #7774

## Test plan

Documentation-only change. Verified markdown structure and heading hierarchy are consistent with existing doc patterns.