### PR TITLE
test: cover asymmetric matcher failures with worker threads

### DIFF
--- a/e2e/__tests__/__snapshots__/nonSerializableStructuresInequality.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nonSerializableStructuresInequality.test.ts.snap
@@ -130,6 +130,62 @@ Time:        <<REPLACED>>
 Ran all test suites."
 `;
 
+exports[`processChild handles asymmetric matchers 1`] = `
+"FAIL __tests__/test-1.js
+  ● test
+
+    expect(received).toEqual(expected) // deep equality
+
+    - Expected  - 4
+    + Received  + 1
+
+    - Object {
+    -   "value1": 0,
+    -   "value2": Any<String>,
+    - }
+    + Object {}
+
+      1 | it('test', () => {
+    > 2 |   expect({}).toEqual({
+        |              ^
+      3 |     value1: 0,
+      4 |     value2: expect.any(String),
+      5 |   });
+
+      at Object.toEqual (__tests__/test-1.js:2:14)
+
+FAIL __tests__/test-2.js
+  ● test
+
+    expect(received).toEqual(expected) // deep equality
+
+    - Expected  - 4
+    + Received  + 1
+
+    - Object {
+    -   "value1": 0,
+    -   "value2": Any<String>,
+    - }
+    + Object {}
+
+      1 | it('test', () => {
+    > 2 |   expect({}).toEqual({
+        |              ^
+      3 |     value1: 0,
+      4 |     value2: expect.any(String),
+      5 |   });
+
+      at Object.toEqual (__tests__/test-2.js:2:14)"
+`;
+
+exports[`processChild handles asymmetric matchers 2`] = `
+"Test Suites: 2 failed, 2 total
+Tests:       2 failed, 2 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
+`;
+
 exports[`processChild handles circular inequality properly 1`] = `
 "FAIL __tests__/test-1.js
   ● test
@@ -389,6 +445,62 @@ FAIL __tests__/test-2.js
 `;
 
 exports[`workerThreads handles \`Symbol\` 2`] = `
+"Test Suites: 2 failed, 2 total
+Tests:       2 failed, 2 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites."
+`;
+
+exports[`workerThreads handles asymmetric matchers 1`] = `
+"FAIL __tests__/test-1.js
+  ● test
+
+    expect(received).toEqual(expected) // deep equality
+
+    - Expected  - 4
+    + Received  + 1
+
+    - Object {
+    -   "value1": 0,
+    -   "value2": Any<String>,
+    - }
+    + Object {}
+
+      1 | it('test', () => {
+    > 2 |   expect({}).toEqual({
+        |              ^
+      3 |     value1: 0,
+      4 |     value2: expect.any(String),
+      5 |   });
+
+      at Object.toEqual (__tests__/test-1.js:2:14)
+
+FAIL __tests__/test-2.js
+  ● test
+
+    expect(received).toEqual(expected) // deep equality
+
+    - Expected  - 4
+    + Received  + 1
+
+    - Object {
+    -   "value1": 0,
+    -   "value2": Any<String>,
+    - }
+    + Object {}
+
+      1 | it('test', () => {
+    > 2 |   expect({}).toEqual({
+        |              ^
+      3 |     value1: 0,
+      4 |     value2: expect.any(String),
+      5 |   });
+
+      at Object.toEqual (__tests__/test-2.js:2:14)"
+`;
+
+exports[`workerThreads handles asymmetric matchers 2`] = `
 "Test Suites: 2 failed, 2 total
 Tests:       2 failed, 2 total
 Snapshots:   0 total

--- a/e2e/__tests__/nonSerializableStructuresInequality.test.ts
+++ b/e2e/__tests__/nonSerializableStructuresInequality.test.ts
@@ -107,6 +107,22 @@ describe.each([
     expect(summary).toMatchSnapshot();
   });
 
+  test('handles asymmetric matchers', async () => {
+    const {summary, rest} = await testIn2Workers(
+      `
+    it('test', () => {
+      expect({}).toEqual({
+        value1: 0,
+        value2: expect.any(String),
+      });
+    });
+  `,
+      extraOptions,
+    );
+    expect(rest).toMatchSnapshot();
+    expect(summary).toMatchSnapshot();
+  });
+
   test('handles functions', async () => {
     const {summary, rest} = await testIn2Workers(
       `


### PR DESCRIPTION
## Summary

Adds e2e regression coverage for #15078 using the reported `expect.any(String)` asymmetric matcher failure under both process workers and `--workerThreads`.

Current `main` already reports the real `toEqual` failure instead of a `DataCloneError`; this locks that behavior in the existing non-serializable inequality suite.

No changelog entry because this is test-only and does not change runtime behavior.

## Test plan

- `yarn build:js`
- `yarn jest e2e\__tests__\nonSerializableStructuresInequality.test.ts --runInBand -u`
- `yarn jest e2e\__tests__\nonSerializableStructuresInequality.test.ts --runInBand`
- `yarn eslint e2e\__tests__\nonSerializableStructuresInequality.test.ts`
- `git diff --check`