### PR TITLE
fix(jest-resolve): resolve prefixed modules from Jest location first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 ### Fixes
 
+- `[jest-resolve]` Resolve prefixed modules (environments, runners, watch plugins, sequencers) from Jest's own install location first to prevent hoisted dependencies from shadowing bundled versions ([#5913](https://github.com/jestjs/jest/issues/5913), [#16156](https://github.com/jestjs/jest/pull/16156))
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Fixes
 
+- `[jest-resolve]` Resolve prefixed modules (environments, runners, watch plugins, sequencers) from Jest's own install location first to prevent hoisted dependencies from shadowing bundled versions ([#5913](https://github.com/jestjs/jest/issues/5913), [#16156](https://github.com/jestjs/jest/pull/16156))
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[jest-mock]` `mockResolvedValue` / `mockRejectedValue` now see all overload return types, so a Promise-returning overload survives even when a later overload returns a non-Promise (e.g. `pg.Client['end']`) ([#16237](https://github.com/jestjs/jest/pull/16237))

--- a/packages/jest-config/src/__tests__/normalize.test.ts
+++ b/packages/jest-config/src/__tests__/normalize.test.ts
@@ -893,7 +893,7 @@ describe('testEnvironment', () => {
     });
   });
 
-  it('resolves to an environment and prefers jest-environment-`name`', async () => {
+  it('resolves to an environment and prefers jest-environment-`name` from Jest location', async () => {
     const {options} = await normalize(
       {
         rootDir: '/root',
@@ -902,7 +902,12 @@ describe('testEnvironment', () => {
       {} as Config.Argv,
     );
 
-    expect(options.testEnvironment).toBe('node_modules/jest-environment-jsdom');
+    // Jest's own location is preferred over rootDir to avoid version conflicts
+    // when third-party packages hoist jest-environment-* to project root.
+    // See https://github.com/jestjs/jest/issues/5913
+    expect(options.testEnvironment).toBe(
+      require.resolve('jest-environment-jsdom'),
+    );
   });
 
   it('resolves to node environment by default', async () => {
@@ -1761,7 +1766,7 @@ describe('watchPlugins', () => {
     expect(options.watchPlugins).toBeUndefined();
   });
 
-  it('resolves to watch plugins and prefers jest-watch-`name`', async () => {
+  it('resolves to watch plugins and prefers jest-watch-`name` from Jest location', async () => {
     const {options} = await normalize(
       {
         rootDir: '/root/',
@@ -1770,8 +1775,14 @@ describe('watchPlugins', () => {
       {} as Config.Argv,
     );
 
+    // Jest's own location is preferred over rootDir to avoid version conflicts
+    // when third-party packages hoist jest-watch-* to project root.
+    // See https://github.com/jestjs/jest/issues/5913
     expect(options.watchPlugins).toEqual([
-      {config: {} as Config.Argv, path: 'node_modules/jest-watch-typeahead'},
+      {
+        config: {} as Config.Argv,
+        path: require.resolve('jest-watch-typeahead'),
+      },
     ]);
   });
 
@@ -1799,7 +1810,10 @@ describe('watchPlugins', () => {
     );
 
     expect(options.watchPlugins).toEqual([
-      {config: {} as Config.Argv, path: 'node_modules/jest-watch-typeahead'},
+      {
+        config: {} as Config.Argv,
+        path: require.resolve('jest-watch-typeahead'),
+      },
       {config: {} as Config.Argv, path: '/root/path/to/plugin'},
     ]);
   });

--- a/packages/jest-resolve/src/__tests__/utils.test.ts
+++ b/packages/jest-resolve/src/__tests__/utils.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import Resolver from '../resolver';
+import {resolveTestEnvironment} from '../utils';
+
+describe('resolveTestEnvironment', () => {
+  const findNodeModule = Resolver.findNodeModule;
+
+  afterEach(() => {
+    Resolver.findNodeModule = findNodeModule;
+  });
+
+  it('prefers Jest location over rootDir when both resolve', () => {
+    // Simulate a package available both from rootDir (via findNodeModule)
+    // and from Jest's own location (via requireResolveFunction)
+    const jestLocationPath =
+      '/jest/node_modules/jest-environment-node/index.js';
+    const rootDirPath = '/project/node_modules/jest-environment-node';
+
+    Resolver.findNodeModule = jest.fn(() => rootDirPath);
+
+    const result = resolveTestEnvironment({
+      requireResolveFunction: (name: string) => {
+        if (name === 'jest-environment-node') {
+          return jestLocationPath;
+        }
+        throw new Error(`Cannot find module '${name}'`);
+      },
+      rootDir: '/project',
+      testEnvironment: 'node',
+    });
+
+    // Jest's own location should win (requireResolveFunction)
+    expect(result).toBe(jestLocationPath);
+  });
+
+  it('falls back to rootDir when Jest location cannot resolve', () => {
+    const rootDirPath = '/project/node_modules/jest-environment-custom';
+
+    Resolver.findNodeModule = jest.fn((name: string) => {
+      if (name === 'jest-environment-custom') {
+        return rootDirPath;
+      }
+      return null;
+    });
+
+    const result = resolveTestEnvironment({
+      requireResolveFunction: () => {
+        throw new Error('Cannot find module');
+      },
+      rootDir: '/project',
+      testEnvironment: 'custom',
+    });
+
+    // Falls back to rootDir resolution
+    expect(result).toBe(rootDirPath);
+  });
+
+  it('resolves relative paths from rootDir first, not Jest location', () => {
+    const rootDirPath = '/project/custom-env.js';
+
+    Resolver.findNodeModule = jest.fn((name: string) => {
+      if (name === './custom-env.js') {
+        return rootDirPath;
+      }
+      return null;
+    });
+
+    const requireResolveFunction = jest.fn((): string => {
+      return '/jest/node_modules/something-else.js';
+    });
+
+    const result = resolveTestEnvironment({
+      requireResolveFunction,
+      rootDir: '/project',
+      testEnvironment: './custom-env.js',
+    });
+
+    // rootDir resolution should win for relative paths
+    expect(result).toBe(rootDirPath);
+    expect(requireResolveFunction).not.toHaveBeenCalled();
+  });
+
+  it('falls back to requireResolve for path-like inputs when rootDir fails', () => {
+    Resolver.findNodeModule = jest.fn(() => null);
+
+    const absolutePath = '/some/absolute/path/env.js';
+
+    const result = resolveTestEnvironment({
+      requireResolveFunction: (name: string) => {
+        if (name === absolutePath) {
+          return absolutePath;
+        }
+        throw new Error('Cannot find module');
+      },
+      rootDir: '/project',
+      testEnvironment: absolutePath,
+    });
+
+    expect(result).toBe(absolutePath);
+  });
+
+  it('throws when neither location resolves', () => {
+    Resolver.findNodeModule = jest.fn(() => null);
+
+    expect(() =>
+      resolveTestEnvironment({
+        requireResolveFunction: () => {
+          throw new Error('Cannot find module');
+        },
+        rootDir: '/project',
+        testEnvironment: 'nonexistent',
+      }),
+    ).toThrow('cannot be found');
+  });
+});

--- a/packages/jest-resolve/src/utils.ts
+++ b/packages/jest-resolve/src/utils.ts
@@ -48,29 +48,53 @@ const resolveWithPrefix = (
   },
 ): string => {
   const fileName = replaceRootDirInPath(rootDir, filePath);
-  let module = Resolver.findNodeModule(`${prefix}${fileName}`, {
-    basedir: rootDir,
-    resolver: resolver || undefined,
-  });
-  if (module) {
-    return module;
+  const isPathLike = fileName.startsWith('.') || path.isAbsolute(fileName);
+
+  // For path-like inputs (relative or absolute paths), resolve from rootDir
+  // first since they refer to project-local files, not npm packages.
+  // For package names, resolve from Jest's own location first to avoid
+  // loading wrong versions hoisted by third-party dependencies.
+  // See https://github.com/jestjs/jest/issues/5913
+  if (isPathLike) {
+    // For path-like inputs, prefix variants (e.g. jest-environment-./foo) are
+    // nonsensical, so only resolve the bare name from rootDir first, then
+    // fall back to requireResolveFunction.
+    const module = Resolver.findNodeModule(fileName, {
+      basedir: rootDir,
+      resolver: resolver || undefined,
+    });
+    if (module) {
+      return module;
+    }
+
+    try {
+      return requireResolveFunction(fileName);
+    } catch {}
+  } else {
+    try {
+      return requireResolveFunction(`${prefix}${fileName}`);
+    } catch {}
+
+    let module = Resolver.findNodeModule(`${prefix}${fileName}`, {
+      basedir: rootDir,
+      resolver: resolver || undefined,
+    });
+    if (module) {
+      return module;
+    }
+
+    try {
+      return requireResolveFunction(fileName);
+    } catch {}
+
+    module = Resolver.findNodeModule(fileName, {
+      basedir: rootDir,
+      resolver: resolver || undefined,
+    });
+    if (module) {
+      return module;
+    }
   }
-
-  try {
-    return requireResolveFunction(`${prefix}${fileName}`);
-  } catch {}
-
-  module = Resolver.findNodeModule(fileName, {
-    basedir: rootDir,
-    resolver: resolver || undefined,
-  });
-  if (module) {
-    return module;
-  }
-
-  try {
-    return requireResolveFunction(fileName);
-  } catch {}
 
   throw createValidationError(
     `  ${humanOptionName} ${chalk.bold(
@@ -84,10 +108,10 @@ const resolveWithPrefix = (
 /**
  * Finds the test environment to use:
  *
- * 1. looks for jest-environment-<name> relative to project.
  * 1. looks for jest-environment-<name> relative to Jest.
- * 1. looks for <name> relative to project.
+ * 1. looks for jest-environment-<name> relative to project.
  * 1. looks for <name> relative to Jest.
+ * 1. looks for <name> relative to project.
  */
 export const resolveTestEnvironment = ({
   rootDir,
@@ -125,10 +149,15 @@ export const resolveTestEnvironment = ({
 /**
  * Finds the watch plugins to use:
  *
- * 1. looks for jest-watch-<name> relative to project.
+ * For package names:
  * 1. looks for jest-watch-<name> relative to Jest.
- * 1. looks for <name> relative to project.
+ * 1. looks for jest-watch-<name> relative to project.
  * 1. looks for <name> relative to Jest.
+ * 1. looks for <name> relative to project.
+ *
+ * For file paths (relative/absolute):
+ * 1. looks for jest-watch-<name> relative to project.
+ * 1. looks for <name> relative to project.
  */
 export const resolveWatchPlugin = (
   resolver: string | undefined | null,
@@ -154,10 +183,15 @@ export const resolveWatchPlugin = (
 /**
  * Finds the runner to use:
  *
- * 1. looks for jest-runner-<name> relative to project.
+ * For package names:
  * 1. looks for jest-runner-<name> relative to Jest.
- * 1. looks for <name> relative to project.
+ * 1. looks for jest-runner-<name> relative to project.
  * 1. looks for <name> relative to Jest.
+ * 1. looks for <name> relative to project.
+ *
+ * For file paths (relative/absolute):
+ * 1. looks for jest-runner-<name> relative to project.
+ * 1. looks for <name> relative to project.
  */
 export const resolveRunner = (
   resolver: string | undefined | null,


### PR DESCRIPTION
## Summary

Fixes #5913.

`resolveWithPrefix()` in `jest-resolve` resolves environments, runners, sequencers, and watch plugins by trying `rootDir` first, then Jest's own install location. When a 3rd-party package hoists Jest's dependencies (e.g. `jest-environment-node`) to the project root `node_modules`, Jest loads the wrong version.

This PR changes the resolution strategy in `resolveWithPrefix` based on input type:

**Package names** (e.g. `node`, `custom-env`): try `requireResolveFunction` (Jest's own location) first, then fall back to `Resolver.findNodeModule` (project `rootDir`). This way Jest's bundled deps always win, but custom third-party environments/runners/plugins still work as fallback.

**Path-like inputs** (relative `./foo` or absolute `/path/to/env`): resolve from `rootDir` first via `findNodeModule`, then fall back to `requireResolveFunction`. Prefix variants (e.g. `jest-environment-./foo`) are skipped as nonsensical.

### Why this is not a breaking change

The change only affects resolution **order**, not resolution **capability** — all previously resolvable modules still resolve successfully:

- **Custom third-party packages** (e.g. `jest-environment-my-custom`) installed in the project's `node_modules` still resolve via the `rootDir` fallback. They only "lose" if a same-named package also exists at Jest's install location, which would be an unlikely naming collision with Jest's own prefixed packages.
- **Path-like inputs** (`./custom-env.js`, `/absolute/path/env.js`, `<rootDir>/env.js`) continue to resolve from `rootDir` first, preserving existing behavior for project-local file references.
- **Built-in environments/runners** (`node`, `jsdom`, `default`) now consistently resolve to Jest's own bundled version rather than a potentially mismatched hoisted copy, which is the *intended* behavior.

The only scenario affected is when a project's `node_modules` contains a *different version* of a Jest built-in package (e.g. `jest-environment-node`) — previously that version would shadow Jest's own, now Jest's bundled version wins. This is the bug being fixed.

**Changed files:**
- `packages/jest-resolve/src/utils.ts` — split resolution logic for package names vs path-like inputs
- `packages/jest-resolve/src/__tests__/utils.test.ts` — 5 new tests for `resolveTestEnvironment` (Jest-first preference, rootDir fallback, relative path handling, absolute path fallback, error case)
- `packages/jest-config/src/__tests__/normalize.test.ts` — updated behavioral tests to match new resolution priority

## Test plan

```
yarn jest packages/jest-resolve/ --no-coverage
# 66/66 tests pass (61 existing + 5 new)

yarn jest packages/jest-config/src/__tests__/normalize.test.ts --no-coverage
# All behavioral tests pass. 32 snapshot failures are pre-existing chalk formatting issues on main.

yarn lint
yarn lint:prettier
# Both clean
```