### PR TITLE
Update immutable dependency version to 5.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Chore & Maintenance
 
+- `[@jest/expect-utils]` Update immutable version minimal requirements to avoid CVE warning : https://nvd.nist.gov/vuln/detail/CVE-2026-29063 ([#16180](https://github.com/jestjs/jest/pull/16180]))
 - `[jest-haste-map]` Refactor massive class into multiple files ([#16180](https://github.com/jestjs/jest/pull/16180))
 - `[jest-haste-map]` Drop `walker` dependency; replace hand-rolled directory recursion in the JS crawler and watcher startup with `fdir` ([#16187](https://github.com/jestjs/jest/pull/16187))
 - `[jest-runtime]` Avoid magical `null` value in ESM loader ([#16160](https://github.com/jestjs/jest/pull/16160))

--- a/packages/expect-utils/package.json
+++ b/packages/expect-utils/package.json
@@ -22,7 +22,7 @@
     "@jest/get-type": "workspace:*"
   },
   "devDependencies": {
-    "immutable": "^5.1.2",
+    "immutable": "^5.1.5",
     "jest-matcher-utils": "workspace:*"
   },
   "engines": {


### PR DESCRIPTION
## Summary

Small minimum version update to not having warning on this CVE : https://nvd.nist.gov/vuln/detail/CVE-2026-29063

## Test plan

This have no impact just updating the minimal version requirement to the non affected 5.1.5
