### PR TITLE
fix(jest-mock): restore withImplementation after errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
+- `[jest-mock]` Restore `withImplementation(...)` after sync throws and async rejections ([#16219](https://github.com/jestjs/jest/pull/16219))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 - `[jest-runtime]` Support older test environments whose `moduleMocker` does not implement `clearMocksOnScope` ([#16169](https://github.com/jestjs/jest/pull/16169))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 - `[jest-runtime]` Throw `ERR_REQUIRE_CYCLE_MODULE` like Node when a CommonJS module `require()`s an ES module that is still being loaded, instead of evaluating the module a second time ([#16366](https://github.com/jestjs/jest/pull/16366))
 - `[jest-runtime]` Key builtin modules in the ESM registry by one canonical specifier ([#16341](https://github.com/jestjs/jest/pull/16341))
 - `[jest-runtime]` `import.meta.resolve()` for a builtin uses its `node:` specifier ([#16341](https://github.com/jestjs/jest/pull/16341))
+- `[jest-mock]` Restore `withImplementation(...)` after sync throws and async rejections ([#16219](https://github.com/jestjs/jest/pull/16219))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 - `[jest-runtime]` Allow `require()` of ESM-marked files on Node < 24.9 via transform fallback ([#16244](https://github.com/jestjs/jest/pull/16244))
 - `[jest-runtime, @jest/transform]` Surface actionable `ERR_REQUIRE_ESM` error for files with untransformed ESM syntax instead of the generic "unexpected token" message ([#16244](https://github.com/jestjs/jest/pull/16244))

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -1166,6 +1166,43 @@ describe('moduleMocker', () => {
       expect.assertions(4);
     });
 
+    it('restores the previous implementation after the callback throws', () => {
+      const mock = jest
+        .fn(() => 'outside callback')
+        .mockImplementationOnce(() => 'once');
+
+      expect(() =>
+        mock.withImplementation(
+          () => 'inside callback',
+          () => {
+            expect(mock()).toBe('inside callback');
+            throw new Error('boom');
+          },
+        ),
+      ).toThrow('boom');
+
+      expect(mock()).toBe('once');
+      expect(mock()).toBe('outside callback');
+    });
+
+    it('restores whenCalledWith fallbacks after the callback rejects', async () => {
+      const mock = jest.fn<(arg?: string) => string>(() => 'outside callback');
+      mock.whenCalledWith('branch').mockReturnValue('branch');
+
+      await expect(
+        mock.withImplementation(
+          () => 'inside callback',
+          async () => {
+            expect(mock('other')).toBe('inside callback');
+            throw new Error('boom');
+          },
+        ),
+      ).rejects.toThrow('boom');
+
+      expect(mock('branch')).toBe('branch');
+      expect(mock('other')).toBe('outside callback');
+    });
+
     it('mockImplementationOnce does not bleed into withImplementation', () => {
       const mock = jest
         .fn(() => 'outside callback')

--- a/packages/jest-mock/src/__tests__/index.test.ts
+++ b/packages/jest-mock/src/__tests__/index.test.ts
@@ -1185,6 +1185,25 @@ describe('moduleMocker', () => {
       expect(mock()).toBe('outside callback');
     });
 
+    it('restores the previous implementation when the thenable getter throws', () => {
+      const mock = jest.fn(() => 'outside callback');
+      // eslint-disable-next-line unicorn/no-thenable
+      const thenable = Object.defineProperty({}, 'then', {
+        get() {
+          throw new Error('boom');
+        },
+      }) as Promise<unknown>;
+
+      expect(() =>
+        mock.withImplementation(
+          () => 'inside callback',
+          () => thenable,
+        ),
+      ).toThrow('boom');
+
+      expect(mock()).toBe('outside callback');
+    });
+
     it('restores whenCalledWith fallbacks after the callback rejects', async () => {
       const mock = jest.fn<(arg?: string) => string>(() => 'outside callback');
       mock.whenCalledWith('branch').mockReturnValue('branch');

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -910,22 +910,35 @@ export class ModuleMocker {
         const previousImplementation = mockConfig.mockImpl;
         const previousSpecificImplementations = mockConfig.specificMockImpls;
         const previousFallbackImpl = mockConfig.fallbackImpl;
-        mockConfig.mockImpl = fn;
-        mockConfig.specificMockImpls = [];
-
-        const returnedValue = callback();
-
-        if (isPromise(returnedValue)) {
-          return returnedValue.then(() => {
-            mockConfig.mockImpl = previousImplementation;
-            mockConfig.specificMockImpls = previousSpecificImplementations;
-            mockConfig.fallbackImpl = previousFallbackImpl;
-          });
-        } else {
+        const restore = () => {
           mockConfig.mockImpl = previousImplementation;
           mockConfig.specificMockImpls = previousSpecificImplementations;
           mockConfig.fallbackImpl = previousFallbackImpl;
+        };
+        mockConfig.mockImpl = fn;
+        mockConfig.specificMockImpls = [];
+
+        let returnedValue: ReturnType<typeof callback>;
+        try {
+          returnedValue = callback();
+        } catch (error) {
+          restore();
+          throw error;
         }
+
+        if (isPromise(returnedValue)) {
+          return this._environmentGlobal.Promise.resolve(returnedValue).then(
+            () => {
+              restore();
+            },
+            error => {
+              restore();
+              throw error;
+            },
+          );
+        }
+
+        restore();
       }
 
       f.mockImplementation = (fn: T) => {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -948,22 +948,35 @@ export class ModuleMocker {
         const previousImplementation = mockConfig.mockImpl;
         const previousSpecificImplementations = mockConfig.specificMockImpls;
         const previousFallbackImpl = mockConfig.fallbackImpl;
-        mockConfig.mockImpl = fn;
-        mockConfig.specificMockImpls = [];
-
-        const returnedValue = callback();
-
-        if (isPromise(returnedValue)) {
-          return returnedValue.then(() => {
-            mockConfig.mockImpl = previousImplementation;
-            mockConfig.specificMockImpls = previousSpecificImplementations;
-            mockConfig.fallbackImpl = previousFallbackImpl;
-          });
-        } else {
+        const restore = () => {
           mockConfig.mockImpl = previousImplementation;
           mockConfig.specificMockImpls = previousSpecificImplementations;
           mockConfig.fallbackImpl = previousFallbackImpl;
+        };
+        mockConfig.mockImpl = fn;
+        mockConfig.specificMockImpls = [];
+
+        let returnedValue: ReturnType<typeof callback>;
+        try {
+          returnedValue = callback();
+        } catch (error) {
+          restore();
+          throw error;
         }
+
+        if (isPromise(returnedValue)) {
+          return this._environmentGlobal.Promise.resolve(returnedValue).then(
+            () => {
+              restore();
+            },
+            error => {
+              restore();
+              throw error;
+            },
+          );
+        }
+
+        restore();
       }
 
       f.mockImplementation = (fn: T) => {

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -956,24 +956,23 @@ export class ModuleMocker {
         mockConfig.mockImpl = fn;
         mockConfig.specificMockImpls = [];
 
-        let returnedValue: ReturnType<typeof callback>;
         try {
-          returnedValue = callback();
+          const returnedValue = callback();
+
+          if (isPromise(returnedValue)) {
+            return this._environmentGlobal.Promise.resolve(returnedValue).then(
+              () => {
+                restore();
+              },
+              error => {
+                restore();
+                throw error;
+              },
+            );
+          }
         } catch (error) {
           restore();
           throw error;
-        }
-
-        if (isPromise(returnedValue)) {
-          return this._environmentGlobal.Promise.resolve(returnedValue).then(
-            () => {
-              restore();
-            },
-            error => {
-              restore();
-              throw error;
-            },
-          );
         }
 
         restore();


### PR DESCRIPTION
## Summary

Fixes `mockFn.withImplementation(...)` so it restores the previous mock state when the callback throws synchronously or rejects asynchronously.

Closes #16218.

## Motivation

`withImplementation` is documented as a temporary override, but the current implementation only restores state on the normal synchronous path and on fulfilled promises. That leaves the temporary implementation installed after exceptional exits.

## How this works

- restore the previous mock state in a shared helper
- restore immediately when the callback throws
- adopt thenables through the environment `Promise` and restore on both fulfillment and rejection
- add regressions for sync throws and async rejections, including restoration of queued `mockImplementationOnce` state and `whenCalledWith` fallback behavior

## Validation

- `yarn jest packages/jest-mock/src/__tests__/index.test.ts --runInBand`
- `yarn jest packages/jest-mock/src/__tests__ --runInBand`
- `yarn build:ts`
- `yarn typecheck:tests`
