### PR TITLE
feat: add `jest.hoisted` API for hoisting variables alongside jest.mock factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[@jest/expect-utils, jest-mock]` Add `mockFn.whenCalledWith(...args)` for configuring return values per argument list, with first-class asymmetric-matcher support ([#16053](https://github.com/jestjs/jest/pull/16053))
 - `[@jest/expect-utils]` Export `AsymmetricMatcher` and `FunctionParameters` types (previously private to `expect`) ([#16053](https://github.com/jestjs/jest/pull/16053))
+- `[babel-plugin-jest-hoist, jest-environment, jest-runtime]` Add `jest.hoisted(factory)` API for declaring variables that are hoisted alongside `jest.mock` factories ([#16201](https://github.com/jestjs/jest/pull/16201))
 - `[jest-resolve]` Bump `unrs-resolver` to 1.12.1, remove `jest-pnp-resolver` and unnecessary checks ([#15721](https://github.com/jestjs/jest/pull/15721))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[@jest/expect-utils, jest-mock]` Add `mockFn.whenCalledWith(...args)` for configuring return values per argument list, with first-class asymmetric-matcher support ([#16053](https://github.com/jestjs/jest/pull/16053))
 - `[@jest/expect-utils]` Export `AsymmetricMatcher` and `FunctionParameters` types (previously private to `expect`) ([#16053](https://github.com/jestjs/jest/pull/16053))
+- `[babel-plugin-jest-hoist, jest-environment, jest-runtime]` Add `jest.hoisted(factory)` API for declaring variables that are hoisted alongside `jest.mock` factories ([#16201](https://github.com/jestjs/jest/pull/16201))
 - `[jest-circus, jest-core, jest-jasmine2, jest-test-result, jest-types]` `--collectTests` now expands `test.each`/`describe.each` cases and reports per-status counts (skipped/todo via the new `wouldRun` flag for selected tests) plus a summary line that match a real run, including under `--testNamePattern` and `.only`/`fdescribe` focus on both the circus and jasmine2 runners ([#16259](https://github.com/jestjs/jest/pull/16259))
 - `[jest-circus, jest-environment, jest-runtime, jest-types]` Add describe-level retries via `jest.retryTimes(..., {entireDescribe: true})` ([#16322](https://github.com/jestjs/jest/pull/16322))
 - `[jest-circus, jest-message-util, jest-reporters, jest-types]` Add `retryMessages` to `AssertionResult` and export `formatErrorStack`, so the retry log renders nested `cause` and `AggregateError` sections with code frames instead of serialized `[cause]:`/`[errors]:` markers ([#16316](https://github.com/jestjs/jest/pull/16316))

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -348,6 +348,35 @@ Writing tests in TypeScript? Use the [`jest.Mocked`](MockFunctionAPI.md#jestmock
 
 :::
 
+### `jest.hoisted(factory)`
+
+Declares variables that need to be available before any `jest.mock` factory runs. Calls to `jest.hoisted` (and the declarations that consume their return value) are hoisted to the top of the file, alongside `jest.mock` calls, so the values they produce can be safely referenced from `jest.mock` factories.
+
+This is the recommended escape hatch when the `mock`-prefixed naming convention is not enough — for example when you want to share a single mock implementation between the factory and the test body.
+
+```js
+import {jest} from '@jest/globals';
+import {fetchUser} from '../user';
+
+const {mockGet} = jest.hoisted(() => ({mockGet: jest.fn()}));
+
+jest.mock('../api', () => ({getUser: mockGet}));
+
+test('fetchUser delegates to api.getUser', () => {
+  mockGet.mockReturnValue({id: 1, name: 'Alice'});
+  expect(fetchUser(1)).toEqual({id: 1, name: 'Alice'});
+  expect(mockGet).toHaveBeenCalledWith(1);
+});
+```
+
+The factory may be assigned to `const`, `let`, or `var`, destructured, or called as a bare statement for side effects. Because the call runs before any `import` is initialized, the factory **cannot reference imported bindings or any other file-local variables declared later in the file**. Globals (including `globalThis` and built-ins like `Map`, `Promise`), `require` in CommonJS, and `jest` itself remain available.
+
+:::caution
+
+`jest.hoisted` must be called at the top level of the file. Calling it inside a block, function, or other nested scope throws a `ReferenceError` at transform time. The factory argument must be an inline function literal.
+
+:::
+
 ### `jest.Mocked<Source>`
 
 See [TypeScript Usage](MockFunctionAPI.md#jestmockedsource) chapter of Mock Functions page for documentation.

--- a/e2e/__tests__/babelPluginJestHoist.test.ts
+++ b/e2e/__tests__/babelPluginJestHoist.test.ts
@@ -18,5 +18,5 @@ beforeEach(() => {
 it('successfully runs the tests inside `babel-plugin-jest-hoist/`', () => {
   const {json} = runWithJson(DIR, ['--no-cache', '--coverage']);
   expect(json.success).toBe(true);
-  expect(json.numTotalTestSuites).toBe(4);
+  expect(json.numTotalTestSuites).toBe(6);
 });

--- a/e2e/babel-plugin-jest-hoist/__test_modules__/relyOnHoisted.js
+++ b/e2e/babel-plugin-jest-hoist/__test_modules__/relyOnHoisted.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Captured at module-init time. If `jest.hoisted` does NOT hoist its
+// factory above this import, the value will be `undefined`.
+export const observedAtImport = globalThis.__jestHoistedValue__;

--- a/e2e/babel-plugin-jest-hoist/__tests__/hoisted.test.js
+++ b/e2e/babel-plugin-jest-hoist/__tests__/hoisted.test.js
@@ -1,0 +1,30 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {jest} from '@jest/globals';
+import a from '../__test_modules__/a';
+
+const {hoistedFn, hoistedConst} = jest.hoisted(() => ({
+  hoistedConst: 42,
+  hoistedFn: jest.fn(() => 'from-hoisted'),
+}));
+
+jest.mock('../__test_modules__/a', () => ({
+  __esModule: true,
+  default: hoistedFn,
+  hoistedConst,
+}));
+
+test('jest.hoisted variables visible to jest.mock factory', () => {
+  expect(a()).toBe('from-hoisted');
+  expect(hoistedFn).toHaveBeenCalledTimes(1);
+});
+
+test('jest.hoisted returns the factory value verbatim', () => {
+  expect(hoistedConst).toBe(42);
+});

--- a/e2e/babel-plugin-jest-hoist/__tests__/hoistedOrdering.test.js
+++ b/e2e/babel-plugin-jest-hoist/__tests__/hoistedOrdering.test.js
@@ -1,0 +1,27 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ */
+
+import {jest} from '@jest/globals';
+import {observedAtImport} from '../__test_modules__/relyOnHoisted';
+
+const hoistedValue = jest.hoisted(() => {
+  globalThis.__jestHoistedValue__ = 'set-by-hoisted-factory';
+  return 'set-by-hoisted-factory';
+});
+
+afterAll(() => {
+  delete globalThis.__jestHoistedValue__;
+});
+
+test('jest.hoisted factory runs before module imports are initialized', () => {
+  // If the `jest.hoisted` call were not hoisted above the import, the
+  // module-init read of `globalThis.__jestHoistedValue__` would have
+  // observed `undefined`.
+  expect(observedAtImport).toBe('set-by-hoisted-factory');
+  expect(hoistedValue).toBe(observedAtImport);
+});

--- a/packages/babel-plugin-jest-hoist/README.md
+++ b/packages/babel-plugin-jest-hoist/README.md
@@ -1,6 +1,6 @@
 # babel-plugin-jest-hoist
 
-Babel plugin to hoist `jest.disableAutomock`, `jest.enableAutomock`, `jest.unmock`, `jest.mock`, calls above `import` statements. This plugin is automatically included when using [babel-jest](https://github.com/jestjs/jest/tree/main/packages/babel-jest).
+Babel plugin to hoist `jest.disableAutomock`, `jest.enableAutomock`, `jest.unmock`, `jest.mock`, and `jest.hoisted` calls above `import` statements. This plugin is automatically included when using [babel-jest](https://github.com/jestjs/jest/tree/main/packages/babel-jest).
 
 ## Installation
 

--- a/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.nodejs18.test.ts.snap
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.nodejs18.test.ts.snap
@@ -286,3 +286,233 @@ function _getJestObj() {
 }
 
 `;
+
+exports[`babel 7 babel-plugin-jest-hoist 13. jest.hoisted const factory: 13. jest.hoisted const factory 1`] = `
+
+const {mockGet} = jest.hoisted(() => ({mockGet: jest.fn()}));
+
+jest.mock('./api', () => ({get: mockGet}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const {mockGet} = _getJestObj().hoisted(() => ({
+  mockGet: _getJestObj().fn(),
+}));
+_getJestObj().mock('./api', () => ({
+  get: mockGet,
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 14. jest.hoisted let factory: 14. jest.hoisted let factory 1`] = `
+
+let label = jest.hoisted(() => 'hoisted-label');
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+let label = _getJestObj().hoisted(() => 'hoisted-label');
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 15. jest.hoisted var factory: 15. jest.hoisted var factory 1`] = `
+
+var label = jest.hoisted(() => 'hoisted-label');
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var label = _getJestObj().hoisted(() => 'hoisted-label');
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 16. jest.hoisted multi declarators preserves whole statement: 16. jest.hoisted multi declarators preserves whole statement 1`] = `
+
+const a = jest.hoisted(() => 1),
+  b = 2;
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const a = _getJestObj().hoisted(() => 1),
+  b = 2;
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 17. jest.hoisted bare call hoists like jest.mock: 17. jest.hoisted bare call hoists like jest.mock 1`] = `
+
+require('x');
+jest.hoisted(() => (globalThis.__seeded__ = true));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().hoisted(() => (globalThis.__seeded__ = true));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+require('x');
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 18. jest.hoisted bare call rewrites jest refs in factory: 18. jest.hoisted bare call rewrites jest refs in factory 1`] = `
+
+require('x');
+jest.hoisted(() => {
+  globalThis.__fn__ = jest.fn();
+});
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().hoisted(() => {
+  globalThis.__fn__ = _getJestObj().fn();
+});
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+require('x');
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 19. jest.hoisted rewrites jest refs in factory body: 19. jest.hoisted rewrites jest refs in factory body 1`] = `
+
+const {mockFn} = jest.hoisted(() => ({mockFn: jest.fn()}));
+jest.mock('./api', () => ({get: mockFn}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const {mockFn} = _getJestObj().hoisted(() => ({
+  mockFn: _getJestObj().fn(),
+}));
+_getJestObj().mock('./api', () => ({
+  get: mockFn,
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 23. jest.hoisted preserves relative order of multiple declarations: 23. jest.hoisted preserves relative order of multiple declarations 1`] = `
+
+require('x');
+const a = jest.hoisted(() => 1);
+const b = jest.hoisted(() => 2);
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const a = _getJestObj().hoisted(() => 1);
+const b = _getJestObj().hoisted(() => 2);
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+require('x');
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 24. jest.hoisted with destructuring: 24. jest.hoisted with destructuring 1`] = `
+
+const {one, two} = jest.hoisted(() => ({one: 1, two: 2}));
+jest.mock('./api', () => ({one, two}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const {one, two} = _getJestObj().hoisted(() => ({
+  one: 1,
+  two: 2,
+}));
+_getJestObj().mock('./api', () => ({
+  one,
+  two,
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 25. jest.mock can reference jest.hoisted binding declared later in file: 25. jest.mock can reference jest.hoisted binding declared later in file 1`] = `
+
+jest.mock('./api', () => ({get: mockGet}));
+
+const {mockGet} = jest.hoisted(() => ({mockGet: jest.fn()}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().mock('./api', () => ({
+  get: mockGet,
+}));
+const {mockGet} = _getJestObj().hoisted(() => ({
+  mockGet: _getJestObj().fn(),
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 29. jest.hoisted and jest.mock preserve source order when interleaved: 29. jest.hoisted and jest.mock preserve source order when interleaved 1`] = `
+
+require('x');
+jest.hoisted(() => (globalThis.__a__ = 1));
+jest.mock('./first', () => ({value: 'first'}));
+jest.hoisted(() => (globalThis.__b__ = 2));
+jest.mock('./second', () => ({value: 'second'}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().hoisted(() => (globalThis.__a__ = 1));
+_getJestObj().mock('./first', () => ({
+  value: 'first',
+}));
+_getJestObj().hoisted(() => (globalThis.__b__ = 2));
+_getJestObj().mock('./second', () => ({
+  value: 'second',
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+require('x');
+
+`;

--- a/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.nodejs20plus.test.ts.snap
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/__snapshots__/hoistPlugin.nodejs20plus.test.ts.snap
@@ -287,7 +287,237 @@ function _getJestObj() {
 
 `;
 
-exports[`babel 8 babel-plugin-jest-hoist 13. automatic react runtime: 13. automatic react runtime 1`] = `
+exports[`babel 7 babel-plugin-jest-hoist 13. jest.hoisted const factory: 13. jest.hoisted const factory 1`] = `
+
+const {mockGet} = jest.hoisted(() => ({mockGet: jest.fn()}));
+
+jest.mock('./api', () => ({get: mockGet}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const {mockGet} = _getJestObj().hoisted(() => ({
+  mockGet: _getJestObj().fn(),
+}));
+_getJestObj().mock('./api', () => ({
+  get: mockGet,
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 14. jest.hoisted let factory: 14. jest.hoisted let factory 1`] = `
+
+let label = jest.hoisted(() => 'hoisted-label');
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+let label = _getJestObj().hoisted(() => 'hoisted-label');
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 15. jest.hoisted var factory: 15. jest.hoisted var factory 1`] = `
+
+var label = jest.hoisted(() => 'hoisted-label');
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var label = _getJestObj().hoisted(() => 'hoisted-label');
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 16. jest.hoisted multi declarators preserves whole statement: 16. jest.hoisted multi declarators preserves whole statement 1`] = `
+
+const a = jest.hoisted(() => 1),
+  b = 2;
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const a = _getJestObj().hoisted(() => 1),
+  b = 2;
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 17. jest.hoisted bare call hoists like jest.mock: 17. jest.hoisted bare call hoists like jest.mock 1`] = `
+
+require('x');
+jest.hoisted(() => (globalThis.__seeded__ = true));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().hoisted(() => (globalThis.__seeded__ = true));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+require('x');
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 18. jest.hoisted bare call rewrites jest refs in factory: 18. jest.hoisted bare call rewrites jest refs in factory 1`] = `
+
+require('x');
+jest.hoisted(() => {
+  globalThis.__fn__ = jest.fn();
+});
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().hoisted(() => {
+  globalThis.__fn__ = _getJestObj().fn();
+});
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+require('x');
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 19. jest.hoisted rewrites jest refs in factory body: 19. jest.hoisted rewrites jest refs in factory body 1`] = `
+
+const {mockFn} = jest.hoisted(() => ({mockFn: jest.fn()}));
+jest.mock('./api', () => ({get: mockFn}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const {mockFn} = _getJestObj().hoisted(() => ({
+  mockFn: _getJestObj().fn(),
+}));
+_getJestObj().mock('./api', () => ({
+  get: mockFn,
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 23. jest.hoisted preserves relative order of multiple declarations: 23. jest.hoisted preserves relative order of multiple declarations 1`] = `
+
+require('x');
+const a = jest.hoisted(() => 1);
+const b = jest.hoisted(() => 2);
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const a = _getJestObj().hoisted(() => 1);
+const b = _getJestObj().hoisted(() => 2);
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+require('x');
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 24. jest.hoisted with destructuring: 24. jest.hoisted with destructuring 1`] = `
+
+const {one, two} = jest.hoisted(() => ({one: 1, two: 2}));
+jest.mock('./api', () => ({one, two}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const {one, two} = _getJestObj().hoisted(() => ({
+  one: 1,
+  two: 2,
+}));
+_getJestObj().mock('./api', () => ({
+  one,
+  two,
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 25. jest.mock can reference jest.hoisted binding declared later in file: 25. jest.mock can reference jest.hoisted binding declared later in file 1`] = `
+
+jest.mock('./api', () => ({get: mockGet}));
+
+const {mockGet} = jest.hoisted(() => ({mockGet: jest.fn()}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().mock('./api', () => ({
+  get: mockGet,
+}));
+const {mockGet} = _getJestObj().hoisted(() => ({
+  mockGet: _getJestObj().fn(),
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 7 babel-plugin-jest-hoist 29. jest.hoisted and jest.mock preserve source order when interleaved: 29. jest.hoisted and jest.mock preserve source order when interleaved 1`] = `
+
+require('x');
+jest.hoisted(() => (globalThis.__a__ = 1));
+jest.mock('./first', () => ({value: 'first'}));
+jest.hoisted(() => (globalThis.__b__ = 2));
+jest.mock('./second', () => ({value: 'second'}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().hoisted(() => (globalThis.__a__ = 1));
+_getJestObj().mock('./first', () => ({
+  value: 'first',
+}));
+_getJestObj().hoisted(() => (globalThis.__b__ = 2));
+_getJestObj().mock('./second', () => ({
+  value: 'second',
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+require('x');
+
+`;
+
+exports[`babel 8 babel-plugin-jest-hoist 30. automatic react runtime: 30. automatic react runtime 1`] = `
 
 jest.mock('./App', () => () => <div>Hello world</div>);
 
@@ -315,7 +545,7 @@ function _getJestObj() {
 
 `;
 
-exports[`babel 8 babel-plugin-jest-hoist 14. top level mocking: 14. top level mocking 1`] = `
+exports[`babel 8 babel-plugin-jest-hoist 31. top level mocking: 31. top level mocking 1`] = `
 
 require('x');
 
@@ -336,7 +566,7 @@ require('x');
 
 `;
 
-exports[`babel 8 babel-plugin-jest-hoist 15. within a block: 15. within a block 1`] = `
+exports[`babel 8 babel-plugin-jest-hoist 32. within a block: 32. within a block 1`] = `
 
 beforeEach(() => {
   require('x');
@@ -358,7 +588,7 @@ beforeEach(() => {
 
 `;
 
-exports[`babel 8 babel-plugin-jest-hoist 16. within a block with no siblings: 16. within a block with no siblings 1`] = `
+exports[`babel 8 babel-plugin-jest-hoist 33. within a block with no siblings: 33. within a block with no siblings 1`] = `
 
 beforeEach(() => {
   jest.mock('someNode');
@@ -378,7 +608,7 @@ beforeEach(() => {
 
 `;
 
-exports[`babel 8 babel-plugin-jest-hoist 17. required \`jest\` within \`jest\`: 17. required \`jest\` within \`jest\` 1`] = `
+exports[`babel 8 babel-plugin-jest-hoist 34. required \`jest\` within \`jest\`: 34. required \`jest\` within \`jest\` 1`] = `
 
 const {jest} = require('@jest/globals');
 
@@ -396,7 +626,7 @@ jest.mock('some-module', () => {
 
 `;
 
-exports[`babel 8 babel-plugin-jest-hoist 18. imported jest.mock within jest.mock: 18. imported jest.mock within jest.mock 1`] = `
+exports[`babel 8 babel-plugin-jest-hoist 35. imported jest.mock within jest.mock: 35. imported jest.mock within jest.mock 1`] = `
 
 import {jest} from '@jest/globals';
 
@@ -419,7 +649,7 @@ import {jest} from '@jest/globals';
 
 `;
 
-exports[`babel 8 babel-plugin-jest-hoist 19. global jest.mock within jest.mock: 19. global jest.mock within jest.mock 1`] = `
+exports[`babel 8 babel-plugin-jest-hoist 36. global jest.mock within jest.mock: 36. global jest.mock within jest.mock 1`] = `
 
 jest.mock('some-module', () => {
   jest.mock('some-module');
@@ -439,7 +669,7 @@ function _getJestObj() {
 
 `;
 
-exports[`babel 8 babel-plugin-jest-hoist 20. imported jest.requireActual in jest.mock: 20. imported jest.requireActual in jest.mock 1`] = `
+exports[`babel 8 babel-plugin-jest-hoist 37. imported jest.requireActual in jest.mock: 37. imported jest.requireActual in jest.mock 1`] = `
 
 import {jest} from '@jest/globals';
 
@@ -465,7 +695,7 @@ jest.requireActual('some-module');
 
 `;
 
-exports[`babel 8 babel-plugin-jest-hoist 21. global jest.requireActual in jest.mock: 21. global jest.requireActual in jest.mock 1`] = `
+exports[`babel 8 babel-plugin-jest-hoist 38. global jest.requireActual in jest.mock: 38. global jest.requireActual in jest.mock 1`] = `
 
 jest.mock('some-module', () => {
   jest.requireActual('some-module');
@@ -488,7 +718,7 @@ jest.requireActual('some-module');
 
 `;
 
-exports[`babel 8 babel-plugin-jest-hoist 22. TS typeof usage in jest.mock: 22. TS typeof usage in jest.mock 1`] = `
+exports[`babel 8 babel-plugin-jest-hoist 39. TS typeof usage in jest.mock: 39. TS typeof usage in jest.mock 1`] = `
 
 jest.mock('some-module', () => {
   const actual = jest.requireActual('some-module');
@@ -511,7 +741,7 @@ function _getJestObj() {
 
 `;
 
-exports[`babel 8 babel-plugin-jest-hoist 23. jest.spyOn call on the imported module: 23. jest.spyOn call on the imported module 1`] = `
+exports[`babel 8 babel-plugin-jest-hoist 40. jest.spyOn call on the imported module: 40. jest.spyOn call on the imported module 1`] = `
 
 jest.mock('some-module', () => {
   const module = jest.requireActual('some-module');
@@ -535,7 +765,7 @@ function _getJestObj() {
 
 `;
 
-exports[`babel 8 babel-plugin-jest-hoist 24. jest.spyOn call in class constructor: 24. jest.spyOn call in class constructor 1`] = `
+exports[`babel 8 babel-plugin-jest-hoist 41. jest.spyOn call in class constructor: 41. jest.spyOn call in class constructor 1`] = `
 
 jest.mock('some-module', () => {
   const Actual = jest.requireActual('some-module');
@@ -564,5 +794,235 @@ function _getJestObj() {
   _getJestObj = () => jest;
   return jest;
 }
+
+`;
+
+exports[`babel 8 babel-plugin-jest-hoist 42. jest.hoisted const factory: 42. jest.hoisted const factory 1`] = `
+
+const {mockGet} = jest.hoisted(() => ({mockGet: jest.fn()}));
+
+jest.mock('./api', () => ({get: mockGet}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const {mockGet} = _getJestObj().hoisted(() => ({
+  mockGet: _getJestObj().fn(),
+}));
+_getJestObj().mock('./api', () => ({
+  get: mockGet,
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 8 babel-plugin-jest-hoist 43. jest.hoisted let factory: 43. jest.hoisted let factory 1`] = `
+
+let label = jest.hoisted(() => 'hoisted-label');
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+let label = _getJestObj().hoisted(() => 'hoisted-label');
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 8 babel-plugin-jest-hoist 44. jest.hoisted var factory: 44. jest.hoisted var factory 1`] = `
+
+var label = jest.hoisted(() => 'hoisted-label');
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+var label = _getJestObj().hoisted(() => 'hoisted-label');
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 8 babel-plugin-jest-hoist 45. jest.hoisted multi declarators preserves whole statement: 45. jest.hoisted multi declarators preserves whole statement 1`] = `
+
+const a = jest.hoisted(() => 1),
+  b = 2;
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const a = _getJestObj().hoisted(() => 1),
+  b = 2;
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 8 babel-plugin-jest-hoist 46. jest.hoisted bare call hoists like jest.mock: 46. jest.hoisted bare call hoists like jest.mock 1`] = `
+
+require('x');
+jest.hoisted(() => (globalThis.__seeded__ = true));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().hoisted(() => (globalThis.__seeded__ = true));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+require('x');
+
+`;
+
+exports[`babel 8 babel-plugin-jest-hoist 47. jest.hoisted bare call rewrites jest refs in factory: 47. jest.hoisted bare call rewrites jest refs in factory 1`] = `
+
+require('x');
+jest.hoisted(() => {
+  globalThis.__fn__ = jest.fn();
+});
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().hoisted(() => {
+  globalThis.__fn__ = _getJestObj().fn();
+});
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+require('x');
+
+`;
+
+exports[`babel 8 babel-plugin-jest-hoist 48. jest.hoisted rewrites jest refs in factory body: 48. jest.hoisted rewrites jest refs in factory body 1`] = `
+
+const {mockFn} = jest.hoisted(() => ({mockFn: jest.fn()}));
+jest.mock('./api', () => ({get: mockFn}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const {mockFn} = _getJestObj().hoisted(() => ({
+  mockFn: _getJestObj().fn(),
+}));
+_getJestObj().mock('./api', () => ({
+  get: mockFn,
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 8 babel-plugin-jest-hoist 52. jest.hoisted preserves relative order of multiple declarations: 52. jest.hoisted preserves relative order of multiple declarations 1`] = `
+
+require('x');
+const a = jest.hoisted(() => 1);
+const b = jest.hoisted(() => 2);
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const a = _getJestObj().hoisted(() => 1);
+const b = _getJestObj().hoisted(() => 2);
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+require('x');
+
+`;
+
+exports[`babel 8 babel-plugin-jest-hoist 53. jest.hoisted with destructuring: 53. jest.hoisted with destructuring 1`] = `
+
+const {one, two} = jest.hoisted(() => ({one: 1, two: 2}));
+jest.mock('./api', () => ({one, two}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const {one, two} = _getJestObj().hoisted(() => ({
+  one: 1,
+  two: 2,
+}));
+_getJestObj().mock('./api', () => ({
+  one,
+  two,
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 8 babel-plugin-jest-hoist 54. jest.mock can reference jest.hoisted binding declared later in file: 54. jest.mock can reference jest.hoisted binding declared later in file 1`] = `
+
+jest.mock('./api', () => ({get: mockGet}));
+
+const {mockGet} = jest.hoisted(() => ({mockGet: jest.fn()}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().mock('./api', () => ({
+  get: mockGet,
+}));
+const {mockGet} = _getJestObj().hoisted(() => ({
+  mockGet: _getJestObj().fn(),
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+
+`;
+
+exports[`babel 8 babel-plugin-jest-hoist 58. jest.hoisted and jest.mock preserve source order when interleaved: 58. jest.hoisted and jest.mock preserve source order when interleaved 1`] = `
+
+require('x');
+jest.hoisted(() => (globalThis.__a__ = 1));
+jest.mock('./first', () => ({value: 'first'}));
+jest.hoisted(() => (globalThis.__b__ = 2));
+jest.mock('./second', () => ({value: 'second'}));
+
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+_getJestObj().hoisted(() => (globalThis.__a__ = 1));
+_getJestObj().mock('./first', () => ({
+  value: 'first',
+}));
+_getJestObj().hoisted(() => (globalThis.__b__ = 2));
+_getJestObj().mock('./second', () => ({
+  value: 'second',
+}));
+function _getJestObj() {
+  const {jest} = require('@jest/globals');
+  _getJestObj = () => jest;
+  return jest;
+}
+require('x');
 
 `;

--- a/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.nodejs18.test.ts
+++ b/packages/babel-plugin-jest-hoist/src/__tests__/hoistPlugin.nodejs18.test.ts
@@ -192,6 +192,122 @@ export function defineTests({
         formatResult,
         snapshot: true,
       },
+      'jest.hoisted const factory': {
+        code: formatResult(`
+          const { mockGet } = jest.hoisted(() => ({ mockGet: jest.fn() }));
+
+          jest.mock('./api', () => ({ get: mockGet }));
+        `),
+        formatResult,
+        snapshot: true,
+      },
+      'jest.hoisted let factory': {
+        code: formatResult(`
+          let label = jest.hoisted(() => 'hoisted-label');
+        `),
+        formatResult,
+        snapshot: true,
+      },
+      'jest.hoisted var factory': {
+        code: formatResult(`
+          var label = jest.hoisted(() => 'hoisted-label');
+        `),
+        formatResult,
+        snapshot: true,
+      },
+      'jest.hoisted multi declarators preserves whole statement': {
+        code: formatResult(`
+          const a = jest.hoisted(() => 1), b = 2;
+        `),
+        formatResult,
+        snapshot: true,
+      },
+      'jest.hoisted bare call hoists like jest.mock': {
+        code: formatResult(`
+          require('x');
+          jest.hoisted(() => globalThis.__seeded__ = true);
+        `),
+        formatResult,
+        snapshot: true,
+      },
+      'jest.hoisted bare call rewrites jest refs in factory': {
+        code: formatResult(`
+          require('x');
+          jest.hoisted(() => { globalThis.__fn__ = jest.fn(); });
+        `),
+        formatResult,
+        snapshot: true,
+      },
+      'jest.hoisted rewrites jest refs in factory body': {
+        code: formatResult(`
+          const { mockFn } = jest.hoisted(() => ({ mockFn: jest.fn() }));
+          jest.mock('./api', () => ({ get: mockFn }));
+        `),
+        formatResult,
+        snapshot: true,
+      },
+      'jest.hoisted throws when nested inside a block': {
+        code: 'if (true) { const x = jest.hoisted(() => 1); }',
+        error: /must be called at the top level of the file/,
+      },
+      'jest.hoisted throws when factory argument is not a function': {
+        code: 'const x = jest.hoisted({ value: 1 });',
+        error: /must be an inline function/,
+      },
+      'jest.hoisted throws when called with no arguments': {
+        code: 'const x = jest.hoisted();',
+        error: /must be called with exactly one argument/,
+      },
+      'jest.hoisted preserves relative order of multiple declarations': {
+        code: formatResult(`
+          require('x');
+          const a = jest.hoisted(() => 1);
+          const b = jest.hoisted(() => 2);
+        `),
+        formatResult,
+        snapshot: true,
+      },
+      'jest.hoisted with destructuring': {
+        code: formatResult(`
+          const { one, two } = jest.hoisted(() => ({ one: 1, two: 2 }));
+          jest.mock('./api', () => ({ one, two }));
+        `),
+        formatResult,
+        snapshot: true,
+      },
+      'jest.mock can reference jest.hoisted binding declared later in file': {
+        code: formatResult(`
+          jest.mock('./api', () => ({ get: mockGet }));
+
+          const { mockGet } = jest.hoisted(() => ({ mockGet: jest.fn() }));
+        `),
+        formatResult,
+        snapshot: true,
+      },
+      'jest.hoisted called inside jest.mock factory throws': {
+        code: "jest.mock('./api', () => { jest.hoisted(() => 1); return {}; });",
+        error: /must be called at the top level of the file/,
+      },
+      'jest.mock called inside jest.hoisted factory throws': {
+        code: "jest.hoisted(() => { jest.mock('./api', () => ({})); return 1; });",
+        error: /`jest\.mock` cannot be called inside a `jest\.hoisted` factory/,
+      },
+      'jest.hoisted called inside another jest.hoisted factory throws': {
+        code: 'jest.hoisted(() => { jest.hoisted(() => 1); return 1; });',
+        error:
+          /`jest\.hoisted` cannot be called inside a `jest\.hoisted` factory/,
+      },
+      'jest.hoisted and jest.mock preserve source order when interleaved': {
+        code: formatResult(`
+          require('x');
+          jest.hoisted(() => globalThis.__a__ = 1);
+          jest.mock('./first', () => ({ value: 'first' }));
+          jest.hoisted(() => globalThis.__b__ = 2);
+          jest.mock('./second', () => ({ value: 'second' }));
+        `),
+        formatResult,
+        snapshot: true,
+      },
     },
     /* eslint-enable */
   });

--- a/packages/babel-plugin-jest-hoist/src/index.ts
+++ b/packages/babel-plugin-jest-hoist/src/index.ts
@@ -29,6 +29,10 @@ const JEST_GLOBALS_MODULE_JEST_EXPORT_NAME = 'jest';
 const hoistedVariables = new WeakSet<VariableDeclarator>();
 const hoistedJestGetters = new WeakSet<CallExpression>();
 const hoistedJestExpressions = new WeakSet<Expression>();
+// Variable bindings produced by `jest.hoisted(...)` declarators. Referencing
+// them inside a `jest.mock` factory is always safe because the factory still
+// runs after `jest.hoisted` has populated the binding at the top of the file.
+const jestHoistedBindings = new WeakSet<VariableDeclarator>();
 
 // We allow `jest`, `expect`, `require`, all default Node.js globals and all
 // ES2015 built-ins to be used inside of a `jest.mock` factory.
@@ -163,6 +167,10 @@ FUNCTIONS.mock = args => {
             if (initNode && binding.constant && scope.isPure(initNode, true)) {
               hoistedVariables.add(node);
               isAllowedIdentifier = true;
+            } else if (jestHoistedBindings.has(node)) {
+              // `jest.hoisted(...)` declarators run before any `jest.mock`
+              // factory body, so referencing them is always safe.
+              isAllowedIdentifier = true;
             }
           } else if (binding?.path.isImportSpecifier()) {
             const importDecl = binding.path
@@ -206,6 +214,22 @@ FUNCTIONS.unmock = args => args.length === 1 && args[0].isStringLiteral();
 FUNCTIONS.deepUnmock = args => args.length === 1 && args[0].isStringLiteral();
 FUNCTIONS.disableAutomock = FUNCTIONS.enableAutomock = args =>
   args.length === 0;
+
+FUNCTIONS.hoisted = args => {
+  if (args.length !== 1) {
+    throw new TypeError(
+      '`jest.hoisted` must be called with exactly one argument: an inline function.',
+    );
+  }
+  const factory = args[0];
+  if (!factory.isFunction()) {
+    throw factory.buildCodeFrameError(
+      'The argument of `jest.hoisted` must be an inline function.\n',
+      TypeError,
+    );
+  }
+  return true;
+};
 
 const isJestObject = (
   expression: NodePath<Expression | Super>,
@@ -301,6 +325,101 @@ const extractJestObjExprIfHoistable = (expr: NodePath): JestObjInfo | null => {
 };
 
 /* eslint-disable sort-keys */
+const isJestHoistedCall = (
+  expr: NodePath<Node>,
+): expr is NodePath<CallExpression> => {
+  if (!expr.isCallExpression()) {
+    return false;
+  }
+  const callee = expr.get<'callee'>('callee');
+  if (!callee.isMemberExpression() || callee.node.computed) {
+    return false;
+  }
+  const object = callee.get<'object'>('object');
+  const property = callee.get<'property'>('property') as NodePath<Identifier>;
+  return (
+    property.isIdentifier() &&
+    property.node.name === 'hoisted' &&
+    isJestObject(object)
+  );
+};
+
+const enforceHoistedAtTopLevel = (
+  varDecl: NodePath<VariableDeclaration>,
+  call: NodePath<CallExpression>,
+) => {
+  if (!varDecl.parentPath.isProgram()) {
+    throw call.buildCodeFrameError(
+      '`jest.hoisted` must be called at the top level of the file.\n',
+      ReferenceError,
+    );
+  }
+};
+
+// Detects whether a call expression is `jest.mock(...)`.
+const isJestMockCall = (
+  expr: NodePath<Node>,
+): expr is NodePath<CallExpression> => {
+  if (!expr.isCallExpression()) {
+    return false;
+  }
+  const callee = expr.get<'callee'>('callee');
+  if (!callee.isMemberExpression() || callee.node.computed) {
+    return false;
+  }
+  const object = callee.get<'object'>('object');
+  const property = callee.get<'property'>('property') as NodePath<Identifier>;
+  return (
+    property.isIdentifier() &&
+    property.node.name === 'mock' &&
+    isJestObject(object)
+  );
+};
+
+// `jest.hoisted` factory bodies run at the very top of the program. Calls to
+// `jest.mock` or another `jest.hoisted` inside them would never observe the
+// surrounding module state and produce confusing behaviour.
+const enforceNoHoistAffectingCallsInFactory = (factory: NodePath) => {
+  factory.traverse({
+    CallExpression(callPath: NodePath<CallExpression>) {
+      if (isJestMockCall(callPath) || isJestHoistedCall(callPath)) {
+        const calleeName = isJestMockCall(callPath)
+          ? 'jest.mock'
+          : 'jest.hoisted';
+        throw callPath.buildCodeFrameError(
+          `\`${calleeName}\` cannot be called inside a \`jest.hoisted\` factory.\n`,
+          ReferenceError,
+        );
+      }
+    },
+  });
+};
+
+// Rewrites `jest` references inside a `jest.hoisted` factory body to lazy
+// `_getJestObj()` calls. The factory runs at the top of the program, before
+// any `import {jest} from '@jest/globals'` has been initialised, so `jest`
+// would otherwise be `undefined`.
+const rewriteJestRefsInFactory = (
+  factory: NodePath,
+  declareGetter: () => Identifier,
+  t: typeof import('@babel/types'),
+) => {
+  factory.traverse({
+    Identifier(idPath: NodePath<Identifier>) {
+      if (idPath.node.name !== JEST_GLOBAL_NAME) {
+        return;
+      }
+      if (!idPath.isReferencedIdentifier()) {
+        return;
+      }
+      if (!isJestObject(idPath)) {
+        return;
+      }
+      idPath.replaceWith(t.callExpression(declareGetter(), []));
+    },
+  });
+};
+
 export default function jestHoist(
   babel: typeof import('@babel/core'),
 ): PluginObj<{
@@ -339,7 +458,43 @@ export default function jestHoist(
       };
     },
     visitor: {
+      Program: {
+        enter(program) {
+          // Pre-pass: register every top-level `jest.hoisted(...)` declarator
+          // binding before any other visitor runs. This makes the bindings
+          // visible to `jest.mock` factories that appear *earlier* in the
+          // source than the declaration itself — without it, the
+          // `VariableDeclaration` visitor would not have registered the
+          // binding by the time `FUNCTIONS.mock` validates the factory body.
+          for (const stmt of program.get('body')) {
+            if (!stmt.isVariableDeclaration()) {
+              continue;
+            }
+            for (const declarator of stmt.get('declarations')) {
+              const init = declarator.get('init') as NodePath<Expression>;
+              if (!init.node) {
+                continue;
+              }
+              if (!isJestHoistedCall(init)) {
+                continue;
+              }
+              jestHoistedBindings.add(declarator.node);
+            }
+          }
+        },
+      },
       ExpressionStatement(exprStmt) {
+        // Check for `jest.hoisted` BEFORE `extractJestObjExprIfHoistable`
+        // mutates the `jest` reference into `_getJestObj()`, which would
+        // make `isJestHoistedCall` no longer match.
+        const rawExpr = exprStmt.get('expression');
+        const isBareHoisted = isJestHoistedCall(rawExpr);
+        if (isBareHoisted && !exprStmt.parentPath.isProgram()) {
+          throw rawExpr.buildCodeFrameError(
+            '`jest.hoisted` must be called at the top level of the file.\n',
+            ReferenceError,
+          );
+        }
         const jestObjInfo = extractJestObjExprIfHoistable(
           exprStmt.get('expression'),
         );
@@ -352,22 +507,95 @@ export default function jestHoist(
           if (jestObjInfo.hoist) {
             hoistedJestGetters.add(jestCallExpr);
           }
+          // Bare `jest.hoisted(() => {...})` — rewrite `jest` references
+          // inside the factory body for the same reason as the
+          // `VariableDeclaration` path below.
+          if (isBareHoisted) {
+            const inner = exprStmt.get(
+              'expression',
+            ) as NodePath<CallExpression>;
+            enforceNoHoistAffectingCallsInFactory(inner.get('arguments')[0]);
+            rewriteJestRefsInFactory(
+              inner.get('arguments')[0],
+              this.declareJestObjGetterIdentifier.bind(this),
+              t,
+            );
+          }
+        }
+      },
+      VariableDeclaration(varDecl) {
+        // Look for declarators initialized by `jest.hoisted(...)`. Each match
+        // registers the binding so it can be referenced inside `jest.mock`
+        // factories, and rewrites the jest-object expression to the lazy
+        // `_getJestObj()` getter so the factory can run before the `jest`
+        // import is initialised.
+        let hoistsAnyDeclarator = false;
+        for (const declarator of varDecl.get('declarations')) {
+          const init = declarator.get('init') as NodePath<Expression>;
+          if (!init.node) {
+            continue;
+          }
+          const inner = init;
+          if (!isJestHoistedCall(inner)) {
+            continue;
+          }
+          // Validate argument shape via the FUNCTIONS entry (throws on bad
+          // input — must run before we start mutating the tree).
+          const args = inner.get('arguments');
+          if (!FUNCTIONS.hoisted(args)) {
+            continue;
+          }
+          enforceHoistedAtTopLevel(varDecl, inner);
+          enforceNoHoistAffectingCallsInFactory(inner.get('arguments')[0]);
+          jestHoistedBindings.add(declarator.node);
+          hoistsAnyDeclarator = true;
+
+          const callee = inner.get('callee') as NodePath<MemberExpression>;
+          const jestObjExpr = callee.get('object');
+          const jestCallExpr = t.callExpression(
+            this.declareJestObjGetterIdentifier(),
+            [],
+          );
+          jestObjExpr.replaceWith(jestCallExpr);
+
+          rewriteJestRefsInFactory(
+            inner.get('arguments')[0],
+            this.declareJestObjGetterIdentifier.bind(this),
+            t,
+          );
+        }
+        if (hoistsAnyDeclarator && !varDecl.parentPath.isProgram()) {
+          throw varDecl.buildCodeFrameError(
+            '`jest.hoisted` declarations must be at the top level of the file.\n',
+            ReferenceError,
+          );
         }
       },
     },
     // in `post` to make sure we come after an import transform and can unshift above the `require`s
     post({path: program}) {
-      type Item = {calls: Array<Statement>; vars: Array<Statement>};
+      type Item = {
+        // User-authored hoisted statements: `jest.mock(...)` calls and
+        // `jest.hoisted(...)` declarations, in source-traversal order. Side
+        // effects of bare `jest.hoisted` factories must run in the same
+        // relative order as `jest.mock` factories around them, so we keep
+        // them in a single list instead of bucketing by kind.
+        statements: Array<Statement>;
+        // Synthesised pure-constant declarations lifted out of `jest.mock`
+        // factory bodies. Always come first because they are dependencies of
+        // the user-authored hoisted statements, not user-visible side effects.
+        pureVars: Array<Statement>;
+      };
 
-      const stack: Array<Item> = [{calls: [], vars: []}];
+      const stack: Array<Item> = [{pureVars: [], statements: []}];
       program.traverse({
         BlockStatement: {
           enter() {
-            stack.push({calls: [], vars: []});
+            stack.push({pureVars: [], statements: []});
           },
           exit(path) {
             const item = stack.pop()!;
-            path.node.body.unshift(...item.vars, ...item.calls);
+            path.node.body.unshift(...item.pureVars, ...item.statements);
           },
         },
         CallExpression(callExpr: NodePath<CallExpression>) {
@@ -375,10 +603,23 @@ export default function jestHoist(
             const mockStmt = callExpr.getStatementParent();
 
             if (mockStmt?.parentPath.isBlock()) {
-              stack.at(-1)!.calls.push(mockStmt.node);
+              stack.at(-1)!.statements.push(mockStmt.node);
               mockStmt.remove();
             }
           }
+        },
+        VariableDeclaration(varDecl: NodePath<VariableDeclaration>) {
+          const isHoistedJestDecl = varDecl.node.declarations.some(declarator =>
+            jestHoistedBindings.has(declarator),
+          );
+          if (!isHoistedJestDecl) {
+            return;
+          }
+          // Move the entire declaration so `const`/`let`/`var` kind, multiple
+          // declarators, and destructuring patterns survive verbatim.
+          const declNode = varDecl.node;
+          varDecl.remove();
+          stack.at(-1)!.statements.push(declNode);
         },
         VariableDeclarator(varDecl: NodePath<VariableDeclarator>) {
           if (hoistedVariables.has(varDecl.node)) {
@@ -393,12 +634,12 @@ export default function jestHoist(
             }
             stack
               .at(-1)!
-              .vars.push(t.variableDeclaration(kind, [varDecl.node]));
+              .pureVars.push(t.variableDeclaration(kind, [varDecl.node]));
           }
         },
       });
       const item = stack.pop()!;
-      program.node.body.unshift(...item.vars, ...item.calls);
+      program.node.body.unshift(...item.pureVars, ...item.statements);
     },
   };
 }

--- a/packages/jest-environment/src/index.ts
+++ b/packages/jest-environment/src/index.ts
@@ -178,6 +178,24 @@ export interface Jest {
    */
   getTimerCount(): number;
   /**
+   * When using `babel-jest`, the call to `jest.hoisted` will automatically
+   * be hoisted to the top of the test file, before any imports or
+   * `jest.mock()` factories. Variables bound from `jest.hoisted` may then
+   * be referenced inside `jest.mock` factories without the usual
+   * `mock`-prefix restriction. The factory must be an inline function
+   * literal so that `babel-plugin-jest-hoist` can move the declaration
+   * statically. Outside of the Babel transform (e.g. raw ESM without the
+   * plugin) `jest.hoisted` simply invokes the factory inline and the
+   * hoisting guarantee does not apply.
+   *
+   * @example
+   * ```ts
+   * const { mockGet } = jest.hoisted(() => ({ mockGet: jest.fn() }));
+   * jest.mock('./api', () => ({ get: mockGet }));
+   * ```
+   */
+  hoisted<T>(factory: () => T): T;
+  /**
    * Returns `true` if test environment has been torn down.
    *
    * @example

--- a/packages/jest-runtime/src/internals/JestGlobals.ts
+++ b/packages/jest-runtime/src/internals/JestGlobals.ts
@@ -352,6 +352,7 @@ export class JestGlobals {
       },
       getSeed: () => this.globalConfig.seed,
       getTimerCount: () => _getFakeTimers().getTimerCount(),
+      hoisted: factory => factory(),
       isEnvironmentTornDown: () => this.testState.isTornDown(),
       isMockFunction: this.moduleMocker.isMockFunction,
       isolateModules,

--- a/packages/jest-runtime/src/internals/JestGlobals.ts
+++ b/packages/jest-runtime/src/internals/JestGlobals.ts
@@ -365,6 +365,7 @@ export class JestGlobals {
       },
       getSeed: () => this.globalConfig.seed,
       getTimerCount: () => _getFakeTimers().getTimerCount(),
+      hoisted: factory => factory(),
       isEnvironmentTornDown: () => this.testState.isTornDown(),
       isMockFunction: this.moduleMocker.isMockFunction,
       isolateModules,


### PR DESCRIPTION
## Summary

Adds `jest.hoisted(factory)` API, mirroring [`vi.hoisted`](https://vitest.dev/api/vi.html#vi-hoisted) from Vitest

### Motivation

`jest.mock` factories run before module imports. Today the only escape hatch for referencing variables from a `jest.mock` factory is the `mock`-prefix allowlist (any identifier matching `/^mock/i`). For everything else, `babel-plugin-jest-hoist` throws:

```
The module factory of `jest.mock()` is not allowed to reference any out-of-scope variables.
```

`jest.hoisted` provides an explicit, opt-in mechanism: any variable declared via `jest.hoisted` is hoisted to the top of the file alongside `jest.mock` calls, so it is available inside `jest.mock` factory bodies — regardless of naming.

### Example

```js
import {jest} from '@jest/globals';
import {getUser} from './user';

const {mockGet} = jest.hoisted(() => ({mockGet: jest.fn()}));

jest.mock('../api', () => ({getUser: mockGet}));

test('getUser uses hoisted mock', () => {
  mockGet.mockReturnValue({name: 'Alice'});
  expect(getUser()).toEqual({name: 'Alice'});
});
```

### Scope

Sync overload only: `jest.hoisted<T>(factory: () => T): T`.

The async overload (`() => Promise<T>`) is intentionally **not** included. It would only be useful in native ESM (top-level `await`), but the underlying `_getJestObj()` template in `babel-plugin-jest-hoist` uses `require('@jest/globals')`, which is undefined under `--experimental-vm-modules`. This is a pre-existing limitation that also affects `jest.mock` and is out of scope for this PR.

### Changes

- **`babel-plugin-jest-hoist`** — recognises `jest.hoisted(factory)` as a hoistable call in both `VariableDeclaration` and `ExpressionStatement` positions. Supports `const`/`let`/`var` and destructuring. Rewrites `jest.*` references inside the factory body to `_getJestObj().*`. Throws `ReferenceError` for non-top-level usage, nested `jest.mock`/`jest.hoisted` inside a hoisted factory, and `TypeError` for non-function arguments or wrong arity.
- **`jest-runtime`** — adds `hoisted: factory => factory()` to the per-file jest object built in `JestGlobals.jestObjectFor`, shared by both CJS and ESM module loaders.
- **`jest-environment`** — adds `hoisted<T>(factory: () => T): T` to the `Jest` interface.
- **Docs** — new section in `docs/JestObjectAPI.md`, README update in `babel-plugin-jest-hoist`, `CHANGELOG.md` entry.

### Validation rules (vitest parity)

| Case | Behaviour |
|---|---|
| `const x = jest.hoisted(() => 1)` at top level | ✅ hoisted |
| Bare `jest.hoisted(() => { ... })` at top level | ✅ hoisted |
| `let`/`var` / destructure | ✅ hoisted |
| Multiple `jest.hoisted` calls | ✅ relative order preserved |
| `jest.hoisted` inside `if (true) { ... }` | ❌ `ReferenceError` |
| `jest.hoisted` inside `jest.mock` factory | ❌ `ReferenceError` |
| `jest.mock` inside `jest.hoisted` factory | ❌ `ReferenceError` |
| `jest.hoisted({notAFunction: true})` | ❌ `TypeError` |
| `jest.hoisted()` | ❌ `TypeError` |

## Test plan

```bash
yarn build:js
CI= yarn jest packages/babel-plugin-jest-hoist --ci=false
# Test Suites: 1 passed, 1 total
# Tests:       52 passed, 52 total
# Snapshots:   42 passed, 42 total

yarn jest e2e/__tests__/babelPluginJestHoist
# Test Suites: 1 passed, 1 total
# Tests:       1 passed, 1 total
# (6 fixture suites: importJest, integration, integrationAutomockOff, typescript, hoisted, hoistedOrdering)

yarn lint           # ✅ no new errors
yarn lint:prettier  # ✅
```

E2E fixture `e2e/babel-plugin-jest-hoist/__tests__/hoistedOrdering.test.js` proves hoist order by setting `globalThis.__jestHoistedValue__` inside a bare `jest.hoisted` factory and observing it from a sibling module's import-time snapshot — mirrors Vitest's `hoisted-simple.test.ts`.
