### PR TITLE
fix(jest-console): buffer console output in CustomConsole for reporters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- `[jest-console]` `CustomConsole` now buffers console output so `TestResult.console` is populated for reporters when `verbose` is enabled ([#16155](https://github.com/jestjs/jest/pull/16155))
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 ### Fixes
 
+- `[jest-console, jest-reporters]` `CustomConsole` now buffers console output so `TestResult.console` is populated for reporters when `verbose` is enabled, while `GitHubActionsReporter` avoids replaying buffered output in verbose mode ([#16155](https://github.com/jestjs/jest/pull/16155))
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[jest-circus]` Call a generator test body with the shared test context, so `this` matches what a regular test function receives ([#16347](https://github.com/jestjs/jest/pull/16347))

--- a/packages/jest-console/src/CustomConsole.ts
+++ b/packages/jest-console/src/CustomConsole.ts
@@ -15,8 +15,14 @@ import {
   inspect,
 } from 'node:util';
 import chalk from 'chalk';
-import {clearLine, formatTime} from 'jest-util';
-import type {LogCounters, LogMessage, LogTimers, LogType} from './types';
+import {ErrorWithStack, clearLine, formatTime, invariant} from 'jest-util';
+import type {
+  ConsoleBuffer,
+  LogCounters,
+  LogMessage,
+  LogTimers,
+  LogType,
+} from './types';
 
 type Formatter = (type: LogType, message: LogMessage) => string;
 
@@ -24,6 +30,7 @@ export default class CustomConsole extends Console {
   private readonly _stdout: WriteStream;
   private readonly _stderr: WriteStream;
   private readonly _formatBuffer: Formatter;
+  private readonly _buffer: ConsoleBuffer = [];
   private _counters: LogCounters = {};
   private _timers: LogTimers = {};
   private _groupDepth = 0;
@@ -46,6 +53,7 @@ export default class CustomConsole extends Console {
     super.log(
       this._formatBuffer(type, '  '.repeat(this._groupDepth) + message),
     );
+    this._addToBuffer(type, message);
   }
 
   private _logError(type: LogType, message: string) {
@@ -53,7 +61,22 @@ export default class CustomConsole extends Console {
     super.error(
       this._formatBuffer(type, '  '.repeat(this._groupDepth) + message),
     );
+    this._addToBuffer(type, message);
   }
+
+  private readonly _addToBuffer = (type: LogType, message: string) => {
+    const rawStack = new ErrorWithStack(undefined, this._addToBuffer).stack;
+
+    invariant(rawStack != null, 'always have a stack trace');
+
+    const origin = rawStack.split('\n').slice(3).filter(Boolean).join('\n');
+
+    this._buffer.push({
+      message: '  '.repeat(this._groupDepth) + message,
+      origin,
+      type,
+    });
+  };
 
   override assert(value: unknown, message?: string | Error): asserts value {
     try {
@@ -159,7 +182,7 @@ export default class CustomConsole extends Console {
     this._logError('warn', format(firstArg, ...args));
   }
 
-  getBuffer(): undefined {
-    return undefined;
+  getBuffer(): ConsoleBuffer | undefined {
+    return this._buffer.length > 0 ? this._buffer : undefined;
   }
 }

--- a/packages/jest-console/src/__tests__/CustomConsole.test.ts
+++ b/packages/jest-console/src/__tests__/CustomConsole.test.ts
@@ -241,4 +241,62 @@ describe('CustomConsole', () => {
       expect(_console.Console).toBeDefined();
     });
   });
+
+  describe('getBuffer', () => {
+    test('should return undefined when no messages have been logged', () => {
+      expect(_console.getBuffer()).toBeUndefined();
+    });
+
+    test('should return buffer with log entries after logging', () => {
+      _console.log('Hello world!');
+
+      const buffer = _console.getBuffer();
+      expect(buffer).toBeDefined();
+      expect(buffer).toHaveLength(1);
+      expect(buffer![0].message).toBe('Hello world!');
+      expect(buffer![0].type).toBe('log');
+      expect(buffer![0].origin).toBeDefined();
+    });
+
+    test('should buffer error messages', () => {
+      _console.error('Some error');
+
+      const buffer = _console.getBuffer();
+      expect(buffer).toBeDefined();
+      expect(buffer).toHaveLength(1);
+      expect(buffer![0].message).toBe('Some error');
+      expect(buffer![0].type).toBe('error');
+    });
+
+    test('should buffer warn messages', () => {
+      _console.warn('Some warning');
+
+      const buffer = _console.getBuffer();
+      expect(buffer).toBeDefined();
+      expect(buffer).toHaveLength(1);
+      expect(buffer![0].message).toBe('Some warning');
+      expect(buffer![0].type).toBe('warn');
+    });
+
+    test('should accumulate multiple log entries', () => {
+      _console.log('first');
+      _console.error('second');
+      _console.warn('third');
+
+      const buffer = _console.getBuffer();
+      expect(buffer).toHaveLength(3);
+      expect(buffer![0].type).toBe('log');
+      expect(buffer![1].type).toBe('error');
+      expect(buffer![2].type).toBe('warn');
+    });
+
+    test('should still print to stdout/stderr while buffering', () => {
+      _console.log('to stdout');
+      _console.error('to stderr');
+
+      expect(_stdout).toBe('to stdout\n');
+      expect(_stderr).toBe('to stderr\n');
+      expect(_console.getBuffer()).toHaveLength(2);
+    });
+  });
 });

--- a/packages/jest-reporters/src/DefaultReporter.ts
+++ b/packages/jest-reporters/src/DefaultReporter.ts
@@ -227,7 +227,7 @@ export default class DefaultReporter extends BaseReporter {
     }
 
     this.log(getResultHeader(result, this._globalConfig, config));
-    if (result.console) {
+    if (result.console && !(config.verbose ?? this._globalConfig.verbose)) {
       this.log(
         `  ${TITLE_BULLET}Console\n\n${getConsoleOutput(result.console, config, this._globalConfig)}`,
       );

--- a/packages/jest-reporters/src/DefaultReporter.ts
+++ b/packages/jest-reporters/src/DefaultReporter.ts
@@ -236,7 +236,7 @@ export default class DefaultReporter extends BaseReporter {
     }
 
     this.log(getResultHeader(result, this._globalConfig, config));
-    if (result.console) {
+    if (result.console && !(config.verbose ?? this._globalConfig.verbose)) {
       this.log(
         `  ${TITLE_BULLET}Console\n\n${getConsoleOutput(result.console, config, this._globalConfig)}`,
       );

--- a/packages/jest-reporters/src/GitHubActionsReporter.ts
+++ b/packages/jest-reporters/src/GitHubActionsReporter.ts
@@ -331,7 +331,11 @@ export default class GitHubActionsReporter extends BaseReporter {
       this.startGroup(
         `${chalk.bold.green.inverse('PASS')} ${resultTree.name}${perfMs}`,
       );
-      if (consoleLog && !this.options.silent) {
+      if (
+        consoleLog &&
+        !this.options.silent &&
+        !(config.verbose ?? this.globalConfig.verbose)
+      ) {
         this.log(getConsoleOutput(consoleLog, config, this.globalConfig));
       }
       for (const child of resultTree.children) {
@@ -427,7 +431,11 @@ export default class GitHubActionsReporter extends BaseReporter {
           written = true;
         }
         this.startGroup(`Errors thrown in ${testDir}`);
-        if (consoleLog && !this.options.silent) {
+        if (
+          consoleLog &&
+          !this.options.silent &&
+          !(context.context.config.verbose ?? this.globalConfig.verbose)
+        ) {
           this.log(
             getConsoleOutput(
               consoleLog,

--- a/packages/jest-reporters/src/__tests__/GitHubActionsReporter.test.ts
+++ b/packages/jest-reporters/src/__tests__/GitHubActionsReporter.test.ts
@@ -739,11 +739,116 @@ describe('logs', () => {
       expect(mockedStderrWrite.mock.calls).toMatchSnapshot();
     });
 
+    test('onTestResult last does not repeat console output for failed verbose test', () => {
+      const mockTest = {
+        context: {
+          config: {
+            rootDir: '/testDir',
+          },
+        },
+      };
+      const mockTestResult = {
+        console: [
+          {
+            message: 'bar',
+            origin:
+              '    at Object.log (/tmp/jest-test/a.test.js:2:13)\n    at Promise.finally.completed (/github.com/jestjs/jest/packages/jest-circus/build/jestAdapterInit.js:1557:28)',
+            type: 'log',
+          },
+        ],
+        failureMessage: 'Failure message',
+        perfStats: {
+          runtime: 20,
+          slow: false,
+        },
+        testFilePath: '/testDir/test1.js',
+        testResults: [
+          {
+            ancestorTitles: [],
+            duration: 10,
+            status: 'passed',
+            title: 'test1',
+          },
+        ],
+      };
+      const mockResults = {
+        numFailedTestSuites: 1,
+        numPassedTestSuites: 2,
+        numTotalTestSuites: 3,
+        testResults: [mockTestResult],
+      };
+      const gha = new GitHubActionsReporter(makeGlobalConfig({verbose: true}), {
+        silent: false,
+      });
+      gha.generateAnnotations = jest.fn();
+
+      gha.onTestResult(
+        mockTest as Test,
+        mockTestResult as unknown as TestResult,
+        mockResults as unknown as AggregatedResult,
+      );
+
+      expect(mockedStderrWrite.mock.calls).toMatchSnapshot();
+    });
+
     test('onTestResult last with console output for success test', () => {
       const mockTest = {
         context: {
           config: {
             rootDir: '/testDir',
+            verbose: false,
+          },
+        },
+      };
+      const mockTestResult = {
+        console: [
+          {
+            message: 'bar',
+            origin:
+              '    at Object.log (/tmp/jest-test/a.test.js:2:13)\n    at Promise.finally.completed (/github.com/jestjs/jest/packages/jest-circus/build/jestAdapterInit.js:1557:28)',
+            type: 'log',
+          },
+        ],
+        perfStats: {
+          runtime: 20,
+          slow: false,
+        },
+        testFilePath: '/testDir/test1.js',
+        testResults: [
+          {
+            ancestorTitles: [],
+            duration: 10,
+            status: 'passed',
+            title: 'test1',
+          },
+        ],
+      };
+      const mockResults = {
+        numFailedTestSuites: 0,
+        numPassedTestSuites: 1,
+        numTotalTestSuites: 1,
+        testResults: [mockTestResult],
+      };
+      const gha = new GitHubActionsReporter(makeGlobalConfig({verbose: true}), {
+        silent: false,
+      });
+      gha.generateAnnotations = jest.fn();
+
+      gha.onTestResult(
+        mockTest as Test,
+        mockTestResult as unknown as TestResult,
+        mockResults as unknown as AggregatedResult,
+      );
+
+      expect(mockedStderrWrite.mock.calls).toMatchSnapshot();
+    });
+
+    test('onTestResult last does not repeat console output for successful verbose test', () => {
+      const mockTest = {
+        context: {
+          config: {
+            rootDir: '/testDir',
+            verbose: true,
           },
         },
       };

--- a/packages/jest-reporters/src/__tests__/__snapshots__/GitHubActionsReporter.test.ts.snap
+++ b/packages/jest-reporters/src/__tests__/__snapshots__/GitHubActionsReporter.test.ts.snap
@@ -72,6 +72,56 @@ Array [
 ]
 `;
 
+exports[`logs Reporter interface onTestResult last does not repeat console output for failed verbose test 1`] = `
+Array [
+  Array [
+    "::group::<bold><green><inverse>PASS</inverse></color></intensity> test1.js (20 ms)
+",
+  ],
+  Array [
+    "  <green>✓</color> test1 (10 ms)
+",
+  ],
+  Array [
+    "::endgroup::
+",
+  ],
+  Array [
+    "
+",
+  ],
+  Array [
+    "::group::Errors thrown in test1.js
+",
+  ],
+  Array [
+    "Failure message
+",
+  ],
+  Array [
+    "::endgroup::
+",
+  ],
+]
+`;
+
+exports[`logs Reporter interface onTestResult last does not repeat console output for successful verbose test 1`] = `
+Array [
+  Array [
+    "::group::<bold><green><inverse>PASS</inverse></color></intensity> test1.js (20 ms)
+",
+  ],
+  Array [
+    "  <green>✓</color> test1 (10 ms)
+",
+  ],
+  Array [
+    "::endgroup::
+",
+  ],
+]
+`;
+
 exports[`logs Reporter interface onTestResult last with console output for failed test 1`] = `
 Array [
   Array [
@@ -128,8 +178,8 @@ Array [
 ",
   ],
   Array [
-    "    <dim>console.log</intensity>
-      bar
+    "  <dim>console.log</intensity>
+    bar
 <dim></intensity>
 <dim>      <dim>at Object.log (</intensity><dim>../tmp/jest-test/a.test.js<dim>:2:13)</intensity><dim></intensity>
 


### PR DESCRIPTION
## Summary

Fixes #6441

When running a single test file, Jest forces `verbose: true` ([source](https://github.com/jestjs/jest/blob/main/packages/jest-core/src/runJest.ts#L326-L333)), which causes `runTest` to use `CustomConsole` instead of `BufferedConsole`. `CustomConsole.getBuffer()` returned `undefined`, so `TestResult.console` was never populated — reporters (including custom reporters) received no console data.

This PR adds buffer tracking to `CustomConsole` so it both:
- **Prints live to stdout** (preserving the existing verbose UX)
- **Buffers entries** so `getBuffer()` returns a `ConsoleBuffer`, populating `TestResult.console` for reporters

### Changes

- **`packages/jest-console/src/CustomConsole.ts`**:
  - Added `_buffer: ConsoleBuffer` field
  - Added `_addToBuffer()` private method that captures stack origin (matching `BufferedConsole.write` behavior)
  - `_log()` and `_logError()` now also write to the buffer
  - `getBuffer()` returns the buffer (instead of always `undefined`)

- **`packages/jest-reporters/src/DefaultReporter.ts`**:
  - Skip printing the `● Console` section when the effective verbose setting (`config.verbose ?? globalConfig.verbose`) is true, since `CustomConsole` already prints output inline — avoids double-printing

- **`packages/jest-console/src/__tests__/CustomConsole.test.ts`**:
  - Added 6 unit tests covering `getBuffer()` behavior

- **`e2e/__tests__/__snapshots__/executeTestsOnceInMpr.ts.snap`**:
  - Updated snapshot to reflect new behavior

## Test plan

- All affected e2e tests pass: `console.test.ts`, `consoleDebugging.test.ts`, `consoleLogOutputWhenRunInBand.test.ts`, `testRetries.test.ts`, `jest.config.ts.test.ts`, `jest.config.js.test.ts`, `executeTestsOnceInMpr.ts`
- Unit tests pass: `yarn jest packages/jest-console --no-coverage`
- Lint passes: `yarn lint`
- Build succeeds: `yarn build`