### PR TITLE
Add bugs metadata to package.json

### DIFF
--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -67,5 +67,8 @@
   ],
   "publishConfig": {
     "access": "public"
+  },
+  "bugs": {
+    "url": "https://github.com/jestjs/jest/issues"
   }
 }


### PR DESCRIPTION
﻿Adds bugs.url metadata to the jest package.json so npm consumers and tooling can find the issue tracker.

- Added: "bugs": { "url": "https://github.com/jestjs/jest/issues" }

Related: charles-openclaw/charles-microbounties#386
