### PR TITLE
fix(jest-mock): walk overloads in ResolveType/RejectType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
+- `[jest-mock]` `mockResolvedValue` / `mockRejectedValue` now see all overload return types, so a Promise-returning overload survives even when a later overload returns a non-Promise (e.g. `pg.Client['end']`) ([#16237](https://github.com/jestjs/jest/pull/16237))
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
 - `[jest-runtime]` Support older test environments whose `moduleMocker` does not implement `clearMocksOnScope` ([#16169](https://github.com/jestjs/jest/pull/16169))

--- a/packages/jest-mock/__typetests__/mock-functions.test.ts
+++ b/packages/jest-mock/__typetests__/mock-functions.test.ts
@@ -530,6 +530,28 @@ describe('jest.fn()', () => {
     ).type.not.toBeCallableWith();
   });
 
+  test('.mockResolvedValue() / .mockRejectedValue() see overloaded return types', () => {
+    // Regression for #16174. `pg.Client['end']` is the canonical example: the
+    // promise-returning overload is shadowed by a callback overload that
+    // returns `void`, so `ReturnType` collapses to `void` and the resolve /
+    // reject value types infer `never`. Walking the overload list and
+    // unioning return types lets the Promise-shaped overload survive.
+    interface OverloadedEnd {
+      (): Promise<void>;
+      (callback: (err: Error) => void): void;
+    }
+    const overloaded = fn<OverloadedEnd>();
+
+    expect(overloaded.mockResolvedValue).type.toBeCallableWith(undefined);
+    expect(overloaded.mockResolvedValueOnce).type.toBeCallableWith(undefined);
+    expect(overloaded.mockRejectedValue).type.toBeCallableWith(
+      new Error('boom'),
+    );
+    expect(overloaded.mockRejectedValueOnce).type.toBeCallableWith(
+      new Error('boom'),
+    );
+  });
+
   test('.withImplementation()', () => {
     expect(mockFn.withImplementation(mockFnImpl, () => {})).type.toBe<void>();
     expect(mockFn.withImplementation(mockFnImpl, async () => {})).type.toBe<

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -160,16 +160,18 @@ type OverloadedReturnType<T> = T extends {
         : never;
 
 type ResolveType<T extends FunctionLike> =
-  Extract<OverloadedReturnType<T>, PromiseLike<any>> extends PromiseLike<
-    infer U
-  >
-    ? U
-    : never;
+  [Extract<OverloadedReturnType<T>, PromiseLike<any>>] extends [never]
+    ? never
+    : Extract<OverloadedReturnType<T>, PromiseLike<any>> extends PromiseLike<
+          infer U
+        >
+      ? U
+      : never;
 
 type RejectType<T extends FunctionLike> =
-  Extract<OverloadedReturnType<T>, PromiseLike<any>> extends PromiseLike<any>
-    ? unknown
-    : never;
+  [Extract<OverloadedReturnType<T>, PromiseLike<any>>] extends [never]
+    ? never
+    : unknown;
 
 export interface MockInstance<
   T extends FunctionLike = UnknownFunction,

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -126,8 +126,7 @@ export type Spied<T extends ClassLike | FunctionLike> = T extends ClassLike
  * is provided, its typings are inferred correctly.
  */
 export interface Mock<T extends FunctionLike = UnknownFunction>
-  extends Function,
-    MockInstance<T> {
+  extends Function, MockInstance<T> {
   new (...args: Parameters<T>): ReturnType<T>;
   (...args: Parameters<T>): ReturnType<T>;
 }
@@ -176,8 +175,9 @@ type RejectType<T extends FunctionLike> = [
   ? never
   : unknown;
 
-export interface MockInstance<T extends FunctionLike = UnknownFunction>
-  extends Disposable {
+export interface MockInstance<
+  T extends FunctionLike = UnknownFunction,
+> extends Disposable {
   _isMockFunction: true;
   _protoImpl: Function;
   getMockImplementation(): T | undefined;

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -138,29 +138,31 @@ export interface Mock<T extends FunctionLike = UnknownFunction>
 // `never` and reject any value. Walk up to four overloads and union their
 // return types so the Promise-shaped overload (if any) survives.
 type OverloadedReturnType<T> = T extends {
-  (...args: any[]): infer R1;
-  (...args: any[]): infer R2;
-  (...args: any[]): infer R3;
-  (...args: any[]): infer R4;
+  (...args: Array<any>): infer R1;
+  (...args: Array<any>): infer R2;
+  (...args: Array<any>): infer R3;
+  (...args: Array<any>): infer R4;
 }
   ? R1 | R2 | R3 | R4
   : T extends {
-        (...args: any[]): infer R1;
-        (...args: any[]): infer R2;
-        (...args: any[]): infer R3;
+        (...args: Array<any>): infer R1;
+        (...args: Array<any>): infer R2;
+        (...args: Array<any>): infer R3;
       }
     ? R1 | R2 | R3
     : T extends {
-          (...args: any[]): infer R1;
-          (...args: any[]): infer R2;
+          (...args: Array<any>): infer R1;
+          (...args: Array<any>): infer R2;
         }
       ? R1 | R2
-      : T extends (...args: any[]) => infer R
+      : T extends (...args: Array<any>) => infer R
         ? R
         : never;
 
 type ResolveType<T extends FunctionLike> =
-  Extract<OverloadedReturnType<T>, PromiseLike<any>> extends PromiseLike<infer U>
+  Extract<OverloadedReturnType<T>, PromiseLike<any>> extends PromiseLike<
+    infer U
+  >
     ? U
     : never;
 

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -126,7 +126,8 @@ export type Spied<T extends ClassLike | FunctionLike> = T extends ClassLike
  * is provided, its typings are inferred correctly.
  */
 export interface Mock<T extends FunctionLike = UnknownFunction>
-  extends Function, MockInstance<T> {
+  extends Function,
+    MockInstance<T> {
   new (...args: Parameters<T>): ReturnType<T>;
   (...args: Parameters<T>): ReturnType<T>;
 }
@@ -159,23 +160,24 @@ type OverloadedReturnType<T> = T extends {
         ? R
         : never;
 
-type ResolveType<T extends FunctionLike> =
-  [Extract<OverloadedReturnType<T>, PromiseLike<any>>] extends [never]
-    ? never
-    : Extract<OverloadedReturnType<T>, PromiseLike<any>> extends PromiseLike<
-          infer U
-        >
-      ? U
-      : never;
+type ResolveType<T extends FunctionLike> = [
+  Extract<OverloadedReturnType<T>, PromiseLike<any>>,
+] extends [never]
+  ? never
+  : Extract<OverloadedReturnType<T>, PromiseLike<any>> extends PromiseLike<
+        infer U
+      >
+    ? U
+    : never;
 
-type RejectType<T extends FunctionLike> =
-  [Extract<OverloadedReturnType<T>, PromiseLike<any>>] extends [never]
-    ? never
-    : unknown;
+type RejectType<T extends FunctionLike> = [
+  Extract<OverloadedReturnType<T>, PromiseLike<any>>,
+] extends [never]
+  ? never
+  : unknown;
 
-export interface MockInstance<
-  T extends FunctionLike = UnknownFunction,
-> extends Disposable {
+export interface MockInstance<T extends FunctionLike = UnknownFunction>
+  extends Disposable {
   _isMockFunction: true;
   _protoImpl: Function;
   getMockImplementation(): T | undefined;

--- a/packages/jest-mock/src/index.ts
+++ b/packages/jest-mock/src/index.ts
@@ -131,11 +131,43 @@ export interface Mock<T extends FunctionLike = UnknownFunction>
   (...args: Parameters<T>): ReturnType<T>;
 }
 
+// `ReturnType<T>` picks the LAST overload signature of `T`, so for a function
+// like `pg.Client['end']` whose overloads are `(): Promise<void>` and
+// `(cb): void`, `ReturnType` collapses to `void` and the Promise-shaped
+// overload disappears — `mockResolvedValue` / `mockRejectedValue` then infer
+// `never` and reject any value. Walk up to four overloads and union their
+// return types so the Promise-shaped overload (if any) survives.
+type OverloadedReturnType<T> = T extends {
+  (...args: any[]): infer R1;
+  (...args: any[]): infer R2;
+  (...args: any[]): infer R3;
+  (...args: any[]): infer R4;
+}
+  ? R1 | R2 | R3 | R4
+  : T extends {
+        (...args: any[]): infer R1;
+        (...args: any[]): infer R2;
+        (...args: any[]): infer R3;
+      }
+    ? R1 | R2 | R3
+    : T extends {
+          (...args: any[]): infer R1;
+          (...args: any[]): infer R2;
+        }
+      ? R1 | R2
+      : T extends (...args: any[]) => infer R
+        ? R
+        : never;
+
 type ResolveType<T extends FunctionLike> =
-  ReturnType<T> extends PromiseLike<infer U> ? U : never;
+  Extract<OverloadedReturnType<T>, PromiseLike<any>> extends PromiseLike<infer U>
+    ? U
+    : never;
 
 type RejectType<T extends FunctionLike> =
-  ReturnType<T> extends PromiseLike<any> ? unknown : never;
+  Extract<OverloadedReturnType<T>, PromiseLike<any>> extends PromiseLike<any>
+    ? unknown
+    : never;
 
 export interface MockInstance<
   T extends FunctionLike = UnknownFunction,


### PR DESCRIPTION
Closes #16174.

## Summary

`ReturnType<T>` picks the **last** overload signature of `T`. For functions like [`pg.Client['end']`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/5b8b3cdc7c82f3b424e9cbb18c229f40b6497cec/types/pg/index.d.ts#L307-L308) whose overloads are `(): Promise<void>` and `(cb): void`, `ReturnType` collapses to `void` — the Promise-shaped overload disappears, `ResolveType` / `RejectType` both infer `never`, and `mockResolvedValue` / `mockRejectedValue` reject any value with `TS2345: Argument of type Error is not assignable to parameter of type never`.

## Fix

Introduce `OverloadedReturnType<T>` that walks up to four call signatures and unions their return types. Then keep the existing PromiseLike check through `Extract<..., PromiseLike<any>>` so:

- Sync overloads disappear from the resolve-type pool — `mockResolvedValue` on a sync overload still infers `never`.
- The Promise-shaped overload survives — `mockResolvedValue` infers the resolved `U`, `mockRejectedValue` infers `unknown` (matching the historical contract).

```ts
type OverloadedReturnType<T> = T extends {
    (...args: any[]): infer R1;
    (...args: any[]): infer R2;
    (...args: any[]): infer R3;
    (...args: any[]): infer R4;
  } ? R1 | R2 | R3 | R4
  : T extends { (...args: any[]): infer R1; (...args: any[]): infer R2; (...args: any[]): infer R3 } ? R1 | R2 | R3
  : T extends { (...args: any[]): infer R1; (...args: any[]): infer R2 } ? R1 | R2
  : T extends (...args: any[]) => infer R ? R
  : never;

type ResolveType<T extends FunctionLike> =
  Extract<OverloadedReturnType<T>, PromiseLike<any>> extends PromiseLike<infer U> ? U : never;

type RejectType<T extends FunctionLike> =
  Extract<OverloadedReturnType<T>, PromiseLike<any>> extends PromiseLike<any> ? unknown : never;
```

Four overload arities should cover the long tail — `pg.Client['end']` has 2, most DOM/Node APIs cap at 3-4. If anyone needs more, the pattern extends mechanically.

## Test plan

Added one typetest in `packages/jest-mock/__typetests__/mock-functions.test.ts`:

```ts
interface OverloadedEnd {
  (): Promise<void>;
  (callback: (err: Error) => void): void;
}
const overloaded = fn<OverloadedEnd>();
expect(overloaded.mockResolvedValue).type.toBeCallableWith(undefined);
expect(overloaded.mockRejectedValue).type.toBeCallableWith(new Error('boom'));
```

The existing typetests at lines 78-90 and 479-531 (single-signature sync vs async functions) continue to assert the same contract — sync-only functions still reject any resolve/reject value, async functions still narrow the resolve type to the resolved `U`.

I wasn't able to run `yarn build:js` / `yarn test-types` locally (disk space exhausted on my machine). CI should cover `typecheck:tests` and the tstyche suite — happy to amend if anything surfaces.