### PR TITLE
fix(jest-util): prevent infinite recursion when writing to soft-deleted data property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixes
 
+- `[jest-util]` Fix infinite recursion (`RangeError: Maximum call stack size exceeded`) when writing to a data property soft-deleted by `globalsCleanup: 'soft'` ([#16044](https://github.com/jestjs/jest/issues/16044))
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Fixes
 
-- `[jest-util]` Fix infinite recursion (`RangeError: Maximum call stack size exceeded`) when writing to a data property soft-deleted by `globalsCleanup: 'soft'` ([#16044](https://github.com/jestjs/jest/issues/16044))
+- `[jest-util]` Fix infinite recursion (`RangeError: Maximum call stack size exceeded`) when writing to a data property soft-deleted by `globalsCleanup: 'soft'` ([#16175](https://github.com/jestjs/jest/pull/16175))
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 

--- a/packages/jest-util/src/__tests__/garbage-collection-utils.test.ts
+++ b/packages/jest-util/src/__tests__/garbage-collection-utils.test.ts
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {protectProperties} from '../garbage-collection-utils';
+import {deleteProperties, protectProperties} from '../garbage-collection-utils';
 
 const omit = require('lodash').omit;
+
+const DELETION_MODE_SYMBOL = Symbol.for('$$jest-deletion-mode');
 
 it('protection symbol doesnt leak', () => {
   const obj = {a: 1, b: 2};
@@ -15,4 +17,32 @@ it('protection symbol doesnt leak', () => {
   expect(obj).toStrictEqual(obj);
   expect(omit(obj, 'a')).toStrictEqual({b: 2});
   expect({b: 2}).toStrictEqual(omit(obj, 'a'));
+});
+
+describe('soft deletion of data properties', () => {
+  let originalMode: unknown;
+
+  beforeEach(() => {
+    originalMode = Reflect.get(globalThis, DELETION_MODE_SYMBOL);
+    Reflect.set(globalThis, DELETION_MODE_SYMBOL, 'soft');
+  });
+
+  afterEach(() => {
+    Reflect.set(globalThis, DELETION_MODE_SYMBOL, originalMode);
+  });
+
+  it('does not recurse infinitely when writing to a soft-deleted data property', () => {
+    const obj: {foo: string} = {foo: 'bar'};
+    deleteProperties(obj);
+    expect(() => {
+      obj.foo = 'baz';
+    }).not.toThrow();
+  });
+
+  it('reflects the updated value after writing to a soft-deleted data property', () => {
+    const obj: {foo: string} = {foo: 'bar'};
+    deleteProperties(obj);
+    obj.foo = 'baz';
+    expect(obj.foo).toBe('baz');
+  });
 });

--- a/packages/jest-util/src/garbage-collection-utils.ts
+++ b/packages/jest-util/src/garbage-collection-utils.ts
@@ -161,9 +161,13 @@ function deleteProperty(obj: object, key: string | symbol): boolean {
     return Reflect.deleteProperty(obj, key);
   }
 
-  const originalGetter = descriptor.get ?? (() => descriptor.value);
+  let storedValue = descriptor.value;
+  const originalGetter = descriptor.get ?? (() => storedValue);
   const originalSetter =
-    descriptor.set ?? (value => Reflect.set(obj, key, value));
+    descriptor.set ??
+    (value => {
+      storedValue = value;
+    });
 
   return Reflect.defineProperty(obj, key, {
     configurable: true,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Fixes #16044.

When globalsCleanup: 'soft' is enabled, Jest replaces globals set between test files with accessor properties that emit a deprecation warning on access. For data properties the fallback setter was:

`descriptor.set ?? (value => Reflect.set(obj, key, value))`

After the property is redefined as an accessor, Reflect.set re-invokes that same setter → infinite recursion → RangeError: Maximum call stack size exceeded. Any project using globalsCleanup: 'soft' that re-assigns a global from a previous test file would hit this.

The fix introduces a closure variable (storedValue) that the getter reads from and the setter writes to directly, with no Reflect.set involved:

```
  let storedValue = descriptor.value;
  const originalGetter = descriptor.get ?? (() => storedValue);
  const originalSetter = descriptor.set ?? (value => { storedValue = value; });
```

This also fixes a secondary issue where the getter would always return the value captured at deletion time even after a successful write.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Two new tests added to packages/jest-util/src/__tests__/garbage-collection-utils.test.ts:

`yarn jest packages/jest-util/src/__tests__/garbage-collection-utils.test.ts`
  
Tests: 3 passed, 3 total

- "does not recurse infinitely when writing to a soft-deleted data property" — would have thrown RangeError before the fix
- "reflects the updated value after writing to a soft-deleted data property" — verifies the written value is readable back after the write
