### PR TITLE
fix(jest-runtime, @jest/transform): improve ESM error handling on Node < 24.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
 - `[jest-mock]` Remove the leftover own accessor descriptor when restoring a `spyOn` of an inherited getter or setter, so the instance keeps reflecting the prototype ([#16226](https://github.com/jestjs/jest/pull/16226))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))
+- `[jest-runtime]` Allow `require()` of ESM-marked files on Node < 24.9 via transform fallback ([#16244](https://github.com/jestjs/jest/pull/16244))
+- `[jest-runtime, @jest/transform]` Surface actionable `ERR_REQUIRE_ESM` error for files with untransformed ESM syntax instead of the generic "unexpected token" message ([#16244](https://github.com/jestjs/jest/pull/16244))
 - `[jest-runtime]` Support older test environments whose `moduleMocker` does not implement `clearMocksOnScope` ([#16169](https://github.com/jestjs/jest/pull/16169))
 
 ### Chore & Maintenance

--- a/e2e/__tests__/unexpectedToken.test.ts
+++ b/e2e/__tests__/unexpectedToken.test.ts
@@ -35,7 +35,7 @@ test('triggers unexpected token error message for non-JS assets', () => {
   expect(stderr).toMatch(/Unexpected token ./);
 });
 
-test('triggers unexpected token error message for untranspiled node_modules', () => {
+test('triggers ERR_REQUIRE_ESM for untranspiled node_modules with ESM syntax', () => {
   writeFiles(DIR, {
     '.watchmanconfig': '{}',
     'node_modules/untranspiled-module': 'import {module} from "some-module"',
@@ -50,10 +50,8 @@ test('triggers unexpected token error message for untranspiled node_modules', ()
   const {stdout, stderr} = runJest(DIR, ['']);
 
   expect(stdout).toBe('');
-  expect(stderr).toMatch(/Jest encountered an unexpected token/);
-  expect(stderr).toMatch(/import {module}/);
   expect(stderr).toMatch(
-    /SyntaxError: Cannot use import statement outside a module/,
+    /Must use import to load ES Module.*untranspiled-module/,
   );
 });
 

--- a/packages/jest-runtime/src/__tests__/runtime_esm_cjs_interop.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_cjs_interop.test.ts
@@ -6,7 +6,12 @@
  */
 
 import * as path from 'path';
-import {testWithSyncEsm, testWithVmEsm} from '@jest/test-utils';
+import {replacePathSepForRegex} from 'jest-regex-util';
+import {
+  testWithSyncEsm,
+  testWithVmEsm,
+  testWithoutSyncEsm,
+} from '@jest/test-utils';
 
 const ROOT_DIR = path.join(__dirname, 'test_esm_interop_root');
 const FROM = path.join(ROOT_DIR, 'test.js');
@@ -184,6 +189,63 @@ describe('Runtime loadCjsAsEsm SyntaxError fallback', () => {
     },
   );
 
+  testWithSyncEsm(
+    'require()s an ESM-marked node_modules package natively without a transform',
+    async () => {
+      const runtime = await createRuntime(__filename, {
+        rootDir: ROOT_DIR,
+        transformIgnorePatterns: [replacePathSepForRegex('/node_modules/')],
+      });
+      const ns = runtime.requireModule(FROM, 'esm-marked');
+      expect(ns.esmMarkedValue).toBe(789);
+    },
+  );
+
+  testWithoutSyncEsm(
+    'require()s an ESM-marked node_modules package when a transform covers it',
+    async () => {
+      const runtime = await createRuntime(__filename, {
+        rootDir: ROOT_DIR,
+        transformIgnorePatterns: [
+          replacePathSepForRegex('/node_modules/(?!esm-marked/)'),
+        ],
+      });
+      const ns = runtime.requireModule(FROM, 'esm-marked');
+      expect(ns.esmMarkedValue).toBe(789);
+    },
+  );
+
+  testWithoutSyncEsm(
+    'throws ERR_REQUIRE_ESM for an untransformed ESM-marked package',
+    async () => {
+      const runtime = await createRuntime(__filename, {
+        rootDir: ROOT_DIR,
+        transformIgnorePatterns: [replacePathSepForRegex('/node_modules/')],
+      });
+      expect(() => runtime.requireModule(FROM, 'esm-marked')).toThrow(
+        expect.objectContaining({
+          code: 'ERR_REQUIRE_ESM',
+          message: expect.stringContaining(
+            `Must use import to load ES Module: ${path.join(ROOT_DIR, 'node_modules', 'esm-marked', 'index.js')}`,
+          ),
+        }),
+      );
+    },
+  );
+
+  testWithoutSyncEsm(
+    'throws a normal SyntaxError for a genuine syntax error in an ESM-marked package',
+    async () => {
+      const runtime = await createRuntime(__filename, {
+        rootDir: ROOT_DIR,
+        transformIgnorePatterns: [replacePathSepForRegex('/node_modules/')],
+      });
+      expect(() =>
+        runtime.requireModule(FROM, 'esm-marked-syntax-error'),
+      ).toThrow("Unexpected token ';'");
+    },
+  );
+
   // hasEsmSyntax returns false when es-module-lexer throws (broken ESM like
   // `export {`). No CjsParseError is thrown, so the raw CJS compile error
   // surfaces directly — no pointless ESM retry.
@@ -192,7 +254,7 @@ describe('Runtime loadCjsAsEsm SyntaxError fallback', () => {
     async () => {
       const runtime = await createRuntime(__filename, {
         rootDir: ROOT_DIR,
-        transformIgnorePatterns: ['/node_modules/'],
+        transformIgnorePatterns: [replacePathSepForRegex('/node_modules/')],
       });
       await expect(
         runtime.unstable_importModule(FROM, './import-esm-syntax-error.mjs'),

--- a/packages/jest-runtime/src/__tests__/test_esm_interop_root/node_modules/esm-marked-syntax-error/index.js
+++ b/packages/jest-runtime/src/__tests__/test_esm_interop_root/node_modules/esm-marked-syntax-error/index.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// ESM-marked package with a genuine syntax error and no import/export syntax.
+const value = {;

--- a/packages/jest-runtime/src/__tests__/test_esm_interop_root/node_modules/esm-marked-syntax-error/package.json
+++ b/packages/jest-runtime/src/__tests__/test_esm_interop_root/node_modules/esm-marked-syntax-error/package.json
@@ -1,0 +1,1 @@
+{"name": "esm-marked-syntax-error", "type": "module", "main": "index.js"}

--- a/packages/jest-runtime/src/__tests__/test_esm_interop_root/node_modules/esm-marked/index.js
+++ b/packages/jest-runtime/src/__tests__/test_esm_interop_root/node_modules/esm-marked/index.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// ESM-marked package (type:module) that exports a named value.
+export const esmMarkedValue = 789;

--- a/packages/jest-runtime/src/__tests__/test_esm_interop_root/node_modules/esm-marked/package.json
+++ b/packages/jest-runtime/src/__tests__/test_esm_interop_root/node_modules/esm-marked/package.json
@@ -1,0 +1,1 @@
+{"name": "esm-marked", "type": "module", "main": "index.js"}

--- a/packages/jest-runtime/src/internals/CjsLoader.ts
+++ b/packages/jest-runtime/src/internals/CjsLoader.ts
@@ -8,6 +8,7 @@
 import * as path from 'node:path';
 import type {Module as VMModule} from 'node:vm';
 import type {JestEnvironment, Module} from '@jest/environment';
+import {isError} from 'jest-util';
 import type {MockState} from './MockState';
 import {CjsParseError, type ModuleExecutor} from './ModuleExecutor';
 import type {ModuleRegistries} from './ModuleRegistries';
@@ -15,6 +16,7 @@ import type {Resolution} from './Resolution';
 import type {TestState} from './TestState';
 import type {TransformCache, TransformOptions} from './TransformCache';
 import type {CoreModuleProvider} from './cjsRequire';
+import {hasEsmSyntax} from './esmLexer';
 import type {InitialModule, ModuleRegistry} from './moduleTypes';
 import {
   runtimeSupportsVmModules,
@@ -97,17 +99,9 @@ export class CjsLoader {
       modulePath = this.resolution.resolveCjs(from, moduleName);
     }
 
-    if (this.resolution.shouldLoadAsEsm(modulePath)) {
-      if (!supportsSyncEvaluate) {
-        const error: NodeJS.ErrnoException = new Error(
-          `Must use import to load ES Module: ${modulePath}\n` +
-            "Jest's require(ESM) requires Node v24.9+ for " +
-            'synchronous vm module APIs; the current Node version does not ' +
-            'expose them.',
-        );
-        error.code = 'ERR_REQUIRE_ESM';
-        throw error;
-      }
+    // On Node 24.9+ we can require() ESM natively. On older Node, fall
+    // through to the CJS path so a configured transform can convert it.
+    if (supportsSyncEvaluate && this.resolution.shouldLoadAsEsm(modulePath)) {
       // Fast path: skip the graph walker on cache hits.
       const reg = this.registries.getActiveEsmRegistry();
       const cached = reg.get(modulePath);
@@ -151,22 +145,53 @@ export class CjsLoader {
       );
     } catch (error) {
       moduleRegistry.delete(modulePath);
-      // ESM-syntax-in-CJS fallback for require(): retry as native ESM, but if
-      // the ESM parser also rejects it, surface the original CJS error.
-      if (supportsSyncEvaluate && error instanceof CjsParseError) {
-        try {
-          return this.requireEsm<T>(modulePath);
-        } catch (esmError) {
-          if (esmError instanceof Error && esmError.name === 'SyntaxError') {
-            throw error.cause;
-          }
-          throw esmError;
-        }
+      if (error instanceof CjsParseError) {
+        return this.handleCjsParseError(modulePath, error);
+      }
+      // Without --experimental-vm-modules, CjsParseError is never thrown.
+      // Detect untransformed ESM syntax and surface an actionable error.
+      if (
+        !supportsSyncEvaluate &&
+        isError(error) &&
+        error.name === 'SyntaxError' &&
+        hasEsmSyntax(this.transformCache.getCachedSource(modulePath) ?? '')
+      ) {
+        throw createRequireEsmError(modulePath);
       }
       throw error;
     }
 
     return localModule.exports;
+  }
+
+  /**
+   * The CJS compiler rejected the file (ESM syntax in a non-ESM context).
+   * On Node 24.9+ retry as native ESM; on older Node either surface an
+   * actionable error (for explicitly ESM-marked files) or re-throw so the
+   * ESM loader's own CjsParseError catch can trigger its fallback path.
+   */
+  private handleCjsParseError<T>(
+    modulePath: string,
+    parseError: CjsParseError,
+  ): T {
+    if (supportsSyncEvaluate) {
+      try {
+        return this.requireEsm<T>(modulePath);
+      } catch (esmError) {
+        // Both CJS and ESM parsers rejected it — surface the original CJS error.
+        if (esmError instanceof Error && esmError.name === 'SyntaxError') {
+          throw parseError.cause;
+        }
+        throw esmError;
+      }
+    }
+    // Explicitly ESM-marked files (.mjs / "type":"module") can't be retried
+    // by the ESM loader — give the user an actionable error.
+    if (this.resolution.shouldLoadAsEsm(modulePath)) {
+      throw createRequireEsmError(modulePath);
+    }
+    // Unmarked file with ESM syntax — re-throw so the ESM loader can retry.
+    throw parseError;
   }
 
   loadModule(
@@ -218,4 +243,21 @@ export class CjsLoader {
     }
     localModule.loaded = true;
   }
+}
+
+function createRequireEsmError(modulePath: string): NodeJS.ErrnoException {
+  const error: NodeJS.ErrnoException = new Error(
+    `Must use import to load ES Module: ${modulePath}\n\n` +
+      'The file contains ESM syntax (import/export) that could not be ' +
+      'executed as CommonJS. Either:\n' +
+      '  - Configure a transform (e.g. babel-jest) that compiles this ' +
+      'file to CommonJS (see https://jestjs.io/docs/code-transformation)\n' +
+      '  - If the file is in "node_modules", allow it to be transformed by ' +
+      'adjusting "transformIgnorePatterns" (see ' +
+      'https://jestjs.io/docs/configuration#transformignorepatterns-arraystring)\n' +
+      '  - Use Node v24.9+ where Jest supports require(esm) natively ' +
+      '(see https://jestjs.io/docs/ecmascript-modules#require-of-esm)',
+  );
+  error.code = 'ERR_REQUIRE_ESM';
+  return error;
 }

--- a/packages/jest-transform/src/enhanceUnexpectedTokenMessage.ts
+++ b/packages/jest-transform/src/enhanceUnexpectedTokenMessage.ts
@@ -41,9 +41,6 @@ Out of the box Jest supports Babel, which will be used to transform your files i
 By default "node_modules" folder is ignored by transformers.
 
 Here's what you can do:
-${DOT}If you are trying to use ECMAScript Modules, see ${chalk.underline(
-    'https://jestjs.io/docs/ecmascript-modules',
-  )} for how to enable it.
 ${DOT}If you are trying to use TypeScript, see ${chalk.underline(
     'https://jestjs.io/docs/getting-started#using-typescript',
   )}

--- a/packages/test-utils/src/ConditionalTest.ts
+++ b/packages/test-utils/src/ConditionalTest.ts
@@ -38,15 +38,20 @@ export function testWithVmEsm(
   return fn(...args);
 }
 
+const hasSyncEsm =
+  // @ts-expect-error - hasAsyncGraph is in Node v24.9+, not yet typed
+  typeof SourceTextModule?.prototype.hasAsyncGraph === 'function';
+
 export function testWithSyncEsm(
   ...args: Parameters<typeof test>
 ): ReturnType<typeof test> {
-  const fn =
-    // @ts-expect-error - hasAsyncGraph is in Node v24.9+, not yet typed
-    typeof SourceTextModule?.prototype.hasAsyncGraph === 'function'
-      ? test
-      : test.skip;
-  return fn(...args);
+  return (hasSyncEsm ? test : test.skip)(...args);
+}
+
+export function testWithoutSyncEsm(
+  ...args: Parameters<typeof test>
+): ReturnType<typeof test> {
+  return (hasSyncEsm ? test.skip : test)(...args);
 }
 
 export function testWithLinkedSyntheticModule(

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -15,6 +15,7 @@ export {
   testWithLinkedSyntheticModule,
   testWithSyncEsm,
   testWithVmEsm,
+  testWithoutSyncEsm,
 } from './ConditionalTest';
 
 export {makeGlobalConfig, makeProjectConfig} from './config';


### PR DESCRIPTION
## Summary

Jest 30.4's ESM runtime rewrite gates `require()` of ESM-marked files (`"type": "module"` or `.mjs`) behind `supportsSyncEvaluate`, which requires Node 24.9+. On older Node, this immediately throws `ERR_REQUIRE_ESM`, bypassing the transform pipeline entirely. This breaks projects that rely on a configured transform (e.g. babel-jest) to convert ESM dependencies to CJS (backstage/backstage#34182).

This PR:
- Moves the `supportsSyncEvaluate` check into the outer condition so ESM-marked files fall through to the CJS path on older Node. If the configured transform converts the file, `require()` succeeds.
- When no transform covers the file and ESM syntax remains after transformation, surfaces a specific `ERR_REQUIRE_ESM` error with actionable guidance (configure a transform or upgrade to Node v24.9+), replacing the generic "Jest encountered an unexpected token" message.
- Removes the now-redundant ECMAScript Modules bullet from `enhanceUnexpectedTokenMessage` in `@jest/transform`, since all valid ESM cases are intercepted by the new `ERR_REQUIRE_ESM` error.

Cleaner reimplementation of #16240.

## Test plan

Unit and e2e tests added covering:
- Native ESM require on Node 24.9+ (`testWithSyncEsm`)
- Transform fallback on older Node (`testWithoutSyncEsm`)
- `ERR_REQUIRE_ESM` for untransformed ESM-marked packages (`testWithoutSyncEsm`)
- Genuine syntax errors pass through unchanged (`testWithoutSyncEsm`)
- e2e: `ERR_REQUIRE_ESM` for untranspiled node_modules with ESM syntax