### PR TITLE
Make @types/jsdom a peer dependency of jest-environment-jsdom-abstract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ### Fixes
 
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
-- `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 - `[jest-environment-jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
+- `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Fixes
 
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
-- `[jest-environment-jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
+- `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 
 ### Chore & Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
+- `[jest-environment-jsdom-abstract]` Make @types/jsdom a peer dependency with a lax version constraint.
+- `[jest-environment-jsdom]` @types/jsdom is now a dependency.
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
-- `[jest-environment-jsdom-abstract]` Make @types/jsdom a peer dependency with a lax version constraint.
-- `[jest-environment-jsdom]` @types/jsdom is now a dependency.
+- `[jest-environment-jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
 
 ### Chore & Maintenance
 

--- a/packages/jest-environment-jsdom-abstract/package.json
+++ b/packages/jest-environment-jsdom-abstract/package.json
@@ -22,16 +22,17 @@
     "@jest/environment": "workspace:*",
     "@jest/fake-timers": "workspace:*",
     "@jest/types": "workspace:*",
-    "@types/jsdom": "^21.1.7",
     "@types/node": "*",
     "jest-mock": "workspace:*",
     "jest-util": "workspace:*"
   },
   "devDependencies": {
     "@jest/test-utils": "workspace:*",
+    "@types/jsdom": "^21.1.7",
     "jsdom": "^26.1.0"
   },
   "peerDependencies": {
+    "@types/jsdom": "*",
     "canvas": "^3.0.0",
     "jsdom": "*"
   },

--- a/packages/jest-environment-jsdom/package.json
+++ b/packages/jest-environment-jsdom/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@jest/environment": "workspace:*",
     "@jest/environment-jsdom-abstract": "workspace:*",
+    "@types/jsdom": "^21.1.7",
     "jsdom": "^26.1.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4333,6 +4333,7 @@ __metadata:
     jest-util: "workspace:*"
     jsdom: "npm:^26.1.0"
   peerDependencies:
+    "@types/jsdom": "*"
     canvas: ^3.0.0
     jsdom: "*"
   peerDependenciesMeta:
@@ -14473,6 +14474,7 @@ __metadata:
     "@jest/environment": "workspace:*"
     "@jest/environment-jsdom-abstract": "workspace:*"
     "@jest/test-utils": "workspace:*"
+    "@types/jsdom": "npm:^21.1.7"
     jsdom: "npm:^26.1.0"
   peerDependencies:
     canvas: ^3.0.0


### PR DESCRIPTION
## Summary

Consumers of jest-environment-jsdom-abstract can now provide the type package version that matches their installed jsdom version. Just like the jsdom peer dependency, this uses a star to allow consumers to pick their precise version.

As a use case, @types/jsdom recently released a new version and even though I updated this package within my project,
jest-environment-jsdom-abstract continues to reference the older version.

## Test plan

CI test suite. Run the code in my local projects.