### PR TITLE
fix(expect): revert `node:` protocol imports to restore webpack/browser compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 
+- `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16161](https://github.com/jestjs/jest/issues/16161))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 
 ### Chore & Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16161](https://github.com/jestjs/jest/issues/16161))
+- `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 
 ### Chore & Maintenance

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -613,6 +613,17 @@ const config = defineConfig(
     },
   },
   {
+    files: [
+      'packages/jest-message-util/src/**/*',
+      'packages/jest-pattern/src/**/*',
+      'packages/jest-regex-util/src/**/*',
+      'packages/jest-util/src/**/*',
+    ],
+    rules: {
+      'unicorn/prefer-node-protocol': 'off',
+    },
+  },
+  {
     files: ['packages/**/*.ts'],
     rules: {
       '@typescript-eslint/explicit-module-boundary-types': 'error',

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as path from 'node:path';
-import {fileURLToPath} from 'node:url';
+import * as path from 'path';
+import {fileURLToPath} from 'url';
 import {codeFrameColumns} from '@babel/code-frame';
 import chalk from 'chalk';
 import * as fs from 'graceful-fs';

--- a/packages/jest-pattern/src/TestPathPatterns.ts
+++ b/packages/jest-pattern/src/TestPathPatterns.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as path from 'node:path';
+import * as path from 'path';
 import {replacePathSepForRegex} from 'jest-regex-util';
 
 export class TestPathPatterns {

--- a/packages/jest-regex-util/src/index.ts
+++ b/packages/jest-regex-util/src/index.ts
@@ -6,7 +6,7 @@
  *
  */
 
-import {sep} from 'node:path';
+import {sep} from 'path';
 
 export const escapePathForRegex = (dir: string): string => {
   if (sep === '\\') {

--- a/packages/jest-util/src/clearLine.ts
+++ b/packages/jest-util/src/clearLine.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {WriteStream} from 'node:tty';
+import type {WriteStream} from 'tty';
 
 export default function clearLine(stream: WriteStream): void {
   if (stream.isTTY) {

--- a/packages/jest-util/src/createProcessObject.ts
+++ b/packages/jest-util/src/createProcessObject.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type * as Process from 'node:process';
+import type * as Process from 'process';
 import deepCyclicCopy from './deepCyclicCopy';
 
 const BLACKLIST = new Set(['env', 'mainModule', '_events']);
@@ -81,7 +81,7 @@ function createProcessEnv(): NodeJS.ProcessEnv {
 }
 
 export default function createProcessObject(): typeof Process {
-  const process = require('node:process');
+  const process = require('process');
   const newProcess = deepCyclicCopy(process, {
     blacklist: BLACKLIST,
     keepPrototype: true,

--- a/packages/jest-util/src/isError.ts
+++ b/packages/jest-util/src/isError.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {isNativeError} from 'node:util/types';
+import {isNativeError} from 'util/types';
 
 export const isError =
   typeof Error.isError === 'function' ? Error.isError : isNativeError;

--- a/packages/jest-util/src/preRunMessage.ts
+++ b/packages/jest-util/src/preRunMessage.ts
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {WriteStream} from 'node:tty';
+import type {WriteStream} from 'tty';
 import chalk from 'chalk';
 import clearLine from './clearLine';
 import isInteractive from './isInteractive';

--- a/packages/jest-util/src/requireOrImportModule.ts
+++ b/packages/jest-util/src/requireOrImportModule.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {isAbsolute} from 'node:path';
-import {pathToFileURL} from 'node:url';
+import {isAbsolute} from 'path';
+import {pathToFileURL} from 'url';
 import interopRequireDefault from './interopRequireDefault';
 
 async function importModule(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

PR #16077 introduced the `unicorn/prefer-node-protocol` rule which changed bare specifiers (e.g. `'path'`) to use the `node:` prefix (e.g. `'node:path'`) across the codebase. While functionally identical in Node.js, the `node:` URI scheme is not recognized by webpack, breaking the `expect` package when used in browser-bundled environments like Cypress or Playwright.

  This reverts the `node:` prefix in the packages that are transitive runtime dependencies of `expect` (`jest-util`, `jest-message-util`, `jest-pattern`, `jest-regex-util`), and disables the `unicorn/prefer-node-protocol` ESLint rule for those packages to prevent the regression from being reintroduced.

[  Fixes #16161](https://github.com/jestjs/jest/issues/16161)

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

 1. yarn build:js
 2. yarn jest packages/jest-util/src/__tests__/ packages/jest-message-util/ packages/jest-pattern/ packages/jest-regex-util/
 3. yarn eslint packages/jest-util/src/ packages/jest-message-util/src/ packages/jest-pattern/src/ packages/jest-regex-util/src/ eslint.config.mjs
 4. Confirmed no `node:` prefix remains in built output:
     grep -r "node:" packages/jest-util/build/ packages/jest-message-util/build/ packages/jest-pattern/build/ packages/jest-regex-util/build/ (no output)
