### PR TITLE
fix(jest-mock): type constructed mocked class instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
+- `[jest-mock]` Type constructed mocked class instances returned by `ModuleMocker.generateFromMetadata()` as mocked objects ([#16212](https://github.com/jestjs/jest/pull/16212))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 - `[jest-runtime]` Support older test environments whose `moduleMocker` does not implement `clearMocksOnScope` ([#16169](https://github.com/jestjs/jest/pull/16169))
 

--- a/packages/jest-mock/__typetests__/ModuleMocker.test.ts
+++ b/packages/jest-mock/__typetests__/ModuleMocker.test.ts
@@ -6,7 +6,12 @@
  */
 
 import {expect, test} from 'tstyche';
-import {type MockMetadata, type Mocked, ModuleMocker} from 'jest-mock';
+import {
+  type MockMetadata,
+  type Mocked,
+  type MockedObject,
+  ModuleMocker,
+} from 'jest-mock';
 
 class ExampleClass {
   memberA: Array<number>;
@@ -78,4 +83,14 @@ test('generateFromMetadata', () => {
   expect(exampleMock.propertyD).type.toBe<string>();
   expect(exampleMock.propertyE).type.toBe<boolean>();
   expect(exampleMock.propertyF).type.toBe<symbol>();
+});
+
+test('generateFromMetadata constructs mocked class instances', () => {
+  const classMetadata = moduleMocker.getMetadata(ExampleClass);
+  const MockClass = moduleMocker.generateFromMetadata(classMetadata!);
+
+  const instance = new MockClass();
+
+  expect(instance).type.toBeAssignableTo<MockedObject<ExampleClass>>();
+  expect(instance.memberB.mock.calls).type.toBe<Array<[]>>();
 });

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -56,6 +56,7 @@ export type PropertyLikeKeys<T> = Exclude<
 export type MockedClass<T extends ClassLike> = MockInstance<
   (...args: ConstructorParameters<T>) => Mocked<InstanceType<T>>
 > &
+  (new (...args: ConstructorParameters<T>) => Mocked<InstanceType<T>>) &
   MockedObject<T>;
 
 export type MockedFunction<T extends FunctionLike> = MockInstance<T> &


### PR DESCRIPTION
## Summary

Fixes #14458.

`MockedClass<T>` already typed mock calls with constructor parameters, but it did not expose a construct signature returning a mocked instance. As a result, constructing a class returned by `ModuleMocker.generateFromMetadata()` was typed as the original instance type, so mocked methods like `instance.memberB.mock` were missing at the type level even though they exist at runtime.

This adds the missing construct signature and covers the regression in the `jest-mock` TSTyche tests.

## Test plan

- `corepack yarn tsc -b packages\expect-utils packages\jest-types packages\jest-util packages\jest-mock`
- `corepack yarn tstyche packages\jest-mock\__typetests__\ModuleMocker.test.ts packages\jest-mock\__typetests__\Mocked.test.ts`
- `corepack yarn tstyche packages/jest-mock/__typetests__`
- `corepack yarn eslint packages\jest-mock\src\index.ts packages\jest-mock\__typetests__\ModuleMocker.test.ts`
- `corepack yarn jest packages\jest-mock\src\__tests__\index.test.ts --runInBand`
- `git diff --check`