### PR TITLE
Satisfying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,6 @@
-## [Unrealesed]
-
 ### Features
 
 - `[expect]` Add `expect.satisfying(fn)` as a new built-in asymmetric matcher to wrap `(value) => boolean` to be used anywhere an asymmetric matcher is accepted (([#16242](https://github.com/jestjs/jest/pull/16242))
-
-## main
-
-### Features
-
 - `[@jest/expect-utils, jest-mock]` Add `mockFn.whenCalledWith(...args)` for configuring return values per argument list, with first-class asymmetric-matcher support ([#16053](https://github.com/jestjs/jest/pull/16053))
 - `[@jest/expect-utils]` Export `AsymmetricMatcher` and `FunctionParameters` types (previously private to `expect`) ([#16053](https://github.com/jestjs/jest/pull/16053))
 - `[jest-resolve]` Bump `unrs-resolver` to 1.12.1, remove `jest-pnp-resolver` and unnecessary checks ([#15721](https://github.com/jestjs/jest/pull/15721))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## [Unrealesed]
 
 ### Features
-- `[expect]` Add `expect.satisfying(fn)` as a new built-in asymmetric matcher to wrap `(value) => boolean` to be used anywhere an asymmetric matcher is accepted 
+
+- `[expect]` Add `expect.satisfying(fn)` as a new built-in asymmetric matcher to wrap `(value) => boolean` to be used anywhere an asymmetric matcher is accepted (([#16242](https://github.com/jestjs/jest/pull/16242))
 
 ## main
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## main
+
 ### Features
 
 - `[expect]` Add `expect.satisfying(fn)` as a new built-in asymmetric matcher to wrap `(value) => boolean` to be used anywhere an asymmetric matcher is accepted (([#16242](https://github.com/jestjs/jest/pull/16242))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unrealesed]
+
+### Features
+- `[expect]` Add `expect.satisfying(fn)` as a new built-in asymmetric matcher to wrap `(value) => boolean` to be used anywhere an asymmetric matcher is accepted 
+
 ## main
 
 ### Features

--- a/e2e/__tests__/satisfying.test.ts
+++ b/e2e/__tests__/satisfying.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import runJest from '../runJest';
 
 test('satisfying', () => {

--- a/e2e/__tests__/satisfying.test.ts
+++ b/e2e/__tests__/satisfying.test.ts
@@ -1,0 +1,6 @@
+import runJest from '../runJest';
+
+test('satisfying', () => {
+  const {exitCode} = runJest('satisfying');
+  expect(exitCode).toBe(0);
+});

--- a/e2e/satisfying/__tests__/composedMatchers.test.js
+++ b/e2e/satisfying/__tests__/composedMatchers.test.js
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 it('Satisfying composed inside other matchers works', () => {
   const user1 = {age: 50, email: 'john4@gmail.com', score: 0.2};
   const user2 = {age: 50, email: 'ted5@gmail.com', score: 0.8};

--- a/e2e/satisfying/__tests__/composedMatchers.test.js
+++ b/e2e/satisfying/__tests__/composedMatchers.test.js
@@ -1,0 +1,10 @@
+it('Satisfying composed inside other matchers works', () => {
+  const user1 = {age: 50, email: 'john4@gmail.com', score: 0.2};
+  const user2 = {age: 50, email: 'ted5@gmail.com', score: 0.8};
+  const users = [user1, user2];
+  expect(users).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({score: expect.satisfying(n => n > 0.5)}),
+    ]),
+  );
+});

--- a/e2e/satisfying/__tests__/inlineAssertion.test.js
+++ b/e2e/satisfying/__tests__/inlineAssertion.test.js
@@ -1,0 +1,7 @@
+it('Satisfying inline assertion works', () => {
+  const user = {age: 50, email: 'john4@gmail.com'};
+  expect(user).toEqual({
+    age: expect.satisfying(n => n >= 18),
+    email: expect.stringMatching(/@/),
+  });
+});

--- a/e2e/satisfying/__tests__/inlineAssertion.test.js
+++ b/e2e/satisfying/__tests__/inlineAssertion.test.js
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 it('Satisfying inline assertion works', () => {
   const user = {age: 50, email: 'john4@gmail.com'};
   expect(user).toEqual({

--- a/e2e/satisfying/__tests__/mockArgumentRouting.test.js
+++ b/e2e/satisfying/__tests__/mockArgumentRouting.test.js
@@ -1,0 +1,16 @@
+it('Satisfying Mock argument routing', () => {
+  const charge = jest.fn();
+
+  // Threshold split that objectContaining can't express:
+  charge
+    .whenCalledWith(expect.satisfying(req => req.amount > 1000))
+    .mockReturnValue({status: 'needs-approval'});
+  charge
+    .whenCalledWith(expect.satisfying(req => req.amount <= 1000))
+    .mockReturnValue({status: 'auto-approved'});
+
+  // Cross-field invariant:
+  charge
+    .whenCalledWith(expect.satisfying(req => req.start < req.end))
+    .mockReturnValue({status: 'ok'});
+});

--- a/e2e/satisfying/__tests__/mockArgumentRouting.test.js
+++ b/e2e/satisfying/__tests__/mockArgumentRouting.test.js
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 it('Satisfying Mock argument routing', () => {
   const charge = jest.fn();
 

--- a/e2e/satisfying/__tests__/negation.test.js
+++ b/e2e/satisfying/__tests__/negation.test.js
@@ -1,0 +1,5 @@
+it('Satisfying negation assertion works', () => {
+  const isEmpty = x => x.length === 0;
+  const value = [1, 2, 3];
+  expect(value).toEqual(expect.not.satisfying(isEmpty));
+});

--- a/e2e/satisfying/__tests__/negation.test.js
+++ b/e2e/satisfying/__tests__/negation.test.js
@@ -1,3 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
 it('Satisfying negation assertion works', () => {
   const isEmpty = x => x.length === 0;
   const value = [1, 2, 3];

--- a/e2e/satisfying/package.json
+++ b/e2e/satisfying/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/expect/src/__tests__/asymmetricMatchers.test.ts
+++ b/packages/expect/src/__tests__/asymmetricMatchers.test.ts
@@ -17,8 +17,10 @@ import {
   closeTo,
   notArrayOf,
   notCloseTo,
+  notSatisfying,
   objectContaining,
   objectNotContaining,
+  satisfying,
   stringContaining,
   stringMatching,
   stringNotContaining,
@@ -339,6 +341,34 @@ test('ObjectNotContaining throws for non-objects', () => {
     objectNotContaining(1337).asymmetricMatch();
   }).toThrow(
     "You must provide an object to ObjectNotContaining, not 'number'.",
+  );
+});
+
+test('Satisfying matches', () => {
+  const isLong = (s: string) => s.length > 0;
+  jestExpect(satisfying(isLong).asymmetricMatch('LongName')).toBe(true);
+});
+
+test('Satisfying does not match', () => {
+  const isLong = (s: string) => s.length > 0;
+  jestExpect(satisfying(isLong).asymmetricMatch('')).toBe(false);
+});
+
+test('NotSatisfying matches', () => {
+  const isLong = (s: string) => s.length > 0;
+  jestExpect(notSatisfying(isLong).asymmetricMatch('')).toBe(true);
+});
+
+test('NotSatisfying does not match', () => {
+  const isLong = (s: string) => s.length > 0;
+  jestExpect(notSatisfying(isLong).asymmetricMatch('LongName')).toBe(false);
+});
+
+test('Satisfying toString works', () => {
+  const isLong = (s: string) => s.length > 0;
+  jestExpect(satisfying(isLong).toString()).toBe('Satisfying[isLong]');
+  jestExpect(satisfying((s: string) => s.length > 0).toString()).toBe(
+    'Satisfying',
   );
 });
 

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -297,15 +297,22 @@ class ObjectContaining extends AsymmetricMatcher<
   }
 }
 
-class Satisfying extends AsymmetricMatcher<(value: unknown) => boolean> {
-  constructor(sample: (value: unknown) => boolean, inverse = false) {
+class Satisfying<T> extends AsymmetricMatcher<(value: T) => boolean> {
+  constructor(sample: (value: T) => boolean, inverse = false) {
     super(sample, inverse);
   }
-  asymmetricMatch(other: unknown): boolean {
-    return true;
+  asymmetricMatch(other: T): boolean {
+    if (typeof this.sample !== 'function') {
+      throw new TypeError(
+        `You must provide a predicate to ${this.toString()}, not '${typeof this.sample}'.`,
+      );
+    }
+    const result = this.sample(other);
+    return this.inverse ? !result : result;
   }
   toString() {
-    return `${this.inverse ? 'Not' : ''}Satisfying[]`;
+    const name = this.sample.name === '' ? '' : `[${this.sample.name}]`;
+    return `${this.inverse ? 'Not' : ''}Satisfying${name}`;
   }
 }
 
@@ -426,6 +433,11 @@ export const objectContaining = (
 export const objectNotContaining = (
   sample: Record<string, unknown>,
 ): ObjectContaining => new ObjectContaining(sample, true);
+export const satisfying = <T>(expected: (value: T) => boolean): Satisfying<T> =>
+  new Satisfying(expected);
+export const notSatisfying = <T>(
+  expected: (value: T) => boolean,
+): Satisfying<T> => new Satisfying(expected, true);
 export const stringContaining = (expected: string): StringContaining =>
   new StringContaining(expected);
 export const stringNotContaining = (expected: string): StringContaining =>

--- a/packages/expect/src/asymmetricMatchers.ts
+++ b/packages/expect/src/asymmetricMatchers.ts
@@ -297,6 +297,18 @@ class ObjectContaining extends AsymmetricMatcher<
   }
 }
 
+class Satisfying extends AsymmetricMatcher<(value: unknown) => boolean> {
+  constructor(sample: (value: unknown) => boolean, inverse = false) {
+    super(sample, inverse);
+  }
+  asymmetricMatch(other: unknown): boolean {
+    return true;
+  }
+  toString() {
+    return `${this.inverse ? 'Not' : ''}Satisfying[]`;
+  }
+}
+
 class StringContaining extends AsymmetricMatcher<string> {
   constructor(sample: string, inverse = false) {
     if (!isA('String', sample)) {

--- a/packages/expect/src/index.ts
+++ b/packages/expect/src/index.ts
@@ -20,8 +20,10 @@ import {
   closeTo,
   notArrayOf,
   notCloseTo,
+  notSatisfying,
   objectContaining,
   objectNotContaining,
+  satisfying,
   stringContaining,
   stringMatching,
   stringNotContaining,
@@ -408,6 +410,7 @@ expect.not = {
   arrayOf: notArrayOf,
   closeTo: notCloseTo,
   objectContaining: objectNotContaining,
+  satisfying: notSatisfying,
   stringContaining: stringNotContaining,
   stringMatching: stringNotMatching,
 };
@@ -416,6 +419,7 @@ expect.arrayContaining = arrayContaining;
 expect.arrayOf = arrayOf;
 expect.closeTo = closeTo;
 expect.objectContaining = objectContaining;
+expect.satisfying = satisfying;
 expect.stringContaining = stringContaining;
 expect.stringMatching = stringMatching;
 

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -120,6 +120,7 @@ export interface AsymmetricMatchers {
   arrayOf(sample: unknown): AsymmetricMatcher;
   closeTo(sample: number, precision?: number): AsymmetricMatcher;
   objectContaining(sample: object): AsymmetricMatcher;
+  satisfying<T>(sample: (value: T) => boolean): AsymmetricMatcher;
   stringContaining(sample: string): AsymmetricMatcher;
   stringMatching(sample: string | RegExp): AsymmetricMatcher;
 }


### PR DESCRIPTION

## Summary

Implemented a new asymmetric matcher for wrapping (value) => boolean predicates to be used anywhere an asymmetric matcher is accepted. 

- Created a new Satisfying class in packages/expect/src/asymmetricMatchers.ts that evaluates a value given a predicate. 
- Added Satisfying class to expect  module as expect.satsifying and expect.not.satisfying in packages/expect/src/index.ts
- Added unit tests for Satisfying class in packages/expect/src/__tests__/asymmetricMatchers.test.ts
- Added end-to-end tests for Satisfying in e2e/satisfying and added integration test at e2e/__tests__/satisfying.test.ts

First time contributing to open source software, so any improvement/suggestions help!
Resolves #16193

## Test plan
yarn test
yarn jest asymmetricMatchers.test.ts
cd e2e/satisfying; node ../../packages/jest-cli/bin/jest.js 


