### PR TITLE
feat(jest-circus): add test.step() method for test step reporting

### DIFF
--- a/packages/jest-circus/src/index.ts
+++ b/packages/jest-circus/src/index.ts
@@ -9,6 +9,7 @@ import type {Circus, Global} from '@jest/types';
 import {bind as bindEach} from 'jest-each';
 import {ErrorWithStack, convertDescriptorToString, isPromise} from 'jest-util';
 import {dispatchSync} from './state';
+import {stepStorage} from './run';
 
 export {
   setState,
@@ -222,6 +223,27 @@ const test: Global.It = (() => {
       name: 'add_test',
       testName,
       timeout,
+    });
+  };
+
+  test.step = async function step<T>(
+    title: string,
+    body: () => T | Promise<T>,
+  ): Promise<T> {
+    const currentStepPath = stepStorage.getStore();
+    const fullStepPath = currentStepPath
+      ? `${currentStepPath} > ${title}`
+      : title;
+
+    return stepStorage.run(fullStepPath, async () => {
+      try {
+        return await body();
+      } catch (error) {
+        if (error instanceof Error) {
+          error.message = `step "${fullStepPath}": ${error.message}`;
+        }
+        throw error;
+      }
     });
   };
 

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -29,6 +29,7 @@ import {
 const {setTimeout} = globalThis;
 
 const testNameStorage = new AsyncLocalStorage<string>();
+const stepStorage = new AsyncLocalStorage<string | undefined>();
 
 const run = async (): Promise<Circus.RunResult> => {
   const {rootDescribeBlock, seed, randomize} = getState();
@@ -305,4 +306,5 @@ const _callCircusTest = async (
   }
 };
 
+export {stepStorage};
 export default run;

--- a/packages/jest-types/src/Global.ts
+++ b/packages/jest-types/src/Global.ts
@@ -123,6 +123,7 @@ export interface ItBase {
   (testName: TestNameLike, fn: TestFn, timeout?: number): void;
   each: Each<TestFn>;
   failing: Failing<TestFn>;
+  step: <T>(title: string, body: () => T | Promise<T>) => Promise<T>;
 }
 
 export interface It extends ItBase {


### PR DESCRIPTION
## Summary

Adds `test.step()` / `it.step()` method to Jest's circus test runner, similar to Playwright's [test.step](https://playwright.dev/docs/api/class-test#test-step). This allows users to add named steps within a test body for better error reporting.

## Features

- `test.step(title, body)` - wraps a test step with a descriptive name
- Nested steps are supported (displayed as `parent > child` in error messages)
- Errors thrown inside a step include the step path in the error message
- Works with both sync and async callbacks
- Compatible with concurrent tests via AsyncLocalStorage
- TypeScript types included

## Usage

```typescript
it('should log in successfully', async () => {
  await it.step('Navigate to login page', async () => {
    await page.goto('https://example.com/login');
  });

  await it.step('Fill credentials', async () => {
    await page.fill('#username', 'user');
    await page.fill('#password', 'pass');
  });

  await it.step('Submit form', async () => {
    await page.click('#submit');
    await expect(page.locator('.welcome')).toBeVisible();
  });
});
```

If a step fails, the error message includes the step path:
```
step "Fill credentials": expect(received).toBe(expected) // Object.is equality
```

Closes #16027
