### PR TITLE
Fix cross-realm Node global constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
+- `[jest-environment-node]` Make Node API values match test realm constructors in `instanceof` and `Object.getPrototypeOf` checks ([#16205](https://github.com/jestjs/jest/pull/16205))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 - `[jest-runtime]` Support older test environments whose `moduleMocker` does not implement `clearMocksOnScope` ([#16169](https://github.com/jestjs/jest/pull/16169))
 

--- a/e2e/__tests__/instanceof.test.ts
+++ b/e2e/__tests__/instanceof.test.ts
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import runJest from '../runJest';
+
+test('suite with cross-context instanceof checks', () => {
+  const {exitCode} = runJest('instanceof');
+
+  expect(exitCode).toBe(0);
+});

--- a/e2e/instanceof/__tests__/test.js
+++ b/e2e/instanceof/__tests__/test.js
@@ -7,7 +7,6 @@
 'use strict';
 
 const fs = require('fs');
-const http = require('http');
 const url = require('url');
 
 test('arrays returned by Node APIs use the test realm Array constructor', () => {
@@ -38,23 +37,9 @@ test('errors thrown by Node APIs do not match unrelated subclasses', () => {
   }
 });
 
-test('Object.getPrototypeOf maps Node fetch results to the test realm', async () => {
-  const server = http.createServer((request, response) => {
-    response.setHeader('Content-Type', 'application/json');
-    response.end(JSON.stringify({ok: true}));
-  });
+test('Object.getPrototypeOf maps Node API results to the test realm', () => {
+  const report = process.report.getReport();
 
-  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
-
-  try {
-    const {port} = server.address();
-    const response = await fetch(`http://127.0.0.1:${port}`);
-    const json = await response.json();
-
-    expect(Object.getPrototypeOf(json)).toBe(Object.prototype);
-  } finally {
-    await new Promise((resolve, reject) => {
-      server.close(error => (error ? reject(error) : resolve()));
-    });
-  }
+  expect(report).toBeInstanceOf(Object);
+  expect(Object.getPrototypeOf(report)).toBe(Object.prototype);
 });

--- a/e2e/instanceof/__tests__/test.js
+++ b/e2e/instanceof/__tests__/test.js
@@ -1,0 +1,60 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const fs = require('fs');
+const http = require('http');
+const url = require('url');
+
+test('arrays returned by Node APIs use the test realm Array constructor', () => {
+  const {query} = url.parse('https://jestjs.io/?tag=node&tag=vm', true);
+
+  expect(query.tag).toBeInstanceOf(Array);
+});
+
+test('errors thrown by Node APIs use the test realm Error constructor', () => {
+  expect.hasAssertions();
+
+  try {
+    fs.readFileSync('this-file-does-not-exist');
+  } catch (error) {
+    expect(error).toBeInstanceOf(Error);
+  }
+});
+
+test('errors thrown by Node APIs do not match unrelated subclasses', () => {
+  class CustomError extends Error {}
+
+  expect.hasAssertions();
+
+  try {
+    fs.readFileSync('this-file-does-not-exist');
+  } catch (error) {
+    expect(error).not.toBeInstanceOf(CustomError);
+  }
+});
+
+test('Object.getPrototypeOf maps Node fetch results to the test realm', async () => {
+  const server = http.createServer((request, response) => {
+    response.setHeader('Content-Type', 'application/json');
+    response.end(JSON.stringify({ok: true}));
+  });
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve));
+
+  try {
+    const {port} = server.address();
+    const response = await fetch(`http://127.0.0.1:${port}`);
+    const json = await response.json();
+
+    expect(Object.getPrototypeOf(json)).toBe(Object.prototype);
+  } finally {
+    await new Promise((resolve, reject) => {
+      server.close(error => (error ? reject(error) : resolve()));
+    });
+  }
+});

--- a/e2e/instanceof/package.json
+++ b/e2e/instanceof/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -45,6 +45,53 @@ const denyList = new Set([
 
 type GlobalProperties = Array<keyof typeof globalThis>;
 
+type NativeConstructor = {
+  prototype: object;
+  [Symbol.hasInstance](value: unknown): boolean;
+};
+
+const crossContextConstructorNames = [
+  'AggregateError',
+  'Array',
+  'ArrayBuffer',
+  'BigInt',
+  'BigInt64Array',
+  'BigUint64Array',
+  'Boolean',
+  'DataView',
+  'Date',
+  'Error',
+  'EvalError',
+  'Float32Array',
+  'Float64Array',
+  'Function',
+  'Int8Array',
+  'Int16Array',
+  'Int32Array',
+  'Map',
+  'Number',
+  'Object',
+  'Promise',
+  'RangeError',
+  'ReferenceError',
+  'RegExp',
+  'Set',
+  'SharedArrayBuffer',
+  'String',
+  'Symbol',
+  'SyntaxError',
+  'TypeError',
+  'URIError',
+  'Uint8Array',
+  'Uint8ClampedArray',
+  'Uint16Array',
+  'Uint32Array',
+  'WeakMap',
+  'WeakSet',
+];
+
+const functionHasInstance = Function.prototype[Symbol.hasInstance];
+
 // Storage proxies (Node 25+) emit a warning on any Reflect.get access when
 // --localstorage-file is not set. We install them as non-caching passthrough
 // getters so they never land in GlobalProxy.propertyToValue and are never
@@ -72,6 +119,99 @@ const nodeGlobals = new Map(
 
 function isString(value: unknown): value is string {
   return typeof value === 'string';
+}
+
+function isObject(value: unknown): value is object {
+  return (
+    (typeof value === 'object' && value !== null) || typeof value === 'function'
+  );
+}
+
+function getNativeConstructor(
+  globalObject: typeof globalThis,
+  name: string,
+): NativeConstructor | undefined {
+  const constructor = globalObject[name as keyof typeof globalThis];
+
+  if (typeof constructor !== 'function') {
+    return undefined;
+  }
+
+  const prototype = (constructor as {prototype?: unknown}).prototype;
+
+  if (!isObject(prototype)) {
+    return undefined;
+  }
+
+  return constructor as unknown as NativeConstructor;
+}
+
+function addCrossContextInstanceOfAlias(
+  target: NativeConstructor,
+  alias: NativeConstructor,
+): void {
+  const originalHasInstance = target[Symbol.hasInstance];
+
+  Object.defineProperty(target, Symbol.hasInstance, {
+    configurable: true,
+    value(this: NativeConstructor, value: unknown) {
+      return (
+        originalHasInstance.call(this, value) ||
+        (this === target && functionHasInstance.call(alias, value))
+      );
+    },
+    writable: true,
+  });
+}
+
+function installCrossContextGetPrototypeOfAlias(
+  globalObject: typeof globalThis,
+  prototypeMap: Map<object, object>,
+): void {
+  const {getPrototypeOf} = globalObject.Object;
+
+  Object.defineProperty(globalObject.Object, 'getPrototypeOf', {
+    configurable: true,
+    value(value: unknown): object | null {
+      const prototype = getPrototypeOf(value);
+
+      return prototype === null
+        ? null
+        : (prototypeMap.get(prototype) ?? prototype);
+    },
+    writable: true,
+  });
+}
+
+function installCrossContextConstructorAliases(
+  globalObject: typeof globalThis,
+): void {
+  const prototypeMap = new Map<object, object>();
+
+  // Node APIs can return values from the parent realm. Teach the test realm's
+  // constructors to recognize those values without replacing the VM intrinsics.
+  for (const constructorName of crossContextConstructorNames) {
+    const globalConstructor = getNativeConstructor(
+      globalObject,
+      constructorName,
+    );
+    const nativeConstructor = getNativeConstructor(globalThis, constructorName);
+
+    if (
+      globalConstructor === undefined ||
+      nativeConstructor === undefined ||
+      globalConstructor === nativeConstructor
+    ) {
+      continue;
+    }
+
+    addCrossContextInstanceOfAlias(globalConstructor, nativeConstructor);
+    prototypeMap.set(nativeConstructor.prototype, globalConstructor.prototype);
+  }
+
+  if (prototypeMap.size > 0) {
+    installCrossContextGetPrototypeOfAlias(globalObject, prototypeMap);
+  }
 }
 
 const timerIdToRef = (id: number) => ({
@@ -185,6 +325,8 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
     // different than the global one used by users in tests. This makes sure the
     // same constructor is referenced by both.
     global.Uint8Array = Uint8Array;
+
+    installCrossContextConstructorAliases(global);
 
     installCommonGlobals(global, projectConfig.globals, globalsCleanupMode);
 


### PR DESCRIPTION
## Summary

Fixes #2549.

`jest-environment-node` already keeps the VM intrinsics for isolation, but Node APIs can still return values created in the parent realm. That makes checks like `error instanceof Error`, `query.tag instanceof Array`, and `Object.getPrototypeOf(process.report.getReport()) === Object.prototype` fail inside tests even though the values come from normal Node APIs.

This change teaches the test realm's native constructors to recognize matching parent-realm values through `Symbol.hasInstance`, while keeping the VM constructors in place. It also maps parent-realm native prototypes returned by `Object.getPrototypeOf` back to the corresponding test-realm prototypes.

The new e2e fixture covers:

- arrays returned from Node's URL parser
- errors thrown by `fs`
- avoiding the old failure mode where a parent-realm `Error` matched unrelated test-realm subclasses
- objects returned by Node's process report API

## Test plan

- `corepack yarn@4.14.1 install --immutable`
- `corepack yarn@4.14.1 build:js`
- `corepack yarn@4.14.1 eslint --cache --fix packages/jest-environment-node/src/index.ts e2e/__tests__/instanceof.test.ts e2e/instanceof/__tests__/test.js`
- `corepack yarn@4.14.1 build:ts`
- `corepack yarn@4.14.1 jest e2e/__tests__/instanceof.test.ts --runInBand`
- `npx -y node@18.20.8 .yarn/releases/yarn-4.14.1.cjs jest e2e/__tests__/instanceof.test.ts --runInBand`
- `corepack yarn@4.14.1 jest e2e/__tests__/env.test.ts e2e/__tests__/json.test.ts e2e/__tests__/global.test.ts --runInBand`
- `GLOBALS_CLEANUP=off|soft|on corepack yarn@4.14.1 jest --runInBand packages/jest-environment-node/src/__tests__`
- `corepack yarn@4.14.1 check-changelog 16205`
- `git diff --check`

Also ran `corepack yarn@4.14.1 check-copyright-headers`; it currently fails on existing `e2e/transform-linked-modules/ignored/symlink.js`, which this PR does not touch.