### PR TITLE
Normalize .rejects.toThrow

### DIFF
--- a/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/toThrowMatchers.test.ts.snap
@@ -198,13 +198,22 @@ Expected has type:  number
 Expected has value: <g>111</>
 `;
 
-exports[`toThrow promise/async throws if Error-like object is returned did not throw at all 1`] = `
+exports[`toThrow promise/async throws if rejects did not throw at all 1`] = `
 <d>expect(</><r>received</><d>).</>rejects<d>.</>toThrow<d>()</>
 
-Received function did not throw
+Received promise resolved instead of rejected
+Resolved to value: <r>"apple"</>
 `;
 
-exports[`toThrow promise/async throws if Error-like object is returned threw, but class did not match 1`] = `
+exports[`toThrow promise/async throws if rejects rejects with non-Error value, expected substring does not match 1`] = `
+<d>expect(</><r>received</><d>).</>rejects<d>.</>toThrow<d>(</><g>expected</><d>)</>
+
+Expected substring: <g>"banana"</>
+Received value:     <r>"apple"</>
+
+`;
+
+exports[`toThrow promise/async throws if rejects threw, but class did not match 1`] = `
 <d>expect(</><r>received</><d>).</>rejects<d>.</>toThrow<d>(</><g>expected</><d>)</>
 
 Expected constructor: <g>Err2</>
@@ -215,7 +224,7 @@ Received message: <r>"async apple"</>
       <d>at jestExpect (</>packages/expect/src/__tests__/toThrowMatchers-test.js<d>:24:74)</>
 `;
 
-exports[`toThrow promise/async throws if Error-like object is returned threw, but should not have 1`] = `
+exports[`toThrow promise/async throws if rejects threw, but should not have 1`] = `
 <d>expect(</><r>received</><d>).</>rejects<d>.</>not<d>.</>toThrow<d>()</>
 
 Error name:    <r>"Error"</>

--- a/packages/expect/src/__tests__/toThrowMatchers.test.ts
+++ b/packages/expect/src/__tests__/toThrowMatchers.test.ts
@@ -571,7 +571,7 @@ describe('toThrow', () => {
     });
   });
 
-  describe('promise/async throws if Error-like object is returned', () => {
+  describe('promise/async throws if rejects', () => {
     const asyncFn = async (shouldThrow?: boolean, resolve?: boolean) => {
       let err;
       if (shouldThrow) {
@@ -607,10 +607,10 @@ describe('toThrow', () => {
       await jestExpect(asyncFn(false, true)).resolves.not.toThrow('banana');
       await jestExpect(asyncFn(false, true)).resolves.not.toThrow(/banana/);
 
-      await jestExpect(asyncFn()).rejects.not.toThrow();
+      await jestExpect(asyncFn()).rejects.toThrow();
       await jestExpect(asyncFn()).rejects.not.toThrow(Error);
-      await jestExpect(asyncFn()).rejects.not.toThrow('apple');
-      await jestExpect(asyncFn()).rejects.not.toThrow(/apple/);
+      await jestExpect(asyncFn()).rejects.toThrow('apple');
+      await jestExpect(asyncFn()).rejects.toThrow(/apple/);
       await jestExpect(asyncFn()).rejects.not.toThrow('banana');
       await jestExpect(asyncFn()).rejects.not.toThrow(/banana/);
 
@@ -625,7 +625,7 @@ describe('toThrow', () => {
 
     test('did not throw at all', async () => {
       await expect(
-        jestExpect(asyncFn()).rejects.toThrow(),
+        jestExpect(asyncFn(false, true)).rejects.toThrow(),
       ).rejects.toThrowErrorMatchingSnapshot();
     });
 
@@ -638,6 +638,12 @@ describe('toThrow', () => {
     test('threw, but should not have', async () => {
       await expect(
         jestExpect(asyncFn(true)).rejects.not.toThrow(),
+      ).rejects.toThrowErrorMatchingSnapshot();
+    });
+
+    test('rejects with non-Error value, expected substring does not match', async () => {
+      await expect(
+        jestExpect(Promise.reject('apple')).rejects.toThrow('banana'),
       ).rejects.toThrowErrorMatchingSnapshot();
     });
   });

--- a/packages/expect/src/toThrowMatchers.ts
+++ b/packages/expect/src/toThrowMatchers.ts
@@ -87,27 +87,28 @@ export const createMatcher = (
 
     let thrown = null;
 
-    if (fromPromise && isError(received)) {
-      thrown = getThrown(received);
-    } else {
-      if (typeof received === 'function') {
-        try {
-          received();
-        } catch (error) {
-          thrown = getThrown(error);
-        }
-      } else {
-        if (!fromPromise) {
-          const placeholder = expected === undefined ? '' : 'expected';
-          throw new Error(
-            matcherErrorMessage(
-              matcherHint(matcherName, undefined, placeholder, options),
-              `${RECEIVED_COLOR('received')} value must be a function`,
-              printWithType('Received', received, printReceived),
-            ),
-          );
-        }
+    if (typeof received === 'function') {
+      try {
+        received();
+      } catch (error) {
+        thrown = getThrown(error);
       }
+    } else if (fromPromise) {
+      // Treating a Promise.resolve(err) as "throws" is unusual but matches with
+      // previous versions of Jest.
+      thrown =
+        this.promise === 'rejects' || isError(received)
+          ? getThrown(received)
+          : null;
+    } else {
+      const placeholder = expected === undefined ? '' : 'expected';
+      throw new Error(
+        matcherErrorMessage(
+          matcherHint(matcherName, undefined, placeholder, options),
+          `${RECEIVED_COLOR('received')} value must be a function`,
+          printWithType('Received', received, printReceived),
+        ),
+      );
     }
 
     if (expected === undefined) {


### PR DESCRIPTION
## Summary

`.rejects.toThrow` is inconsistent with `.toThrow`: `.toThrow` will accept any string or anything with a `message`, while `.rejects.toThrow` only accepts Error objects.

Besides the general inconsistency, this causes a couple of specific issues:

* It fails with `Error` objects from other realms (which can happen to with native modules across Jest's vm realms). (See https://github.com/jestjs/jest/blob/v30.4.2/packages/expect-utils/src/utils.ts#L559 and [`Error.isError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError).)
* Because of the toThrowMatchers implementation, if a non-Error is rejected, it will be treated as if nothing was thrown, resulting in a very confusing error message ("Received function did not throw").

This has been reported a few times: #12024, #9748, #6675. See also the original implementation at #5670.

Specific notes:

- The linked GitHub issues discuss whether "throws" is even the appropriate term for promises. Intuitively, I would expect "rejects" to be equivalent to "throws from an async function," so I would expect Jest's `.rejects.toThrow` to be implemented accordingly.
- As a result of Jest's previous implementation, code like `expect(Promise.resolve(new Error('apple'))).resolves.toThrow('apple')` passes. This does not match my intuition, but I'm preserving it for backward compatibility.
- Previous versions of Jest unwrap functions within promises: `expect(Promise.reject(() => { throw new Error('apple'); })).rejects.toThrow('apple')` passes. This is unusual, but I'm preserving it for backward compatibility.

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Test plan

```
yarn test
```

**Note**: I have not yet updated the changelog, because I'm not certain if this should be classified as a feature or a fix.