### PR TITLE
fix(jest-runtime): allow require() of ESM-marked files on Node < 24.9 via transform fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
+- `[jest-runtime]` Allow `require()` of ESM-marked files on Node < 24.9 via transform fallback ([#16152](https://github.com/jestjs/jest/pull/16152))
 - `[jest-runtime]` Support older test environments whose `moduleMocker` does not implement `clearMocksOnScope` ([#16169](https://github.com/jestjs/jest/pull/16169))
 
 ### Chore & Maintenance

--- a/packages/jest-runtime/src/__tests__/runtime_esm_cjs_interop.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_cjs_interop.test.ts
@@ -6,7 +6,11 @@
  */
 
 import * as path from 'path';
-import {testWithSyncEsm, testWithVmEsm} from '@jest/test-utils';
+import {
+  testWithSyncEsm,
+  testWithVmEsm,
+  testWithoutSyncEsm,
+} from '@jest/test-utils';
 
 const ROOT_DIR = path.join(__dirname, 'test_esm_interop_root');
 const FROM = path.join(ROOT_DIR, 'test.js');
@@ -181,6 +185,54 @@ describe('Runtime loadCjsAsEsm SyntaxError fallback', () => {
       )) as any;
       expect(m.namespace.fromA).toBe(456);
       expect(m.namespace.fromB).toBe(456);
+    },
+  );
+
+  testWithSyncEsm(
+    'require()s an ESM-marked node_modules package natively on Node 24.9+',
+    async () => {
+      const runtime = await createRuntime(__filename, {
+        rootDir: ROOT_DIR,
+        transformIgnorePatterns: ['/node_modules/'],
+      });
+      const ns = runtime.requireModule(FROM, 'esm-marked');
+      expect(ns.esmMarkedValue).toBe(789);
+    },
+  );
+
+  testWithoutSyncEsm(
+    'require()s an ESM-marked node_modules package when a transform covers it',
+    async () => {
+      const runtime = await createRuntime(__filename, {
+        rootDir: ROOT_DIR,
+        transformIgnorePatterns: ['/node_modules/(?!esm-marked/)'],
+      });
+      const ns = runtime.requireModule(FROM, 'esm-marked');
+      expect(ns.esmMarkedValue).toBe(789);
+    },
+  );
+
+  testWithoutSyncEsm(
+    'gives a clear error when requiring an untransformed ESM-marked package',
+    async () => {
+      const runtime = await createRuntime(__filename, {
+        rootDir: ROOT_DIR,
+        transformIgnorePatterns: ['/node_modules/'],
+      });
+      const modulePath = path.join(
+        ROOT_DIR,
+        'node_modules',
+        'esm-marked',
+        'index.js',
+      );
+      expect(() => runtime.requireModule(FROM, 'esm-marked')).toThrow(
+        expect.objectContaining({
+          code: 'ERR_REQUIRE_ESM',
+          message: expect.stringContaining(
+            `Must use import to load ES Module: ${modulePath}`,
+          ),
+        }),
+      );
     },
   );
 

--- a/packages/jest-runtime/src/__tests__/test_esm_interop_root/node_modules/esm-marked/index.js
+++ b/packages/jest-runtime/src/__tests__/test_esm_interop_root/node_modules/esm-marked/index.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const esmMarkedValue = 789;

--- a/packages/jest-runtime/src/__tests__/test_esm_interop_root/node_modules/esm-marked/package.json
+++ b/packages/jest-runtime/src/__tests__/test_esm_interop_root/node_modules/esm-marked/package.json
@@ -1,0 +1,1 @@
+{"name": "esm-marked", "type": "module", "main": "index.js"}

--- a/packages/jest-runtime/src/internals/CjsLoader.ts
+++ b/packages/jest-runtime/src/internals/CjsLoader.ts
@@ -97,17 +97,9 @@ export class CjsLoader {
       modulePath = this.resolution.resolveCjs(from, moduleName);
     }
 
-    if (this.resolution.shouldLoadAsEsm(modulePath)) {
-      if (!supportsSyncEvaluate) {
-        const error: NodeJS.ErrnoException = new Error(
-          `Must use import to load ES Module: ${modulePath}\n` +
-            "Jest's require(ESM) requires Node v24.9+ for " +
-            'synchronous vm module APIs; the current Node version does not ' +
-            'expose them.',
-        );
-        error.code = 'ERR_REQUIRE_ESM';
-        throw error;
-      }
+    // On Node 24.9+ we can require() ESM natively. On older Node, fall
+    // through to the CJS path so a configured transform can convert it.
+    if (supportsSyncEvaluate && this.resolution.shouldLoadAsEsm(modulePath)) {
       // Fast path: skip the graph walker on cache hits.
       const reg = this.registries.getActiveEsmRegistry();
       const cached = reg.get(modulePath);
@@ -151,22 +143,48 @@ export class CjsLoader {
       );
     } catch (error) {
       moduleRegistry.delete(modulePath);
-      // ESM-syntax-in-CJS fallback for require(): retry as native ESM, but if
-      // the ESM parser also rejects it, surface the original CJS error.
-      if (supportsSyncEvaluate && error instanceof CjsParseError) {
-        try {
-          return this.requireEsm<T>(modulePath);
-        } catch (esmError) {
-          if (esmError instanceof Error && esmError.name === 'SyntaxError') {
-            throw error.cause;
-          }
-          throw esmError;
-        }
+      if (error instanceof CjsParseError) {
+        return this.handleCjsParseError<T>(modulePath, error);
       }
       throw error;
     }
 
     return localModule.exports;
+  }
+
+  /**
+   * The CJS compiler rejected the file (ESM syntax in a non-ESM context).
+   * On Node 24.9+ retry as native ESM; otherwise surface an actionable error.
+   */
+  private handleCjsParseError<T>(
+    modulePath: string,
+    parseError: CjsParseError,
+  ): T {
+    if (supportsSyncEvaluate) {
+      try {
+        return this.requireEsm<T>(modulePath);
+      } catch (esmError) {
+        // Both CJS and ESM parsers rejected it — surface the original CJS error.
+        if (esmError instanceof Error && esmError.name === 'SyntaxError') {
+          throw parseError.cause;
+        }
+        throw esmError;
+      }
+    }
+    this.throwRequireEsmError(modulePath);
+  }
+
+  private throwRequireEsmError(modulePath: string): never {
+    const error: NodeJS.ErrnoException = new Error(
+      `Must use import to load ES Module: ${modulePath}\n\n` +
+        'The file contains ESM syntax (import/export) that could not be ' +
+        'executed as CommonJS. Either:\n' +
+        '  - Configure a transform (e.g. babel-jest) that compiles this ' +
+        'file to CommonJS, or\n' +
+        '  - Use Node v24.9+ where Jest supports require(esm) natively.',
+    );
+    error.code = 'ERR_REQUIRE_ESM';
+    throw error;
   }
 
   loadModule(

--- a/packages/jest-runtime/src/internals/ModuleExecutor.ts
+++ b/packages/jest-runtime/src/internals/ModuleExecutor.ts
@@ -219,7 +219,6 @@ export class ModuleExecutor {
       ) as ModuleWrapper;
     } catch (error: any) {
       if (
-        runtimeSupportsVmModules &&
         isError(error) &&
         error.name === 'SyntaxError' &&
         hasEsmSyntax(scriptSource)

--- a/packages/test-utils/src/ConditionalTest.ts
+++ b/packages/test-utils/src/ConditionalTest.ts
@@ -38,15 +38,20 @@ export function testWithVmEsm(
   return fn(...args);
 }
 
+const hasSyncEsm =
+  // @ts-expect-error - hasAsyncGraph is in Node v24.9+, not yet typed
+  typeof SourceTextModule?.prototype.hasAsyncGraph === 'function';
+
 export function testWithSyncEsm(
   ...args: Parameters<typeof test>
 ): ReturnType<typeof test> {
-  const fn =
-    // @ts-expect-error - hasAsyncGraph is in Node v24.9+, not yet typed
-    typeof SourceTextModule?.prototype.hasAsyncGraph === 'function'
-      ? test
-      : test.skip;
-  return fn(...args);
+  return (hasSyncEsm ? test : test.skip)(...args);
+}
+
+export function testWithoutSyncEsm(
+  ...args: Parameters<typeof test>
+): ReturnType<typeof test> {
+  return (hasSyncEsm ? test.skip : test)(...args);
 }
 
 export function testWithLinkedSyntheticModule(

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -15,6 +15,7 @@ export {
   testWithLinkedSyntheticModule,
   testWithSyncEsm,
   testWithVmEsm,
+  testWithoutSyncEsm,
 } from './ConditionalTest';
 
 export {makeGlobalConfig, makeProjectConfig} from './config';


### PR DESCRIPTION
Jest 30.4's ESM runtime rewrite gates `require()` of ESM-marked files (`"type": "module"` or `.mjs`) behind `supportsSyncEvaluate`, which requires Node 24.9+. On older Node, this immediately throws `ERR_REQUIRE_ESM`, bypassing the transform pipeline entirely. This breaks projects that rely on a configured transform (e.g. babel-jest) to convert ESM dependencies to CJS (backstage/backstage#34182).

This PR moves the `supportsSyncEvaluate` check into the outer condition so ESM-marked files fall through to the CJS path on older Node. If the configured transform converts the file, `require()` succeeds. If not, a clear error message explains the options (configure a transform, or upgrade to Node 24.9+).

Also adds `testWithoutSyncEsm` to `@jest/test-utils` — the inverse of the existing `testWithSyncEsm` gate — for tests that should only run on Node < 24.9.