### PR TITLE
fix(jest-util): stop globalsCleanup 'soft' mode from infinite-recursing on data-property writes (#16044)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[jest-mock]` `mockResolvedValue` / `mockRejectedValue` now see all overload return types, so a Promise-returning overload survives even when a later overload returns a non-Promise (e.g. `pg.Client['end']`) ([#16237](https://github.com/jestjs/jest/pull/16237))
+- `[jest-util]` Fix `globalsCleanup` `'soft'` mode causing `RangeError: Maximum call stack size exceeded` on the first write to any soft-deleted data property ([#16210](https://github.com/jestjs/jest/pull/16210))
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
 - `[jest-mock]` Remove the leftover own accessor descriptor when restoring a `spyOn` of an inherited getter or setter, so the instance keeps reflecting the prototype ([#16226](https://github.com/jestjs/jest/pull/16226))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))

--- a/packages/jest-util/src/__tests__/garbage-collection-utils.test.ts
+++ b/packages/jest-util/src/__tests__/garbage-collection-utils.test.ts
@@ -5,9 +5,26 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {protectProperties} from '../garbage-collection-utils';
+import {deleteProperties, protectProperties} from '../garbage-collection-utils';
 
 const omit = require('lodash').omit;
+
+// Mirror the registered symbols used inside garbage-collection-utils so each
+// test can force the deletion mode it needs regardless of what an earlier
+// setup script already initialized.
+const DELETION_MODE_SYMBOL = Symbol.for('$$jest-deletion-mode');
+
+// Real user objects in a jest run inherit a `PROTECT_SYMBOL` value from
+// globalThis when jest-circus protects the global scope, which causes
+// `deleteProperties` to treat every own key as protected. Construct
+// prototypeless objects so the soft-delete path actually visits them.
+function makeBareObject<T extends object>(props: T): T {
+  const obj = Object.create(null) as T;
+  for (const key of Reflect.ownKeys(props) as Array<keyof T>) {
+    obj[key] = props[key];
+  }
+  return obj;
+}
 
 it('protection symbol doesnt leak', () => {
   const obj = {a: 1, b: 2};
@@ -15,4 +32,72 @@ it('protection symbol doesnt leak', () => {
   expect(obj).toStrictEqual(obj);
   expect(omit(obj, 'a')).toStrictEqual({b: 2});
   expect({b: 2}).toStrictEqual(omit(obj, 'a'));
+});
+
+describe('soft deletion writes', () => {
+  // The soft-deletion code path defines a wrapping setter for every
+  // descriptor it visits. For data properties (no original setter on the
+  // descriptor) the wrapping setter used to forward into
+  // `Reflect.set(obj, key, value)` -- which re-entered the same wrapping
+  // setter and produced `RangeError: Maximum call stack size exceeded`
+  // on the first write after soft-delete. Regression for #16044.
+  let originalEmitWarning: typeof process.emitWarning;
+  let originalDeletionMode: unknown;
+
+  beforeAll(() => {
+    originalDeletionMode = Reflect.get(globalThis, DELETION_MODE_SYMBOL);
+    Reflect.set(globalThis, DELETION_MODE_SYMBOL, 'soft');
+    originalEmitWarning = process.emitWarning;
+    // Silence the deprecation warnings the soft-delete wrappers emit on
+    // every access; otherwise stderr fills with one warning per assertion.
+    process.emitWarning = () => {};
+  });
+
+  afterAll(() => {
+    process.emitWarning = originalEmitWarning;
+    if (originalDeletionMode === undefined) {
+      Reflect.deleteProperty(globalThis, DELETION_MODE_SYMBOL);
+    } else {
+      Reflect.set(globalThis, DELETION_MODE_SYMBOL, originalDeletionMode);
+    }
+  });
+
+  it('writing to a soft-deleted data property does not recurse', () => {
+    const obj = makeBareObject<{foo: string}>({foo: 'bar'});
+    deleteProperties(obj);
+
+    expect(() => {
+      obj.foo = 'baz';
+    }).not.toThrow();
+
+    expect(obj.foo).toBe('baz');
+  });
+
+  it('repeated writes to a soft-deleted data property each take effect', () => {
+    const obj = makeBareObject<{counter: number}>({counter: 0});
+    deleteProperties(obj);
+
+    for (let i = 1; i <= 5; i++) {
+      obj.counter = i;
+      expect(obj.counter).toBe(i);
+    }
+  });
+
+  it('preserves the original accessor setter on accessor descriptors', () => {
+    const log: Array<unknown> = [];
+    const obj = Object.create(null) as {value: number};
+    Reflect.defineProperty(obj, 'value', {
+      configurable: true,
+      enumerable: true,
+      get: () => 1,
+      set: (v: unknown) => {
+        log.push(v);
+      },
+    });
+    deleteProperties(obj);
+
+    obj.value = 42;
+    obj.value = 7;
+    expect(log).toEqual([42, 7]);
+  });
 });

--- a/packages/jest-util/src/garbage-collection-utils.ts
+++ b/packages/jest-util/src/garbage-collection-utils.ts
@@ -161,9 +161,23 @@ function deleteProperty(obj: object, key: string | symbol): boolean {
     return Reflect.deleteProperty(obj, key);
   }
 
-  const originalGetter = descriptor.get ?? (() => descriptor.value);
+  // For data descriptors, the fallback fast-path used to be
+  // `value => Reflect.set(obj, key, value)`, which recursed back into the
+  // new setter we are about to install on `obj[key]` and produced
+  // `RangeError: Maximum call stack size exceeded` on the first write
+  // after a soft delete (issue #16044). Keep the data-property value in a
+  // closure-scoped slot instead so writes update local storage rather
+  // than re-entering the wrapping setter. Accessor descriptors that
+  // already carry their own setter keep using it -- calling
+  // `descriptor.set(value)` directly is correct and does not loop.
+  let storedValue: unknown = descriptor.value;
+  const originalGetter = descriptor.get ?? (() => storedValue);
   const originalSetter =
-    descriptor.set ?? (value => Reflect.set(obj, key, value));
+    descriptor.set ??
+    ((value: unknown) => {
+      storedValue = value;
+      return true;
+    });
 
   return Reflect.defineProperty(obj, key, {
     configurable: true,


### PR DESCRIPTION
Fixes #16044.

## Bug

In soft deletion mode, `deleteProperty` in `jest-util/src/garbage-collection-utils.ts` wraps every visited property with a setter that emits a deprecation warning and then forwards to the original setter. For data descriptors (the common case), the original setter defaulted to:

```ts
const originalSetter = descriptor.set ?? (value => Reflect.set(obj, key, value));
```

That `Reflect.set(obj, key, value)` routes the write back through the same wrapping setter we just installed on `obj[key]`, producing `RangeError: Maximum call stack size exceeded` on the first write to any soft-deleted data property.

Reproducer from the issue:

```js
const obj = { foo: 'bar' };
const descriptor = Reflect.getOwnPropertyDescriptor(obj, 'foo');
const originalSetter = descriptor.set ?? (value => Reflect.set(obj, 'foo', value));
Reflect.defineProperty(obj, 'foo', {
  configurable: true,
  enumerable: descriptor.enumerable,
  get() { return descriptor.value; },
  set(value) { return originalSetter(value); },
});
obj.foo = 'baz'; // RangeError: Maximum call stack size exceeded
```

## Fix

Keep the data-property value in a closure-scoped slot instead of routing back through `Reflect.set`. Accessor descriptors that already carry their own setter keep using it because calling `descriptor.set(value)` directly does not re-enter the wrapping setter.

```ts
let storedValue: unknown = descriptor.value;
const originalGetter = descriptor.get ?? (() => storedValue);
const originalSetter =
  descriptor.set ??
  ((value: unknown) => {
    storedValue = value;
    return true;
  });
```

## Verification

Added regression coverage in `packages/jest-util/src/__tests__/garbage-collection-utils.test.ts` covering:

1. A single write to a soft-deleted data property does not recurse and updates the value.
2. Repeated writes each take effect.
3. Accessor descriptors with their own setter are still routed through the original setter (the non-buggy path is preserved).

Local A/B run:

```
without fix (main): 2 failed, 2 passed
  ✕ writing to a soft-deleted data property does not recurse
  ✕ repeated writes to a soft-deleted data property each take effect
  Stack trace: RangeError: Maximum call stack size exceeded at Reflect.set

with fix:           4 passed, 0 failed
```

The tests construct prototype-less objects (`Object.create(null)`) so they bypass the `PROTECT_SYMBOL` value jest-circus installs on the global scope, which would otherwise cause `deleteProperties` to treat every own key as protected and skip the wrapping path entirely.

## CHANGELOG

Added an entry under `## main` -> `### Fixes` referencing this PR.