### PR TITLE
docs: add docusaurus-plugin-copy-page-button

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -153,6 +153,7 @@ const config = {
         ],
       }),
     ],
+    'docusaurus-plugin-copy-page-button',
   ],
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */

--- a/website/package.json
+++ b/website/package.json
@@ -36,6 +36,7 @@
     "@docusaurus/preset-classic": "^3.0.0",
     "@docusaurus/remark-plugin-npm2yarn": "^3.0.0",
     "clsx": "^2.1.1",
+    "docusaurus-plugin-copy-page-button": "^0.4.2",
     "docusaurus-remark-plugin-tab-blocks": "^4.0.0",
     "prism-react-renderer": "^2.1.0",
     "react": "18.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10502,6 +10502,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"docusaurus-plugin-copy-page-button@npm:^0.4.2":
+  version: 0.4.2
+  resolution: "docusaurus-plugin-copy-page-button@npm:0.4.2"
+  peerDependencies:
+    "@docusaurus/core": ^3.0.0
+    react: ^18.0.0 || ^19.0.0
+  checksum: 10/e591ff132932e4e2ba028f8b221309a6146d618c005c3fd985e3dffe6f435468d6b88d3ac91f717e46762524451ffc8cef75e1fd6de7ea4692488a3123ebc08b
+  languageName: node
+  linkType: hard
+
 "docusaurus-remark-plugin-tab-blocks@npm:^4.0.0":
   version: 4.0.0
   resolution: "docusaurus-remark-plugin-tab-blocks@npm:4.0.0"
@@ -14953,6 +14963,7 @@ __metadata:
     "@docusaurus/tsconfig": "npm:^3.0.0"
     "@types/react": "npm:^18.3.23"
     clsx: "npm:^2.1.1"
+    docusaurus-plugin-copy-page-button: "npm:^0.4.2"
     docusaurus-remark-plugin-tab-blocks: "npm:^4.0.0"
     graphql: "npm:^16.11.0"
     graphql-request: "npm:^6.1.0"


### PR DESCRIPTION
## What this adds

A "Copy page" button in the docs sidebar that exports the current Jest docs page as clean markdown, with one-click "Open in ChatGPT", "Open in Claude", and "Open in Gemini" actions.

## Why for Jest

When a test fails, the very next step for most devs is pasting the failure and the relevant Jest API into ChatGPT or Claude — matchers, mocks, timers, snapshot semantics. Right now that means selecting around the docs sidebar and search box. With this plugin, it's a single click on the page → clean markdown → "Open in Claude".

The plugin is currently shipping on Ethereum execution-apis, Sui (Mysten Labs), Walrus, Seal, SuiNS, Monad, Flare, Kaia, Nillion, Chronicle, and Cardano docs. It's also listed in the [official Docusaurus community plugins](https://docusaurus.io/community/resources#plugins).

## Changes

- Adds `docusaurus-plugin-copy-page-button` to `dependencies` in `website/package.json` (^0.4.2, alphabetical)
- Appends the plugin string to the `plugins` array in `website/docusaurus.config.js`

The button auto-injects into the table-of-contents sidebar. No further config required, theme-aware, mobile-friendly, ~5kb client.

## Links

- Live demo: https://portdeveloper.github.io/copy-page-button-showcase/
- Plugin repo: https://github.com/portdeveloper/docusaurus-plugin-copy-page-button
- npm: https://www.npmjs.com/package/docusaurus-plugin-copy-page-button

Happy to revert or adjust if this doesn't fit the project's direction.