### PR TITLE
docs: fix "setup" used as a verb (should be "set up")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Chore & Maintenance
 
+- `[docs]` Fix `setup` used as a verb in Getting Started and TypeScript examples note (should be `set up`)
 - `[jest-haste-map]` Refactor massive class into multiple files ([#16180](https://github.com/jestjs/jest/pull/16180))
 - `[jest-runtime]` Avoid magical `null` value in ESM loader ([#16160](https://github.com/jestjs/jest/pull/16160))
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -92,7 +92,7 @@ The ideal configuration for Babel will depend on your project. See [Babel's docs
 <details>
   <summary markdown="span"><strong>Making your Babel config jest-aware</strong></summary>
 
-Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally setup only the compilation needed for Jest, e.g.
+Jest will set `process.env.NODE_ENV` to `'test'` if it's not set to something else. You can use that in your configuration to conditionally set up only the compilation needed for Jest, e.g.
 
 ```javascript title="babel.config.js"
 module.exports = api => {

--- a/docs/_TypeScriptExamplesNote.md
+++ b/docs/_TypeScriptExamplesNote.md
@@ -6,6 +6,6 @@ The TypeScript examples from this page will only work as documented if you expli
 import {expect, jest, test} from '@jest/globals';
 ```
 
-Consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to setup Jest with TypeScript.
+Consult the [Getting Started](GettingStarted.md#using-typescript) guide for details on how to set up Jest with TypeScript.
 
 :::


### PR DESCRIPTION
## Summary

Two small wording fixes in the docs where `setup` (a noun) is used as a verb. The verb form is `set up` (two words).

- `docs/GettingStarted.md` — "to conditionally **setup** only the compilation needed for Jest" → "to conditionally **set up** ..."
- `docs/_TypeScriptExamplesNote.md` — "details on how to **setup** Jest with TypeScript" → "details on how to **set up** ..."

Also added a `[docs]` line under **Chore & Maintenance** in `CHANGELOG.md`.

## Test plan

Text-only change. No code paths, examples, or anchors are affected. Verified the only call sites of the previous wording are the two edited.