### PR TITLE
Add support for Error.isError to Jest expect-utils

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixes
 
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
+- `[expect-utils]` Support using [`Error.isError`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError) to handle cross-realm error objects
 
 ### Chore & Maintenance
 

--- a/packages/expect-utils/src/__tests__/utils.test.ts
+++ b/packages/expect-utils/src/__tests__/utils.test.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import {onNodeVersions} from '@jest/test-utils';
 import {List, OrderedMap, OrderedSet, Record} from 'immutable';
 import {stringify} from 'jest-matcher-utils';
 import {createContext, runInContext} from 'vm';
@@ -15,6 +16,7 @@ import {
   emptyObject,
   getObjectSubset,
   getPath,
+  isError,
   iterableEquality,
   subsetEquality,
   typeEquality,
@@ -813,6 +815,31 @@ describe('arrayBufferEquality', () => {
     const a = new URL('https://jestjs.io/docs/getting-started');
     const b = new URL('https://jestjs.io/docs/getting-started#using-babel');
     expect(equals(a, b)).toBe(false);
+  });
+});
+
+describe('isError', () => {
+  it('returns true for Error instances', () => {
+    expect(isError(new Error('error'))).toBe(true);
+  });
+
+  it('returns false for non-errors instances', () => {
+    expect(isError(new Error('error'))).toBe(true);
+  });
+
+  onNodeVersions('>=24.3.0', () => {
+    it('handles cross-realm errors', () => {
+      const context = createContext({});
+      const otherRealmError = runInContext(
+        `new class CustomError extends Error {
+          get [Symbol.toStringTag]() {
+            return "CustomError";
+          }
+        }`,
+        context,
+      );
+      expect(isError(otherRealmError)).toBe(true);
+    });
   });
 });
 

--- a/packages/expect-utils/src/jasmineUtils.ts
+++ b/packages/expect-utils/src/jasmineUtils.ts
@@ -23,6 +23,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
 import type {Tester, TesterContext} from './types';
+import {isError} from './utils';
 
 export type EqualsFunction = (
   a: unknown,
@@ -83,7 +84,7 @@ function eq(
     }
   }
 
-  if (a instanceof Error && b instanceof Error) {
+  if (isError(a) && isError(b)) {
     return a.message === b.message;
   }
 

--- a/packages/expect-utils/src/utils.ts
+++ b/packages/expect-utils/src/utils.ts
@@ -563,7 +563,11 @@ export const isError = (value: unknown): value is Error => {
     case '[object DOMException]':
       return true;
     default:
-      return value instanceof Error;
+      return (
+        value instanceof Error ||
+        (typeof (Error as any).isError === 'function' &&
+          (Error as any).isError(value))
+      );
   }
 };
 

--- a/packages/expect/src/toThrowMatchers.ts
+++ b/packages/expect/src/toThrowMatchers.ts
@@ -229,7 +229,7 @@ const toThrowExpectedObject = (
   const expectedMessageAndCause = createMessageAndCause(expected);
   const thrownMessageAndCause =
     thrown === null ? null : createMessageAndCause(thrown.value);
-  const isCompareErrorInstance = thrown?.isError && expected instanceof Error;
+  const isCompareErrorInstance = thrown?.isError && isError(expected);
   const isExpectedCustomErrorInstance =
     expected.constructor.name !== Error.name;
 


### PR DESCRIPTION

<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

This improves Jest's ability to handle cross-realm error objects. See https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/isError.

## Test plan

```
yarn test
```