### PR TITLE
fix(jest-mock): support promise helpers on overloaded mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
+- `[jest-mock]` Support mock return and promise helper types for overloaded functions ([#16207](https://github.com/jestjs/jest/pull/16207))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 - `[jest-runtime]` Support older test environments whose `moduleMocker` does not implement `clearMocksOnScope` ([#16169](https://github.com/jestjs/jest/pull/16169))
 

--- a/packages/jest-mock/__typetests__/Mocked.test.ts
+++ b/packages/jest-mock/__typetests__/Mocked.test.ts
@@ -117,7 +117,6 @@ describe('Mocked', () => {
     expect(client.end.mockResolvedValueOnce).type.toBeCallableWith(undefined);
     expect(client.end.mockRejectedValue).type.toBeCallableWith(new Error());
     expect(client.end.mockRejectedValueOnce).type.toBeCallableWith(new Error());
-    expect(client.end.mockReturnValue).type.toBeCallableWith(Promise.resolve());
   });
 
   test('wraps a function object type with type definitions of the Jest mock function', () => {

--- a/packages/jest-mock/__typetests__/Mocked.test.ts
+++ b/packages/jest-mock/__typetests__/Mocked.test.ts
@@ -105,6 +105,21 @@ describe('Mocked', () => {
     expect(someAsyncFunction).type.toBeAssignableFrom(mockAsyncFunction);
   });
 
+  test('supports promise helpers on overloaded methods', () => {
+    interface Client {
+      end(): Promise<void>;
+      end(callback: (err: Error) => void): void;
+    }
+
+    const client = {} as Mocked<Client>;
+
+    expect(client.end.mockResolvedValue).type.toBeCallableWith(undefined);
+    expect(client.end.mockResolvedValueOnce).type.toBeCallableWith(undefined);
+    expect(client.end.mockRejectedValue).type.toBeCallableWith(new Error());
+    expect(client.end.mockRejectedValueOnce).type.toBeCallableWith(new Error());
+    expect(client.end.mockReturnValue).type.toBeCallableWith(Promise.resolve());
+  });
+
   test('wraps a function object type with type definitions of the Jest mock function', () => {
     interface SomeFunctionObject {
       (a: number, b?: string): void;

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -132,10 +132,35 @@ export interface Mock<T extends FunctionLike = UnknownFunction>
 }
 
 type ResolveType<T extends FunctionLike> =
-  ReturnType<T> extends PromiseLike<infer U> ? U : never;
+  FunctionReturn<T> extends infer R
+    ? R extends PromiseLike<infer U>
+      ? U
+      : never
+    : never;
 
 type RejectType<T extends FunctionLike> =
-  ReturnType<T> extends PromiseLike<any> ? unknown : never;
+  FunctionReturn<T> extends infer R
+    ? R extends PromiseLike<any>
+      ? unknown
+      : never
+    : never;
+
+type FunctionReturn<F> = F extends {
+  (...args: Array<any>): infer R1;
+  (...args: Array<any>): infer R2;
+  (...args: Array<any>): infer R3;
+  (...args: Array<any>): infer R4;
+  (...args: Array<any>): infer R5;
+  (...args: Array<any>): infer R6;
+  (...args: Array<any>): infer R7;
+  (...args: Array<any>): infer R8;
+  (...args: Array<any>): infer R9;
+  (...args: Array<any>): infer R10;
+}
+  ? R1 | R2 | R3 | R4 | R5 | R6 | R7 | R8 | R9 | R10
+  : F extends (...args: Array<any>) => infer R
+    ? R
+    : never;
 
 export interface MockInstance<
   T extends FunctionLike = UnknownFunction,
@@ -154,8 +179,8 @@ export interface MockInstance<
   withImplementation(fn: T, callback: () => void): void;
   mockName(name: string): this;
   mockReturnThis(): this;
-  mockReturnValue(value: ReturnType<T>): this;
-  mockReturnValueOnce(value: ReturnType<T>): this;
+  mockReturnValue(value: FunctionReturn<T>): this;
+  mockReturnValueOnce(value: FunctionReturn<T>): this;
   mockResolvedValue(value: ResolveType<T>): this;
   mockResolvedValueOnce(value: ResolveType<T>): this;
   mockRejectedValue(value: RejectType<T>): this;
@@ -854,7 +879,7 @@ export class ModuleMocker {
         return restore ? restore() : undefined;
       };
 
-      f.mockReturnValueOnce = (value: ReturnType<T>) =>
+      f.mockReturnValueOnce = (value: FunctionReturn<T>) =>
         // next function call will return this value or default return value
         f.mockImplementationOnce(() => value);
 
@@ -868,7 +893,7 @@ export class ModuleMocker {
           this._environmentGlobal.Promise.reject(value),
         );
 
-      f.mockReturnValue = (value: ReturnType<T>) =>
+      f.mockReturnValue = (value: FunctionReturn<T>) =>
         // next function call will return specified return value or this one
         f.mockImplementation(() => value);
 

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -179,8 +179,8 @@ export interface MockInstance<
   withImplementation(fn: T, callback: () => void): void;
   mockName(name: string): this;
   mockReturnThis(): this;
-  mockReturnValue(value: FunctionReturn<T>): this;
-  mockReturnValueOnce(value: FunctionReturn<T>): this;
+  mockReturnValue(value: ReturnType<T>): this;
+  mockReturnValueOnce(value: ReturnType<T>): this;
   mockResolvedValue(value: ResolveType<T>): this;
   mockResolvedValueOnce(value: ResolveType<T>): this;
   mockRejectedValue(value: RejectType<T>): this;
@@ -879,7 +879,7 @@ export class ModuleMocker {
         return restore ? restore() : undefined;
       };
 
-      f.mockReturnValueOnce = (value: FunctionReturn<T>) =>
+      f.mockReturnValueOnce = (value: ReturnType<T>) =>
         // next function call will return this value or default return value
         f.mockImplementationOnce(() => value);
 
@@ -893,7 +893,7 @@ export class ModuleMocker {
           this._environmentGlobal.Promise.reject(value),
         );
 
-      f.mockReturnValue = (value: FunctionReturn<T>) =>
+      f.mockReturnValue = (value: ReturnType<T>) =>
         // next function call will return specified return value or this one
         f.mockImplementation(() => value);
 


### PR DESCRIPTION
Fixes #16174

## Summary
This fixes `jest-mock` promise helper types for overloaded functions where one overload returns a promise and another returns a non-promise value.

## Why
Before this change, helpers like `mockResolvedValue`, `mockRejectedValue`, and `mockReturnValue` used `ReturnType<T>`. For overloaded functions, TypeScript can collapse that to the callback-style overload, which makes valid promise mocks type as `never` or `void`.

## Test plan
- `corepack yarn build:ts`
- `corepack yarn tstyche packages/jest-mock/__typetests__/Mocked.test.ts`
- `corepack yarn eslint --cache packages/jest-mock/src/index.ts packages/jest-mock/__typetests__/Mocked.test.ts`
- `corepack yarn prettier --check packages/jest-mock/src/index.ts packages/jest-mock/__typetests__/Mocked.test.ts`
