### PR TITLE
fix(jest-resolve): retry volume GUID paths without symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
+- `[jest-resolve]` Retry Windows volume GUID paths without symlink resolution ([#16215](https://github.com/jestjs/jest/pull/16215))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 - `[jest-runtime]` Support older test environments whose `moduleMocker` does not implement `clearMocksOnScope` ([#16169](https://github.com/jestjs/jest/pull/16169))
 

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -22,6 +22,7 @@ jest.mock('../__mocks__/userResolver').mock('../__mocks__/userResolverAsync');
 
 const mockUserResolver = jest.mocked(userResolver);
 const mockUserResolverAsync = jest.mocked(userResolverAsync);
+const itOnWindows = process.platform === 'win32' ? it : it.skip;
 
 beforeEach(() => {
   mockUserResolver.mockClear();
@@ -144,6 +145,30 @@ describe('findNodeModule', () => {
 
     expect(newPath).toBe(__filename);
   });
+
+  itOnWindows(
+    'retries Windows volume GUID paths without symlink resolution',
+    async () => {
+      const basedir =
+        '\\\\?\\Volume{c79c005d-0000-0000-0000-100000000000}\\project';
+
+      expect(() =>
+        defaultResolver('missing-package', {
+          basedir,
+          defaultAsyncResolver,
+          defaultResolver,
+        }),
+      ).toThrow("Cannot find module 'missing-package'");
+
+      await expect(
+        defaultAsyncResolver('missing-package', {
+          basedir,
+          defaultAsyncResolver,
+          defaultResolver,
+        }),
+      ).rejects.toThrow("Cannot find module 'missing-package'");
+    },
+  );
 
   describe('conditions', () => {
     const conditionsRoot = path.resolve(__dirname, '../__mocks__/conditions');

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -93,7 +93,7 @@ function baseResolver(
 
   modules = modules || (moduleDirectory as Array<string>);
 
-  const resolveOptions: UpstreamResolveOptions = {
+  let resolveOptions: UpstreamResolveOptions = {
     conditionNames: conditionNames ||
       (conditions as Array<string> | undefined) || [
         'require',
@@ -119,6 +119,19 @@ function baseResolver(
   const finalResolver = (
     resolve: () => ResolveResult | Promise<ResolveResult>,
   ) => {
+    const retryWithoutSymlinksIfUnsupported = (result: ResolveResult) => {
+      if (
+        typeof result.error === 'string' &&
+        result.error.includes('contains unsupported construct') &&
+        resolveOptions.symlinks !== false
+      ) {
+        resolveOptions = {...resolveOptions, symlinks: false};
+        unrsResolver = unrsResolver!.cloneWithOptions(resolveOptions);
+        setResolver(unrsResolver);
+        return resolve();
+      }
+      return result;
+    };
     const resolveWithPathsFallback = (result: ResolveResult) => {
       if (!result.path && paths?.length) {
         const modulesArr =
@@ -137,13 +150,23 @@ function baseResolver(
       }
       return result;
     };
+    const resolveWithFallbacks = (result: ResolveResult) => {
+      const resultWithSymlinksFallback =
+        retryWithoutSymlinksIfUnsupported(result);
+      if ('then' in resultWithSymlinksFallback) {
+        return resultWithSymlinksFallback.then(resolveWithPathsFallback);
+      }
+      return resolveWithPathsFallback(resultWithSymlinksFallback);
+    };
     const result = resolve();
     if ('then' in result) {
-      return result.then(resolveWithPathsFallback).then(handleResolveResult);
+      return result.then(resolveWithFallbacks).then(handleResolveResult);
     }
-    return handleResolveResult(
-      resolveWithPathsFallback(result) as ResolveResult,
-    );
+    const resultWithFallbacks = resolveWithFallbacks(result);
+    if ('then' in resultWithFallbacks) {
+      return resultWithFallbacks.then(handleResolveResult);
+    }
+    return handleResolveResult(resultWithFallbacks as ResolveResult);
   };
 
   return finalResolver(() =>


### PR DESCRIPTION
﻿## Problem

On Windows mounted volumes, `unrs-resolver` can return `Path "\\?\Volume{...}" contains unsupported construct` while resolving config entries such as `setupFilesAfterEnv`. Jest catches that as a missing module, so installed packages can be reported as not found.

Fixes #15923.

## Root cause

The default resolver always resolves through `unrs-resolver` with symlink realpathing enabled. For Windows volume GUID paths, `unrs-resolver` rejects the extended path construct before normal module lookup can proceed. The same lookup falls through normally when symlink realpathing is disabled.

## Solution

When `unrs-resolver` reports an unsupported path construct, retry the same lookup with `symlinks: false`. The retry is scoped to that failure path; normal resolver symlink behavior is unchanged.

## Tests run

- Reproduced locally with `new ResolverFactory({}).sync('\\?\Volume{...}\project', 'nonexistent-package')`, which returned the unsupported-construct error; `symlinks: false` returned a normal module-not-found result.
- `corepack yarn jest packages/jest-resolve/src/__tests__/resolve.test.ts --runTestsByPath --testNamePattern="Windows volume GUID"`
- `corepack yarn jest packages/jest-resolve/src/__tests__/resolve.test.ts --runTestsByPath --testNamePattern="findNodeModule"`
- `corepack yarn tsc -b packages/jest-resolve`
- `corepack yarn eslint --cache packages/jest-resolve/src/defaultResolver.ts packages/jest-resolve/src/__tests__/resolve.test.ts`
- `corepack yarn prettier --check packages/jest-resolve/src/defaultResolver.ts packages/jest-resolve/src/__tests__/resolve.test.ts`
- `git diff --check`

I also checked the unrelated `resolveModule` / `resolveModuleAsync` realpath tests on this Windows checkout; they fail on `main` too with `TypeError: The "from" argument must be of type string. Received undefined`, so I did not treat them as introduced by this patch.
