### PR TITLE
feat(collect-tests): expand .each and report accurate per-status counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[@jest/expect-utils, jest-mock]` Add `mockFn.whenCalledWith(...args)` for configuring return values per argument list, with first-class asymmetric-matcher support ([#16053](https://github.com/jestjs/jest/pull/16053))
 - `[@jest/expect-utils]` Export `AsymmetricMatcher` and `FunctionParameters` types (previously private to `expect`) ([#16053](https://github.com/jestjs/jest/pull/16053))
+- `[jest-circus, jest-core, jest-jasmine2, jest-test-result]` `--collectTests` now expands `test.each`/`describe.each` cases and reports per-status counts (skipped/todo/runnable) and a summary line that match a real run ([#16200](https://github.com/jestjs/jest/pull/16200))
 - `[jest-resolve]` Bump `unrs-resolver` to 1.12.1, remove `jest-pnp-resolver` and unnecessary checks ([#15721](https://github.com/jestjs/jest/pull/15721))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `[@jest/expect-utils, jest-mock]` Add `mockFn.whenCalledWith(...args)` for configuring return values per argument list, with first-class asymmetric-matcher support ([#16053](https://github.com/jestjs/jest/pull/16053))
 - `[@jest/expect-utils]` Export `AsymmetricMatcher` and `FunctionParameters` types (previously private to `expect`) ([#16053](https://github.com/jestjs/jest/pull/16053))
-- `[jest-circus, jest-core, jest-jasmine2, jest-test-result, jest-types]` `--collectTests` now expands `test.each`/`describe.each` cases and reports per-status counts (skipped/todo via the new `wouldRun` flag for selected tests) plus a summary line that match a real run, including under `--testNamePattern` and `.only`/`fdescribe` focus on both the circus and jasmine2 runners ([#16200](https://github.com/jestjs/jest/pull/16200))
+- `[jest-circus, jest-core, jest-jasmine2, jest-test-result, jest-types]` `--collectTests` now expands `test.each`/`describe.each` cases and reports per-status counts (skipped/todo via the new `wouldRun` flag for selected tests) plus a summary line that match a real run, including under `--testNamePattern` and `.only`/`fdescribe` focus on both the circus and jasmine2 runners ([#16258](https://github.com/jestjs/jest/pull/16258))
 - `[jest-resolve]` Bump `unrs-resolver` to 1.12.1, remove `jest-pnp-resolver` and unnecessary checks ([#15721](https://github.com/jestjs/jest/pull/15721))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `[@jest/expect-utils, jest-mock]` Add `mockFn.whenCalledWith(...args)` for configuring return values per argument list, with first-class asymmetric-matcher support ([#16053](https://github.com/jestjs/jest/pull/16053))
 - `[@jest/expect-utils]` Export `AsymmetricMatcher` and `FunctionParameters` types (previously private to `expect`) ([#16053](https://github.com/jestjs/jest/pull/16053))
-- `[jest-circus, jest-core, jest-jasmine2, jest-test-result, jest-types]` `--collectTests` now expands `test.each`/`describe.each` cases and reports per-status counts (skipped/todo via the new `wouldRun` flag for selected tests) plus a summary line that match a real run, including under `--testNamePattern` ([#16200](https://github.com/jestjs/jest/pull/16200))
+- `[jest-circus, jest-core, jest-jasmine2, jest-test-result, jest-types]` `--collectTests` now expands `test.each`/`describe.each` cases and reports per-status counts (skipped/todo via the new `wouldRun` flag for selected tests) plus a summary line that match a real run, including under `--testNamePattern` and `.only`/`fdescribe` focus on both the circus and jasmine2 runners ([#16200](https://github.com/jestjs/jest/pull/16200))
 - `[jest-resolve]` Bump `unrs-resolver` to 1.12.1, remove `jest-pnp-resolver` and unnecessary checks ([#15721](https://github.com/jestjs/jest/pull/15721))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `[@jest/expect-utils, jest-mock]` Add `mockFn.whenCalledWith(...args)` for configuring return values per argument list, with first-class asymmetric-matcher support ([#16053](https://github.com/jestjs/jest/pull/16053))
 - `[@jest/expect-utils]` Export `AsymmetricMatcher` and `FunctionParameters` types (previously private to `expect`) ([#16053](https://github.com/jestjs/jest/pull/16053))
-- `[jest-circus, jest-core, jest-jasmine2, jest-test-result]` `--collectTests` now expands `test.each`/`describe.each` cases and reports per-status counts (skipped/todo/runnable) and a summary line that match a real run ([#16200](https://github.com/jestjs/jest/pull/16200))
+- `[jest-circus, jest-core, jest-jasmine2, jest-test-result, jest-types]` `--collectTests` now expands `test.each`/`describe.each` cases and reports per-status counts (skipped/todo via the new `wouldRun` flag for selected tests) plus a summary line that match a real run, including under `--testNamePattern` ([#16200](https://github.com/jestjs/jest/pull/16200))
 - `[jest-resolve]` Bump `unrs-resolver` to 1.12.1, remove `jest-pnp-resolver` and unnecessary checks ([#15721](https://github.com/jestjs/jest/pull/15721))
 
 ### Fixes

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -162,9 +162,15 @@ Test suites: 1
 Tests:       2 total, 2 runnable
 ```
 
-Parametrized tests declared with [`test.each`](GlobalAPI.md#testeachtablename-fn-timeout) / `describe.each` are expanded to one entry per case, and each collected test is categorized exactly as a real run would categorize it — runnable tests as `passed`, [`test.skip`](GlobalAPI.md#testskipname-fn) (and tests deselected by `test.only`) as `pending`, and [`test.todo`](GlobalAPI.md#testtodoname) as `todo`. As a result the counts reported by `--collectTests` match those of an actual run (assuming every runnable test passes), so it can be used to count tests without executing them.
+Parametrized tests declared with [`test.each`](GlobalAPI.md#testeachtablename-fn-timeout) / `describe.each` are expanded to one entry per case, and each collected test is categorized exactly as a real run would categorize it:
 
-Use `--json` to get machine-readable output instead. The JSON uses the same shape as a normal run, including `numTotalTests`, `numPassedTests`, `numPendingTests` and `numTodoTests`.
+- a test that would run is reported in the `passed` bucket and flagged `wouldRun: true` (it was selected but never executed);
+- [`test.skip`](GlobalAPI.md#testskipname-fn), tests inside a skipped `describe`, tests deselected by `test.only`, and tests excluded by `--testNamePattern` are reported as `pending`;
+- [`test.todo`](GlobalAPI.md#testtodoname) is reported as `todo`.
+
+Because every test is accounted for in the same bucket an actual run would use, the counts reported by `--collectTests` match those of a run in which every selected test passes — so it can be used to count tests without executing them, including under `--testNamePattern`.
+
+Use `--json` to get machine-readable output instead. The JSON uses the same shape as a normal run, including `numTotalTests`, `numPassedTests`, `numPendingTests` and `numTodoTests`, and each assertion carries the `wouldRun` flag described above.
 
 ### `--colors`
 

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -150,16 +150,17 @@ A glob pattern relative to `rootDir` matching the files that coverage info needs
 
 Discover and print all test suites and test names without executing them. Jest loads each test file, evaluates the top-level `describe` blocks to register tests, then exits before running any test code or lifecycle hooks.
 
-Output is a tree of file paths with their nested describe and test names, followed by a summary of the total counts:
+Output is a tree of file paths with their nested describe and test names, followed by a summary of the total counts. Skipped and todo tests are annotated, and any file that throws while loading is reported with its error (and the exit code is non-zero):
 
 ```
 path/to/my.test.ts
   My suite
     passes
-    fails
+    skips [skipped]
+    write later [todo]
 
 Test suites: 1
-Tests:       2 total, 2 runnable
+Tests:       3 total, 1 runnable, 1 skipped, 1 todo
 ```
 
 Parametrized tests declared with [`test.each`](GlobalAPI.md#testeachtablename-fn-timeout) / `describe.each` are expanded to one entry per case, and each collected test is categorized exactly as a real run would categorize it:

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -150,16 +150,21 @@ A glob pattern relative to `rootDir` matching the files that coverage info needs
 
 Discover and print all test suites and test names without executing them. Jest loads each test file, evaluates the top-level `describe` blocks to register tests, then exits before running any test code or lifecycle hooks.
 
-Output is a tree of file paths with their nested describe and test names:
+Output is a tree of file paths with their nested describe and test names, followed by a summary of the total counts:
 
 ```
 path/to/my.test.ts
   My suite
     passes
     fails
+
+Test suites: 1
+Tests:       2 total, 2 runnable
 ```
 
-Use `--json` to get machine-readable output instead.
+Parametrized tests declared with [`test.each`](GlobalAPI.md#testeachtablename-fn-timeout) / `describe.each` are expanded to one entry per case, and each collected test is categorized exactly as a real run would categorize it — runnable tests as `passed`, [`test.skip`](GlobalAPI.md#testskipname-fn) (and tests deselected by `test.only`) as `pending`, and [`test.todo`](GlobalAPI.md#testtodoname) as `todo`. As a result the counts reported by `--collectTests` match those of an actual run (assuming every runnable test passes), so it can be used to count tests without executing them.
+
+Use `--json` to get machine-readable output instead. The JSON uses the same shape as a normal run, including `numTotalTests`, `numPassedTests`, `numPendingTests` and `numTodoTests`.
 
 ### `--colors`
 

--- a/e2e/__tests__/collectTests.test.ts
+++ b/e2e/__tests__/collectTests.test.ts
@@ -7,6 +7,24 @@
 
 import runJest from '../runJest';
 
+type Counts = {
+  numFailedTests: number;
+  numPassedTests: number;
+  numPendingTests: number;
+  numTodoTests: number;
+  numTotalTestSuites: number;
+  numTotalTests: number;
+};
+
+const counts = (result: Counts): Counts => ({
+  numFailedTests: result.numFailedTests,
+  numPassedTests: result.numPassedTests,
+  numPendingTests: result.numPendingTests,
+  numTodoTests: result.numTodoTests,
+  numTotalTestSuites: result.numTotalTestSuites,
+  numTotalTests: result.numTotalTests,
+});
+
 describe('jest --collect-tests', () => {
   test('lists test names without executing test bodies', () => {
     const {exitCode, stdout} = runJest('each', [
@@ -56,9 +74,11 @@ describe('jest --collect-tests', () => {
 
     const testFile = json.testResults[0];
     expect(testFile.name).toContain('success.test.js');
-    // Every test in this fixture would run, so all collect to `passed`.
+    // Every test in this fixture would run, so all collect to `passed` and are
+    // flagged `wouldRun` (selected, but never executed).
     for (const assertion of testFile.assertionResults) {
       expect(assertion.status).toBe('passed');
+      expect(assertion.wouldRun).toBe(true);
     }
   });
 
@@ -84,16 +104,34 @@ describe('jest --collect-tests', () => {
     expect(stdout).toContain('fails');
   });
 
-  test('filters correctly with --testNamePattern', () => {
+  test('reports --testNamePattern-deselected tests as pending (like a real run)', () => {
     const {exitCode, stdout} = runJest('each', [
       '--collect-tests',
+      '--json',
       '--testPathPatterns=success',
       '--testNamePattern=one row',
     ]);
 
     expect(exitCode).toBe(0);
-    expect(stdout).toContain('passes one row expected');
-    expect(stdout).not.toContain("The word red contains the letter 'e'");
+    const json = JSON.parse(stdout);
+    const byTitle = new Map<string, {status: string; wouldRun?: boolean}>(
+      json.testResults[0].assertionResults.map(
+        (assertion: {status: string; title: string; wouldRun?: boolean}) => [
+          assertion.title,
+          assertion,
+        ],
+      ),
+    );
+
+    // Matching tests would run; non-matching ones are still collected, but as
+    // pending — exactly how an actual run accounts for them.
+    expect(byTitle.get('passes one row expected true == true')).toMatchObject({
+      status: 'passed',
+      wouldRun: true,
+    });
+    expect(byTitle.get("The word red contains the letter 'e'")?.status).toBe(
+      'pending',
+    );
   });
 
   test('exits 0 even when no tests match', () => {
@@ -123,22 +161,6 @@ describe('jest --collect-tests', () => {
       const real = JSON.parse(runReal.stdout);
       const collected = JSON.parse(runCollect.stdout);
 
-      const counts = (result: {
-        numFailedTests: number;
-        numPassedTests: number;
-        numPendingTests: number;
-        numTodoTests: number;
-        numTotalTestSuites: number;
-        numTotalTests: number;
-      }) => ({
-        numFailedTests: result.numFailedTests,
-        numPassedTests: result.numPassedTests,
-        numPendingTests: result.numPendingTests,
-        numTodoTests: result.numTodoTests,
-        numTotalTestSuites: result.numTotalTestSuites,
-        numTotalTests: result.numTotalTests,
-      });
-
       // The real run passes (every runnable test is written to pass), so the
       // full per-status breakdown collected without execution matches it
       // exactly.
@@ -152,6 +174,22 @@ describe('jest --collect-tests', () => {
       expect(collected.numPassedTests).toBeGreaterThan(50);
     },
   );
+
+  testOnCircus('matches a real run when filtered by --testNamePattern', () => {
+    const args = ['--testNamePattern=passes'];
+    const real = JSON.parse(
+      runJest('collect-tests', ['--json', ...args]).stdout,
+    );
+    const collected = JSON.parse(
+      runJest('collect-tests', ['--collect-tests', '--json', ...args]).stdout,
+    );
+
+    // Deselected tests are counted as pending by both, so the totals agree.
+    expect(real.numFailedTests).toBe(0);
+    expect(counts(collected)).toEqual(counts(real));
+    expect(collected.numPendingTests).toBeGreaterThan(0);
+    expect(collected.numPassedTests).toBeGreaterThan(0);
+  });
 
   testOnCircus('marks xfail (test.failing) entries as failing', () => {
     const {exitCode, stdout} = runJest('collect-tests', [

--- a/e2e/__tests__/collectTests.test.ts
+++ b/e2e/__tests__/collectTests.test.ts
@@ -7,59 +7,41 @@
 
 import runJest from '../runJest';
 
-type Counts = {
-  numFailedTests: number;
-  numPassedTests: number;
-  numPendingTests: number;
-  numTodoTests: number;
-  numTotalTestSuites: number;
-  numTotalTests: number;
-};
+const COUNT_KEYS = [
+  'numFailedTests',
+  'numPassedTests',
+  'numPendingTests',
+  'numTodoTests',
+  'numTotalTestSuites',
+  'numTotalTests',
+] as const;
 
-const counts = (result: Counts): Counts => ({
-  numFailedTests: result.numFailedTests,
-  numPassedTests: result.numPassedTests,
-  numPendingTests: result.numPendingTests,
-  numTodoTests: result.numTodoTests,
-  numTotalTestSuites: result.numTotalTestSuites,
-  numTotalTests: result.numTotalTests,
-});
+type Counts = Record<(typeof COUNT_KEYS)[number], number>;
+
+const counts = (result: Counts): Counts =>
+  Object.fromEntries(COUNT_KEYS.map(key => [key, result[key]])) as Counts;
 
 describe('jest --collect-tests', () => {
-  test('lists test names without executing test bodies', () => {
+  // `.only` focus and `test.failing` collection parity is only implemented for
+  // the default circus runner; jasmine2 collection support is best-effort, so
+  // tests that rely on the kitchenSink fixture (which uses `test.failing`) run
+  // on circus only.
+  const testOnCircus = process.env.JEST_JASMINE ? test.skip : test;
+
+  test('prints a tree and summary without executing tests', () => {
     const {exitCode, stdout} = runJest('each', [
       '--collect-tests',
       '--testPathPatterns=success',
     ]);
 
     expect(exitCode).toBe(0);
-    expect(stdout).toContain("The word red contains the letter 'e'");
-    expect(stdout).toContain('passes one row expected true == true');
-    expect(stdout).toContain('passes all rows expected true == true');
     expect(stdout).toContain('success.test.js');
+    expect(stdout).toContain("The word red contains the letter 'e'");
+    expect(stdout).toMatch(/Test suites:\s+1/);
+    expect(stdout).toMatch(/Tests:\s+15 total/);
   });
 
-  test('expands it.each / test.each into one entry per case', () => {
-    const {exitCode, stdout} = runJest('each', [
-      '--collect-tests',
-      '--json',
-      '--testPathPatterns=success',
-    ]);
-
-    expect(exitCode).toBe(0);
-    const json = JSON.parse(stdout);
-    const titles = json.testResults[0].assertionResults.map(
-      (assertion: {title: string}) => assertion.title,
-    );
-
-    // The three-element `test.each(['red', 'green', 'bean'])` becomes three
-    // separate collected entries rather than a single `.each` block.
-    expect(titles).toContain("The word red contains the letter 'e'");
-    expect(titles).toContain("The word green contains the letter 'e'");
-    expect(titles).toContain("The word bean contains the letter 'e'");
-  });
-
-  test('produces valid JSON with --json', () => {
+  test('emits JSON with per-test status and the wouldRun flag', () => {
     const {exitCode, stdout} = runJest('each', [
       '--collect-tests',
       '--json',
@@ -70,7 +52,6 @@ describe('jest --collect-tests', () => {
     const json = JSON.parse(stdout);
     expect(json.success).toBe(true);
     expect(json.numTotalTestSuites).toBe(1);
-    expect(json.numTotalTests).toBeGreaterThan(0);
 
     const testFile = json.testResults[0];
     expect(testFile.name).toContain('success.test.js');
@@ -82,18 +63,7 @@ describe('jest --collect-tests', () => {
     }
   });
 
-  test('prints a summary line with the total count', () => {
-    const {exitCode, stdout} = runJest('each', [
-      '--collect-tests',
-      '--testPathPatterns=success',
-    ]);
-
-    expect(exitCode).toBe(0);
-    expect(stdout).toMatch(/Test suites:\s+1/);
-    expect(stdout).toMatch(/Tests:\s+15 total/);
-  });
-
-  test('annotates skipped and todo tests in the tree', () => {
+  testOnCircus('annotates skipped and todo tests in the tree', () => {
     const {exitCode, stdout} = runJest('collect-tests', [
       '--collect-tests',
       '--testPathPatterns=kitchenSink',
@@ -102,9 +72,7 @@ describe('jest --collect-tests', () => {
     expect(exitCode).toBe(0);
     expect(stdout).toContain('explicitly skipped [skipped]');
     expect(stdout).toContain('write this later [todo]');
-    // Runnable tests are left unannotated.
-    expect(stdout).toContain('deeply nested passes\n');
-    expect(stdout).not.toContain('deeply nested passes [');
+    expect(stdout).toContain('deeply nested passes\n'); // runnable: unannotated
   });
 
   test('surfaces test files that fail to load', () => {
@@ -113,57 +81,24 @@ describe('jest --collect-tests', () => {
     ]);
 
     // A file that throws while loading cannot be collected: it is reported with
-    // its error and counted, and the exit code is non-zero.
+    // its error, and the exit code is non-zero.
     expect(exitCode).not.toBe(0);
-    expect(stdout).toContain('broken.test.js');
     expect(stdout).toContain('boom while loading this test file');
     expect(stdout).toMatch(/test suite\(s\) failed to load/);
-    // The healthy file is still collected.
-    expect(stdout).toContain('this one collects fine');
+    expect(stdout).toContain('this one collects fine'); // healthy file still listed
   });
 
-  test('does not execute tests (failing tests still exit 0)', () => {
+  test('does not execute test bodies (failing tests still exit 0)', () => {
     const {exitCode, stdout} = runJest('each', [
       '--collect-tests',
       '--testPathPatterns=failure',
     ]);
 
     expect(exitCode).toBe(0);
-    expect(stdout).toContain('failure.test.js');
     expect(stdout).toContain('fails');
   });
 
-  test('reports --testNamePattern-deselected tests as pending (like a real run)', () => {
-    const {exitCode, stdout} = runJest('each', [
-      '--collect-tests',
-      '--json',
-      '--testPathPatterns=success',
-      '--testNamePattern=one row',
-    ]);
-
-    expect(exitCode).toBe(0);
-    const json = JSON.parse(stdout);
-    const byTitle = new Map<string, {status: string; wouldRun?: boolean}>(
-      json.testResults[0].assertionResults.map(
-        (assertion: {status: string; title: string; wouldRun?: boolean}) => [
-          assertion.title,
-          assertion,
-        ],
-      ),
-    );
-
-    // Matching tests would run; non-matching ones are still collected, but as
-    // pending — exactly how an actual run accounts for them.
-    expect(byTitle.get('passes one row expected true == true')).toMatchObject({
-      status: 'passed',
-      wouldRun: true,
-    });
-    expect(byTitle.get("The word red contains the letter 'e'")?.status).toBe(
-      'pending',
-    );
-  });
-
-  test('exits 0 even when no tests match', () => {
+  test('exits 0 when no tests match', () => {
     const {exitCode, stdout} = runJest('each', [
       '--collect-tests',
       '--testPathPatterns=nonexistent',
@@ -173,39 +108,13 @@ describe('jest --collect-tests', () => {
     expect(stdout).toContain('No tests found');
   });
 
-  // Focus (`.only`) and `test.failing` collection parity is only implemented for
-  // the default circus runner; jasmine2 collection support is best-effort.
-  const testOnCircus = process.env.JEST_JASMINE ? test.skip : test;
-
-  testOnCircus(
-    'reports the same per-status counts as a real run (skip/todo/xfail/each/focus)',
-    () => {
-      const runReal = runJest('collect-tests', ['--json']);
-      const runCollect = runJest('collect-tests', [
-        '--collect-tests',
-        '--json',
-      ]);
-
-      expect(runCollect.exitCode).toBe(0);
-      const real = JSON.parse(runReal.stdout);
-      const collected = JSON.parse(runCollect.stdout);
-
-      // The real run passes (every runnable test is written to pass), so the
-      // full per-status breakdown collected without execution matches it
-      // exactly.
-      expect(real.numFailedTests).toBe(0);
-      expect(counts(collected)).toEqual(counts(real));
-
-      // Sanity-check the breakdown is non-trivial: skips, todos and `.each`
-      // expansion are all represented.
-      expect(collected.numPendingTests).toBeGreaterThan(0);
-      expect(collected.numTodoTests).toBeGreaterThan(0);
-      expect(collected.numPassedTests).toBeGreaterThan(50);
-    },
-  );
-
-  testOnCircus('matches a real run when filtered by --testNamePattern', () => {
-    const args = ['--testNamePattern=passes'];
+  // The fixture's runnable tests all pass, so the per-status breakdown collected
+  // without execution matches a real run exactly — including `.each` expansion,
+  // skips, todos, xfail, focus, and `--testNamePattern` deselection.
+  testOnCircus.each([
+    ['unfiltered', [] as Array<string>],
+    ['--testNamePattern', ['--testNamePattern=passes']],
+  ])('reports the same counts as a real run (%s)', (_label, args) => {
     const real = JSON.parse(
       runJest('collect-tests', ['--json', ...args]).stdout,
     );
@@ -213,27 +122,22 @@ describe('jest --collect-tests', () => {
       runJest('collect-tests', ['--collect-tests', '--json', ...args]).stdout,
     );
 
-    // Deselected tests are counted as pending by both, so the totals agree.
     expect(real.numFailedTests).toBe(0);
     expect(counts(collected)).toEqual(counts(real));
-    expect(collected.numPendingTests).toBeGreaterThan(0);
     expect(collected.numPassedTests).toBeGreaterThan(0);
+    expect(collected.numPendingTests).toBeGreaterThan(0);
   });
 
   testOnCircus('marks xfail (test.failing) entries as failing', () => {
-    const {exitCode, stdout} = runJest('collect-tests', [
+    const {stdout} = runJest('collect-tests', [
       '--collect-tests',
       '--json',
       '--testPathPatterns=kitchenSink',
     ]);
-
-    expect(exitCode).toBe(0);
-    const json = JSON.parse(stdout);
-    const xfail = json.testResults[0].assertionResults.find(
+    const xfail = JSON.parse(stdout).testResults[0].assertionResults.find(
       (assertion: {title: string}) =>
         assertion.title === 'known broken passes when it throws',
     );
-    expect(xfail).toBeDefined();
     expect(xfail.failing).toBe(true);
   });
 });

--- a/e2e/__tests__/collectTests.test.ts
+++ b/e2e/__tests__/collectTests.test.ts
@@ -21,6 +21,26 @@ describe('jest --collect-tests', () => {
     expect(stdout).toContain('success.test.js');
   });
 
+  test('expands it.each / test.each into one entry per case', () => {
+    const {exitCode, stdout} = runJest('each', [
+      '--collect-tests',
+      '--json',
+      '--testPathPatterns=success',
+    ]);
+
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(stdout);
+    const titles = json.testResults[0].assertionResults.map(
+      (assertion: {title: string}) => assertion.title,
+    );
+
+    // The three-element `test.each(['red', 'green', 'bean'])` becomes three
+    // separate collected entries rather than a single `.each` block.
+    expect(titles).toContain("The word red contains the letter 'e'");
+    expect(titles).toContain("The word green contains the letter 'e'");
+    expect(titles).toContain("The word bean contains the letter 'e'");
+  });
+
   test('produces valid JSON with --json', () => {
     const {exitCode, stdout} = runJest('each', [
       '--collect-tests',
@@ -32,13 +52,25 @@ describe('jest --collect-tests', () => {
     const json = JSON.parse(stdout);
     expect(json.success).toBe(true);
     expect(json.numTotalTestSuites).toBe(1);
-    expect(json.numPendingTests).toBeGreaterThan(0);
+    expect(json.numTotalTests).toBeGreaterThan(0);
 
     const testFile = json.testResults[0];
     expect(testFile.name).toContain('success.test.js');
+    // Every test in this fixture would run, so all collect to `passed`.
     for (const assertion of testFile.assertionResults) {
-      expect(assertion.status).toBe('pending');
+      expect(assertion.status).toBe('passed');
     }
+  });
+
+  test('prints a summary line with the total count', () => {
+    const {exitCode, stdout} = runJest('each', [
+      '--collect-tests',
+      '--testPathPatterns=success',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/Test suites:\s+1/);
+    expect(stdout).toMatch(/Tests:\s+15 total/);
   });
 
   test('does not execute tests (failing tests still exit 0)', () => {
@@ -72,5 +104,69 @@ describe('jest --collect-tests', () => {
 
     expect(exitCode).toBe(0);
     expect(stdout).toContain('No tests found');
+  });
+
+  // Focus (`.only`) and `test.failing` collection parity is only implemented for
+  // the default circus runner; jasmine2 collection support is best-effort.
+  const testOnCircus = process.env.JEST_JASMINE ? test.skip : test;
+
+  testOnCircus(
+    'reports the same per-status counts as a real run (skip/todo/xfail/each/focus)',
+    () => {
+      const runReal = runJest('collect-tests', ['--json']);
+      const runCollect = runJest('collect-tests', [
+        '--collect-tests',
+        '--json',
+      ]);
+
+      expect(runCollect.exitCode).toBe(0);
+      const real = JSON.parse(runReal.stdout);
+      const collected = JSON.parse(runCollect.stdout);
+
+      const counts = (result: {
+        numFailedTests: number;
+        numPassedTests: number;
+        numPendingTests: number;
+        numTodoTests: number;
+        numTotalTestSuites: number;
+        numTotalTests: number;
+      }) => ({
+        numFailedTests: result.numFailedTests,
+        numPassedTests: result.numPassedTests,
+        numPendingTests: result.numPendingTests,
+        numTodoTests: result.numTodoTests,
+        numTotalTestSuites: result.numTotalTestSuites,
+        numTotalTests: result.numTotalTests,
+      });
+
+      // The real run passes (every runnable test is written to pass), so the
+      // full per-status breakdown collected without execution matches it
+      // exactly.
+      expect(real.numFailedTests).toBe(0);
+      expect(counts(collected)).toEqual(counts(real));
+
+      // Sanity-check the breakdown is non-trivial: skips, todos and `.each`
+      // expansion are all represented.
+      expect(collected.numPendingTests).toBeGreaterThan(0);
+      expect(collected.numTodoTests).toBeGreaterThan(0);
+      expect(collected.numPassedTests).toBeGreaterThan(50);
+    },
+  );
+
+  testOnCircus('marks xfail (test.failing) entries as failing', () => {
+    const {exitCode, stdout} = runJest('collect-tests', [
+      '--collect-tests',
+      '--json',
+      '--testPathPatterns=kitchenSink',
+    ]);
+
+    expect(exitCode).toBe(0);
+    const json = JSON.parse(stdout);
+    const xfail = json.testResults[0].assertionResults.find(
+      (assertion: {title: string}) =>
+        assertion.title === 'known broken passes when it throws',
+    );
+    expect(xfail).toBeDefined();
+    expect(xfail.failing).toBe(true);
   });
 });

--- a/e2e/__tests__/collectTests.test.ts
+++ b/e2e/__tests__/collectTests.test.ts
@@ -93,6 +93,35 @@ describe('jest --collect-tests', () => {
     expect(stdout).toMatch(/Tests:\s+15 total/);
   });
 
+  test('annotates skipped and todo tests in the tree', () => {
+    const {exitCode, stdout} = runJest('collect-tests', [
+      '--collect-tests',
+      '--testPathPatterns=kitchenSink',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain('explicitly skipped [skipped]');
+    expect(stdout).toContain('write this later [todo]');
+    // Runnable tests are left unannotated.
+    expect(stdout).toContain('deeply nested passes\n');
+    expect(stdout).not.toContain('deeply nested passes [');
+  });
+
+  test('surfaces test files that fail to load', () => {
+    const {exitCode, stdout} = runJest('collect-tests-load-error', [
+      '--collect-tests',
+    ]);
+
+    // A file that throws while loading cannot be collected: it is reported with
+    // its error and counted, and the exit code is non-zero.
+    expect(exitCode).not.toBe(0);
+    expect(stdout).toContain('broken.test.js');
+    expect(stdout).toContain('boom while loading this test file');
+    expect(stdout).toMatch(/test suite\(s\) failed to load/);
+    // The healthy file is still collected.
+    expect(stdout).toContain('this one collects fine');
+  });
+
   test('does not execute tests (failing tests still exit 0)', () => {
     const {exitCode, stdout} = runJest('each', [
       '--collect-tests',

--- a/e2e/__tests__/collectTests.test.ts
+++ b/e2e/__tests__/collectTests.test.ts
@@ -22,10 +22,10 @@ const counts = (result: Counts): Counts =>
   Object.fromEntries(COUNT_KEYS.map(key => [key, result[key]])) as Counts;
 
 describe('jest --collect-tests', () => {
-  // `.only` focus and `test.failing` collection parity is only implemented for
-  // the default circus runner; jasmine2 collection support is best-effort, so
-  // tests that rely on the kitchenSink fixture (which uses `test.failing`) run
-  // on circus only.
+  // `test.failing` (xfail) collection parity is only implemented for the
+  // default circus runner, so tests that rely on the kitchenSink fixture (which
+  // uses `test.failing`) run on circus only. Focus parity is supported on both
+  // runners and is exercised by a dedicated test below.
   const testOnCircus = process.env.JEST_JASMINE ? test.skip : test;
 
   test('prints a tree and summary without executing tests', () => {
@@ -126,6 +126,27 @@ describe('jest --collect-tests', () => {
     expect(counts(collected)).toEqual(counts(real));
     expect(collected.numPassedTests).toBeGreaterThan(0);
     expect(collected.numPendingTests).toBeGreaterThan(0);
+  });
+
+  // Focus (`test.only`/`fdescribe`) deselects the other tests in the file. Both
+  // runners must collect the same per-status counts a real run produces; the
+  // focused fixture has no `test.failing`, so jasmine parity holds here too.
+  test('reports the same counts as a real run with focused tests', () => {
+    const real = JSON.parse(
+      runJest('collect-tests', ['--json', '--testPathPatterns=focused']).stdout,
+    );
+    const collected = JSON.parse(
+      runJest('collect-tests', [
+        '--collect-tests',
+        '--json',
+        '--testPathPatterns=focused',
+      ]).stdout,
+    );
+
+    expect(real.numFailedTests).toBe(0);
+    expect(real.numPassedTests).toBe(1);
+    expect(real.numPendingTests).toBeGreaterThan(0);
+    expect(counts(collected)).toEqual(counts(real));
   });
 
   testOnCircus('marks xfail (test.failing) entries as failing', () => {

--- a/e2e/collect-tests-load-error/__tests__/broken.test.js
+++ b/e2e/collect-tests-load-error/__tests__/broken.test.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+throw new Error('boom while loading this test file');

--- a/e2e/collect-tests-load-error/__tests__/ok.test.js
+++ b/e2e/collect-tests-load-error/__tests__/ok.test.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+test('this one collects fine', () => {
+  expect(true).toBe(true);
+});

--- a/e2e/collect-tests-load-error/package.json
+++ b/e2e/collect-tests-load-error/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/e2e/collect-tests/__tests__/focused.test.js
+++ b/e2e/collect-tests/__tests__/focused.test.js
@@ -1,0 +1,31 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/* eslint-disable jest/no-focused-tests */
+
+// When a file focuses tests with `.only`, the unfocused tests are reported as
+// skipped (pending) in a real run. `--collect-tests` must reflect the same.
+
+test.only('focused passes a', () => {
+  expect(true).toBe(true);
+});
+
+test.only('focused passes b', () => {
+  expect(true).toBe(true);
+});
+
+test('unfocused becomes skipped', () => {
+  throw new Error('should never run');
+});
+
+describe('unfocused describe', () => {
+  test('also skipped', () => {
+    throw new Error('should never run');
+  });
+});
+
+test.todo('todo survives focus');

--- a/e2e/collect-tests/__tests__/focused.test.js
+++ b/e2e/collect-tests/__tests__/focused.test.js
@@ -10,22 +10,12 @@
 // When a file focuses tests with `.only`, the unfocused tests are reported as
 // skipped (pending) in a real run. `--collect-tests` must reflect the same.
 
-test.only('focused passes a', () => {
-  expect(true).toBe(true);
-});
-
-test.only('focused passes b', () => {
+test.only('focused passes', () => {
   expect(true).toBe(true);
 });
 
 test('unfocused becomes skipped', () => {
   throw new Error('should never run');
-});
-
-describe('unfocused describe', () => {
-  test('also skipped', () => {
-    throw new Error('should never run');
-  });
 });
 
 test.todo('todo survives focus');

--- a/e2e/collect-tests/__tests__/kitchenSink.test.js
+++ b/e2e/collect-tests/__tests__/kitchenSink.test.js
@@ -1,0 +1,94 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// A deliberately large suite exercising every shape that affects test counts:
+// plain tests, `.each` expansion, nested describes, `.skip`, `describe.skip`,
+// `.todo` and `.failing` (xfail). The companion e2e test asserts that
+// `--collect-tests` reports the exact same per-status counts as a real run.
+
+const RUNNABLE_ROWS = Array.from({length: 50}, (_, index) => index);
+
+describe('plain tests', () => {
+  for (const index of RUNNABLE_ROWS) {
+    test(`passes ${index}`, () => {
+      expect(index).toBe(index);
+    });
+  }
+});
+
+describe('each expansion', () => {
+  test.each(RUNNABLE_ROWS)('array case %i', value => {
+    expect(value).toBeGreaterThanOrEqual(0);
+  });
+
+  it.each`
+    left | right
+    ${1} | ${1}
+    ${2} | ${2}
+    ${3} | ${3}
+  `('template case $left == $right', ({left, right}) => {
+    expect(left).toBe(right);
+  });
+
+  describe.each([
+    [1, 1],
+    [2, 2],
+  ])('describe.each %i', (left, right) => {
+    test('inner a', () => {
+      expect(left).toBe(right);
+    });
+    test('inner b', () => {
+      expect(left).toBe(right);
+    });
+  });
+});
+
+describe('nesting', () => {
+  describe('level two', () => {
+    describe('level three', () => {
+      test('deeply nested passes', () => {
+        expect(true).toBe(true);
+      });
+    });
+  });
+});
+
+describe('skips', () => {
+  test.skip('explicitly skipped', () => {
+    throw new Error('should never run');
+  });
+
+  it.skip.each([1, 2, 3])('skipped each %i', value => {
+    throw new Error(`should never run ${value}`);
+  });
+});
+
+describe.skip('entirely skipped describe', () => {
+  test('child one', () => {
+    throw new Error('should never run');
+  });
+  test('child two', () => {
+    throw new Error('should never run');
+  });
+  describe('nested under skip', () => {
+    test('grandchild', () => {
+      throw new Error('should never run');
+    });
+  });
+});
+
+describe('todos', () => {
+  test.todo('write this later');
+  test.todo('and this one');
+  test.todo('plus a third');
+});
+
+describe('xfail', () => {
+  test.failing('known broken passes when it throws', () => {
+    expect(1).toBe(2);
+  });
+});

--- a/e2e/collect-tests/__tests__/kitchenSink.test.js
+++ b/e2e/collect-tests/__tests__/kitchenSink.test.js
@@ -5,23 +5,21 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-// A deliberately large suite exercising every shape that affects test counts:
-// plain tests, `.each` expansion, nested describes, `.skip`, `describe.skip`,
+// Exercises every shape that affects test counts: plain tests, `.each`
+// expansion (array + template), nested describes, `.skip`, `describe.skip`,
 // `.todo` and `.failing` (xfail). The companion e2e test asserts that
-// `--collect-tests` reports the exact same per-status counts as a real run.
+// `--collect-tests` reports the same per-status counts as a real run.
 
-const RUNNABLE_ROWS = Array.from({length: 50}, (_, index) => index);
+const rows = Array.from({length: 30}, (_, index) => index);
 
-describe('plain tests', () => {
-  for (const index of RUNNABLE_ROWS) {
+describe('plain and each', () => {
+  for (const index of rows) {
     test(`passes ${index}`, () => {
       expect(index).toBe(index);
     });
   }
-});
 
-describe('each expansion', () => {
-  test.each(RUNNABLE_ROWS)('array case %i', value => {
+  test.each(rows)('array case %i', value => {
     expect(value).toBeGreaterThanOrEqual(0);
   });
 
@@ -29,30 +27,13 @@ describe('each expansion', () => {
     left | right
     ${1} | ${1}
     ${2} | ${2}
-    ${3} | ${3}
   `('template case $left == $right', ({left, right}) => {
     expect(left).toBe(right);
   });
 
-  describe.each([
-    [1, 1],
-    [2, 2],
-  ])('describe.each %i', (left, right) => {
-    test('inner a', () => {
-      expect(left).toBe(right);
-    });
-    test('inner b', () => {
-      expect(left).toBe(right);
-    });
-  });
-});
-
-describe('nesting', () => {
-  describe('level two', () => {
-    describe('level three', () => {
-      test('deeply nested passes', () => {
-        expect(true).toBe(true);
-      });
+  describe.each([1, 2])('describe.each %i', value => {
+    test('deeply nested passes', () => {
+      expect(value).toBe(value);
     });
   });
 });
@@ -62,16 +43,13 @@ describe('skips', () => {
     throw new Error('should never run');
   });
 
-  it.skip.each([1, 2, 3])('skipped each %i', value => {
-    throw new Error(`should never run ${value}`);
+  it.skip.each([1, 2])('skipped each %i', () => {
+    throw new Error('should never run');
   });
 });
 
 describe.skip('entirely skipped describe', () => {
   test('child one', () => {
-    throw new Error('should never run');
-  });
-  test('child two', () => {
     throw new Error('should never run');
   });
   describe('nested under skip', () => {
@@ -84,11 +62,8 @@ describe.skip('entirely skipped describe', () => {
 describe('todos', () => {
   test.todo('write this later');
   test.todo('and this one');
-  test.todo('plus a third');
 });
 
-describe('xfail', () => {
-  test.failing('known broken passes when it throws', () => {
-    expect(1).toBe(2);
-  });
+test.failing('known broken passes when it throws', () => {
+  expect(1).toBe(2);
 });

--- a/e2e/collect-tests/package.json
+++ b/e2e/collect-tests/package.json
@@ -1,0 +1,5 @@
+{
+  "jest": {
+    "testEnvironment": "node"
+  }
+}

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/collectTestsWithoutRunning.test.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/collectTestsWithoutRunning.test.ts
@@ -120,6 +120,20 @@ describe('collectTestsWithoutRunning', () => {
     expect(result.testResults[0].fullName).toBe('outer inner deep test');
   });
 
+  it('preserves source order across describe blocks', async () => {
+    const root = getRunnerState().rootDescribeBlock;
+    const a = makeDescribe('A', root);
+    root.children.push(a);
+    addTest('first', a);
+    const b = makeDescribe('B', root);
+    root.children.push(b);
+    addTest('second', b);
+
+    const result = await collect();
+
+    expect(result.testResults.map(r => r.title)).toEqual(['first', 'second']);
+  });
+
   it('returns empty results when no tests exist', async () => {
     const result = await collect();
     expect(result.testResults).toHaveLength(0);

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/collectTestsWithoutRunning.test.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/collectTestsWithoutRunning.test.ts
@@ -22,16 +22,21 @@ beforeEach(() => {
   resetState();
 });
 
-const addTest = (name: string, parent: Circus.DescribeBlock) => {
+const addTest = (
+  name: string,
+  parent: Circus.DescribeBlock,
+  mode: Circus.TestMode = undefined,
+  failing = false,
+) => {
   const test = makeTest(
     () => {},
-    undefined,
+    mode,
     false,
     name,
     parent,
     undefined,
     new Error(),
-    false,
+    failing,
   );
   parent.children.push(test);
 };
@@ -40,7 +45,7 @@ const collect = (testPath = '/test.js') =>
   collectTestsWithoutRunning({config: makeProjectConfig(), testPath});
 
 describe('collectTestsWithoutRunning', () => {
-  it('collects flat tests with pending status', async () => {
+  it('collects runnable tests as passed', async () => {
     const root = getRunnerState().rootDescribeBlock;
     addTest('test one', root);
     addTest('test two', root);
@@ -51,8 +56,69 @@ describe('collectTestsWithoutRunning', () => {
       'test one',
       'test two',
     ]);
+    expect(result.testResults[0].status).toBe('passed');
+    expect(result.numPassingTests).toBe(2);
+    expect(result.numPendingTests).toBe(0);
+  });
+
+  it('resolves status per test mode to match a real run', async () => {
+    const root = getRunnerState().rootDescribeBlock;
+    addTest('runnable', root);
+    addTest('skipped', root, 'skip');
+    addTest('todo', root, 'todo');
+
+    const result = await collect();
+
+    expect(
+      result.testResults.map(r => ({status: r.status, title: r.title})),
+    ).toEqual([
+      {status: 'passed', title: 'runnable'},
+      {status: 'pending', title: 'skipped'},
+      {status: 'todo', title: 'todo'},
+    ]);
+    expect(result.numPassingTests).toBe(1);
+    expect(result.numPendingTests).toBe(1);
+    expect(result.numTodoTests).toBe(1);
+  });
+
+  it('marks tests under a skipped describe as pending', async () => {
+    const root = getRunnerState().rootDescribeBlock;
+    const skipped = makeDescribe('skipped suite', root, 'skip');
+    root.children.push(skipped);
+    addTest('child', skipped);
+
+    const result = await collect();
+
     expect(result.testResults[0].status).toBe('pending');
-    expect(result.numPendingTests).toBe(2);
+    expect(result.numPendingTests).toBe(1);
+  });
+
+  it('marks unfocused tests as pending when the file has focused tests', async () => {
+    const state = getRunnerState();
+    state.hasFocusedTests = true;
+    addTest('focused', state.rootDescribeBlock, 'only');
+    addTest('unfocused', state.rootDescribeBlock);
+    addTest('todo survives focus', state.rootDescribeBlock, 'todo');
+
+    const result = await collect();
+
+    expect(
+      result.testResults.map(r => ({status: r.status, title: r.title})),
+    ).toEqual([
+      {status: 'passed', title: 'focused'},
+      {status: 'pending', title: 'unfocused'},
+      {status: 'todo', title: 'todo survives focus'},
+    ]);
+  });
+
+  it('preserves the failing flag for xfail tests', async () => {
+    const root = getRunnerState().rootDescribeBlock;
+    addTest('xfail', root, undefined, true);
+
+    const result = await collect();
+
+    expect(result.testResults[0].failing).toBe(true);
+    expect(result.testResults[0].status).toBe('passed');
   });
 
   it('collects nested tests with correct ancestor titles', async () => {

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/collectTestsWithoutRunning.test.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/collectTestsWithoutRunning.test.ts
@@ -45,24 +45,7 @@ const collect = (testPath = '/test.js') =>
   collectTestsWithoutRunning({config: makeProjectConfig(), testPath});
 
 describe('collectTestsWithoutRunning', () => {
-  it('collects runnable tests as passed', async () => {
-    const root = getRunnerState().rootDescribeBlock;
-    addTest('test one', root);
-    addTest('test two', root);
-
-    const result = await collect();
-
-    expect(result.testResults.map(r => r.title)).toEqual([
-      'test one',
-      'test two',
-    ]);
-    expect(result.testResults[0].status).toBe('passed');
-    expect(result.testResults[0].wouldRun).toBe(true);
-    expect(result.numPassingTests).toBe(2);
-    expect(result.numPendingTests).toBe(0);
-  });
-
-  it('resolves status per test mode to match a real run', async () => {
+  it('resolves status and counts per test mode to match a real run', async () => {
     const root = getRunnerState().rootDescribeBlock;
     addTest('runnable', root);
     addTest('skipped', root, 'skip');
@@ -77,6 +60,7 @@ describe('collectTestsWithoutRunning', () => {
       {status: 'pending', title: 'skipped'},
       {status: 'todo', title: 'todo'},
     ]);
+    expect(result.testResults[0].wouldRun).toBe(true);
     expect(result.numPassingTests).toBe(1);
     expect(result.numPendingTests).toBe(1);
     expect(result.numTodoTests).toBe(1);
@@ -134,20 +118,6 @@ describe('collectTestsWithoutRunning', () => {
 
     expect(result.testResults[0].ancestorTitles).toEqual(['outer', 'inner']);
     expect(result.testResults[0].fullName).toBe('outer inner deep test');
-  });
-
-  it('preserves source order across describe blocks', async () => {
-    const root = getRunnerState().rootDescribeBlock;
-    const a = makeDescribe('A', root);
-    root.children.push(a);
-    addTest('first', a);
-    const b = makeDescribe('B', root);
-    root.children.push(b);
-    addTest('second', b);
-
-    const result = await collect();
-
-    expect(result.testResults.map(r => r.title)).toEqual(['first', 'second']);
   });
 
   it('returns empty results when no tests exist', async () => {

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/collectTestsWithoutRunning.test.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/collectTestsWithoutRunning.test.ts
@@ -57,6 +57,7 @@ describe('collectTestsWithoutRunning', () => {
       'test two',
     ]);
     expect(result.testResults[0].status).toBe('passed');
+    expect(result.testResults[0].wouldRun).toBe(true);
     expect(result.numPassingTests).toBe(2);
     expect(result.numPendingTests).toBe(0);
   });
@@ -154,7 +155,7 @@ describe('collectTestsWithoutRunning', () => {
     expect(result.testResults).toHaveLength(0);
   });
 
-  it('filters tests by testNamePattern from runner state', async () => {
+  it('reports testNamePattern-deselected tests as pending, like a real run', async () => {
     const state = getRunnerState();
     state.testNamePattern = /one/;
     addTest('test one', state.rootDescribeBlock);
@@ -162,6 +163,13 @@ describe('collectTestsWithoutRunning', () => {
 
     const result = await collect();
 
-    expect(result.testResults.map(r => r.title)).toEqual(['test one']);
+    expect(
+      result.testResults.map(r => ({status: r.status, title: r.title})),
+    ).toEqual([
+      {status: 'passed', title: 'test one'},
+      {status: 'pending', title: 'test two'},
+    ]);
+    expect(result.numPassingTests).toBe(1);
+    expect(result.numPendingTests).toBe(1);
   });
 });

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -14,6 +14,7 @@ import {
   type TestFileEvent,
   type TestResult,
   createEmptyTestResult,
+  makeCollectedTestResult,
 } from '@jest/test-result';
 import type {Circus, Config, Global} from '@jest/types';
 import {formatExecError, formatResultsErrors} from 'jest-message-util';
@@ -147,17 +148,21 @@ export const collectTestsWithoutRunning = async ({
   config: Config.ProjectConfig;
   testPath: string;
 }): Promise<TestResult> => {
-  const {rootDescribeBlock, testNamePattern} = getRunnerState();
+  const {hasFocusedTests, rootDescribeBlock, testNamePattern} =
+    getRunnerState();
 
   const assertionResults: Array<AssertionResult> = [];
 
-  const walk = (
-    block: Circus.DescribeBlock,
-    ancestors: Array<string>,
-  ): void => {
+  // Mirror the status resolution performed by an actual run (see `_runTest` in
+  // `run.ts` and `parseSingleTestResult` in `utils.ts`) so collected counts
+  // match what executing the suite would report — without running test bodies.
+  const walk = (block: Circus.DescribeBlock, parent: WalkContext): void => {
     for (const child of block.children) {
       if (child.type === 'describeBlock') {
-        walk(child, [...ancestors, child.name]);
+        walk(child, {
+          ancestors: [...parent.ancestors, child.name],
+          skipped: parent.skipped || child.mode === 'skip',
+        });
         continue;
       }
 
@@ -165,36 +170,54 @@ export const collectTestsWithoutRunning = async ({
         continue;
       }
 
+      const skipped =
+        parent.skipped ||
+        child.mode === 'skip' ||
+        (hasFocusedTests && child.mode === undefined);
+
+      let status: Status;
+      if (skipped) {
+        status = 'pending';
+      } else if (child.mode === 'todo') {
+        status = 'todo';
+      } else {
+        // Test bodies are never executed in collection mode, so a selected test
+        // is reported as it would resolve when passing.
+        status = 'passed';
+      }
+
       const title = child.name;
       assertionResults.push({
-        ancestorTitles: [...ancestors],
+        ancestorTitles: [...parent.ancestors],
         duration: null,
-        failing: false,
+        failing: child.failing,
         failureDetails: [],
         failureMessages: [],
-        fullName: [...ancestors, title].join(' '),
+        fullName: [...parent.ancestors, title].join(' '),
         invocations: 0,
         location: null,
         numPassingAsserts: 0,
         retryReasons: [],
         startAt: null,
-        status: 'pending' as Status,
+        status,
         title,
       });
     }
   };
-  walk(rootDescribeBlock, []);
+  walk(rootDescribeBlock, {
+    ancestors: [],
+    skipped: rootDescribeBlock.mode === 'skip',
+  });
 
   await dispatch({name: 'teardown'});
 
-  return {
-    ...createEmptyTestResult(),
+  return makeCollectedTestResult(assertionResults, {
     displayName: config.displayName,
-    numPendingTests: assertionResults.length,
     testFilePath: testPath,
-    testResults: assertionResults,
-  };
+  });
 };
+
+type WalkContext = {ancestors: Array<string>; skipped: boolean};
 
 export const runAndTransformResultsToJestFormat = async ({
   config,

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -166,24 +166,27 @@ export const collectTestsWithoutRunning = async ({
         continue;
       }
 
-      if (testNamePattern && !testNamePattern.test(getTestID(child))) {
-        continue;
-      }
-
+      // Same conditions `_runTest` uses to dispatch `test_skip`: an actual run
+      // still reports these as pending, so collection counts them too.
+      const deselected =
+        testNamePattern != null && !testNamePattern.test(getTestID(child));
       const skipped =
         parent.skipped ||
         child.mode === 'skip' ||
-        (hasFocusedTests && child.mode === undefined);
+        (hasFocusedTests && child.mode === undefined) ||
+        deselected;
 
       let status: Status;
+      let wouldRun: true | undefined;
       if (skipped) {
         status = 'pending';
       } else if (child.mode === 'todo') {
         status = 'todo';
       } else {
         // Test bodies are never executed in collection mode, so a selected test
-        // is reported as it would resolve when passing.
+        // is reported in the passed bucket and flagged as `wouldRun`.
         status = 'passed';
+        wouldRun = true;
       }
 
       const title = child.name;
@@ -201,6 +204,7 @@ export const collectTestsWithoutRunning = async ({
         startAt: null,
         status,
         title,
+        wouldRun,
       });
     }
   };

--- a/packages/jest-core/src/__tests__/printCollectedTestTree.test.ts
+++ b/packages/jest-core/src/__tests__/printCollectedTestTree.test.ts
@@ -11,7 +11,8 @@ import {printCollectedTestTree} from '../runJest';
 const makeResult = (
   title: string,
   ancestorTitles: Array<string> = [],
-): AssertionResult => ({ancestorTitles, title}) as AssertionResult;
+  status?: AssertionResult['status'],
+): AssertionResult => ({ancestorTitles, status, title}) as AssertionResult;
 
 const collectOutput = (fn: (stream: NodeJS.WritableStream) => void): string => {
   const chunks: Array<string> = [];
@@ -47,6 +48,24 @@ describe('printCollectedTestTree', () => {
     expect(output).toContain('outer\n');
     expect(output).toContain('  inner\n');
     expect(output).toContain('    deep\n');
+  });
+
+  test('annotates skipped and todo tests but leaves runnable ones bare', () => {
+    const output = collectOutput(stream =>
+      printCollectedTestTree(
+        [
+          makeResult('runs', [], 'passed'),
+          makeResult('skipped', [], 'pending'),
+          makeResult('later', [], 'todo'),
+        ],
+        stream,
+      ),
+    );
+    // The runnable test is printed without any status marker.
+    expect(output).toContain('  runs\n');
+    // Skipped/todo markers are present (color codes, if any, surround them).
+    expect(output).toContain('[skipped]');
+    expect(output).toContain('[todo]');
   });
 
   test('handles empty results', () => {

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -44,12 +44,23 @@ export const printCollectedTestTree = (
   testResults: Array<AssertionResult>,
   outputStream: NodeJS.WritableStream,
 ): void => {
+  const annotate = (test: AssertionResult): string => {
+    if (test.status === 'todo') {
+      return chalk.dim(' [todo]');
+    }
+    if (test.status === 'pending') {
+      return chalk.dim(' [skipped]');
+    }
+    return '';
+  };
   const printSuite = (suite: Suite, indent: number): void => {
     if (suite.title) {
       outputStream.write(`${'  '.repeat(indent)}${suite.title}\n`);
     }
     for (const t of suite.tests) {
-      outputStream.write(`${'  '.repeat(indent + 1)}${t.title}\n`);
+      outputStream.write(
+        `${'  '.repeat(indent + 1)}${t.title}${annotate(t)}\n`,
+      );
     }
     for (const child of suite.suites) {
       printSuite(child, indent + 1);
@@ -78,6 +89,14 @@ const printCollectedTestSummary = (
     `\n${chalk.bold('Test suites:')} ${results.numTotalTestSuites}\n`,
   );
   outputStream.write(`${chalk.bold('Tests:')}       ${testsLine.join(', ')}\n`);
+
+  if (results.numRuntimeErrorTestSuites > 0) {
+    outputStream.write(
+      chalk.bold.red(
+        `\n${results.numRuntimeErrorTestSuites} test suite(s) failed to load and could not be collected.\n`,
+      ),
+    );
+  }
 };
 
 const getTestPaths = async (
@@ -314,7 +333,13 @@ export default async function runJest({
 
     if (!globalConfig.json) {
       for (const testResult of results.testResults) {
-        if (testResult.testResults.length > 0) {
+        if (testResult.testExecError) {
+          outputStream.write(
+            `${chalk.red(testResult.testFilePath)}\n${
+              testResult.failureMessage ?? testResult.testExecError.message
+            }\n`,
+          );
+        } else if (testResult.testResults.length > 0) {
           outputStream.write(`${testResult.testFilePath}\n`);
           printCollectedTestTree(testResult.testResults, outputStream);
         }

--- a/packages/jest-core/src/runJest.ts
+++ b/packages/jest-core/src/runJest.ts
@@ -59,6 +59,27 @@ export const printCollectedTestTree = (
   printSuite(root, 0);
 };
 
+const printCollectedTestSummary = (
+  results: AggregatedResult,
+  outputStream: NodeJS.WritableStream,
+): void => {
+  const testsLine = [`${chalk.bold(results.numTotalTests)} total`];
+  if (results.numPassedTests > 0) {
+    testsLine.push(chalk.green(`${results.numPassedTests} runnable`));
+  }
+  if (results.numPendingTests > 0) {
+    testsLine.push(chalk.yellow(`${results.numPendingTests} skipped`));
+  }
+  if (results.numTodoTests > 0) {
+    testsLine.push(chalk.magenta(`${results.numTodoTests} todo`));
+  }
+
+  outputStream.write(
+    `\n${chalk.bold('Test suites:')} ${results.numTotalTestSuites}\n`,
+  );
+  outputStream.write(`${chalk.bold('Tests:')}       ${testsLine.join(', ')}\n`);
+};
+
 const getTestPaths = async (
   globalConfig: Config.GlobalConfig,
   projectConfig: Config.ProjectConfig,
@@ -298,6 +319,7 @@ export default async function runJest({
           printCollectedTestTree(testResult.testResults, outputStream);
         }
       }
+      printCollectedTestSummary(results, outputStream);
     }
 
     await processResults(results, {

--- a/packages/jest-jasmine2/src/__tests__/collectSpecs.test.ts
+++ b/packages/jest-jasmine2/src/__tests__/collectSpecs.test.ts
@@ -13,34 +13,72 @@ import {
   collectSpecs,
 } from '..';
 
-const makeSpec = (description: string, fullName?: string): SpecLike => ({
+const makeSpec = (
+  description: string,
+  {
+    fullName,
+    markedPending,
+    markedTodo,
+  }: {fullName?: string; markedPending?: boolean; markedTodo?: boolean} = {},
+): SpecLike => ({
   description,
   getFullName: () => fullName ?? description,
+  markedPending,
+  markedTodo,
 });
 
 const makeSuite = (
   description: string,
   children: Array<SuiteLike | SpecLike>,
-): SuiteLike => ({children, description});
+  markedPending = false,
+): SuiteLike => ({children, description, markedPending});
+
+const collect = (suite: SuiteLike, testNamePatternRE: RegExp | null = null) =>
+  collectSpecs(suite, {ancestors: [], parentPending: false, testNamePatternRE});
 
 describe('collectSpecs', () => {
-  test('collects flat specs with pending status', () => {
+  test('collects flat runnable specs as passed', () => {
     const root = makeSuite('', [makeSpec('test one'), makeSpec('test two')]);
-    const results = collectSpecs(root, [], null);
+    const results = collect(root);
 
     expect(results).toHaveLength(2);
     expect(results[0].title).toBe('test one');
-    expect(results[0].status).toBe('pending');
+    expect(results[0].status).toBe('passed');
     expect(results[1].title).toBe('test two');
+  });
+
+  test('resolves status per spec mode', () => {
+    const root = makeSuite('', [
+      makeSpec('runnable'),
+      makeSpec('skipped', {markedPending: true}),
+      makeSpec('todo', {markedTodo: true}),
+    ]);
+    const results = collect(root);
+
+    expect(results.map(r => ({status: r.status, title: r.title}))).toEqual([
+      {status: 'passed', title: 'runnable'},
+      {status: 'pending', title: 'skipped'},
+      {status: 'todo', title: 'todo'},
+    ]);
+  });
+
+  test('marks specs under a pending suite as pending', () => {
+    const root = makeSuite('', [
+      makeSuite('skipped suite', [makeSpec('child')], true),
+    ]);
+    const results = collect(root);
+
+    expect(results).toHaveLength(1);
+    expect(results[0].status).toBe('pending');
   });
 
   test('collects nested specs with ancestor titles', () => {
     const root = makeSuite('', [
       makeSuite('outer', [
-        makeSuite('inner', [makeSpec('deep', 'outer inner deep')]),
+        makeSuite('inner', [makeSpec('deep', {fullName: 'outer inner deep'})]),
       ]),
     ]);
-    const results = collectSpecs(root, [], null);
+    const results = collect(root);
 
     expect(results).toHaveLength(1);
     expect(results[0].ancestorTitles).toEqual(['outer', 'inner']);
@@ -50,10 +88,10 @@ describe('collectSpecs', () => {
 
   test('filters by testNamePattern', () => {
     const root = makeSuite('', [
-      makeSpec('matching test', 'matching test'),
-      makeSpec('other test', 'other test'),
+      makeSpec('matching test', {fullName: 'matching test'}),
+      makeSpec('other test', {fullName: 'other test'}),
     ]);
-    const results = collectSpecs(root, [], /matching/i);
+    const results = collect(root, /matching/i);
 
     expect(results).toHaveLength(1);
     expect(results[0].title).toBe('matching test');
@@ -61,24 +99,29 @@ describe('collectSpecs', () => {
 
   test('returns empty array for empty suite', () => {
     const root = makeSuite('', []);
-    const results = collectSpecs(root, [], null);
+    const results = collect(root);
     expect(results).toHaveLength(0);
   });
 
   test('preserves order across sibling suites', () => {
     const root = makeSuite('', [
-      makeSuite('A', [makeSpec('first', 'A first')]),
-      makeSuite('B', [makeSpec('second', 'B second')]),
+      makeSuite('A', [makeSpec('first', {fullName: 'A first'})]),
+      makeSuite('B', [makeSpec('second', {fullName: 'B second'})]),
     ]);
-    const results = collectSpecs(root, [], null);
+    const results = collect(root);
 
     expect(results.map(r => r.title)).toEqual(['first', 'second']);
   });
 });
 
 describe('buildCollectedTestResult', () => {
-  test('returns TestResult with pending tests', () => {
-    const suite = makeSuite('', [makeSpec('test a'), makeSpec('test b')]);
+  test('tallies counts by status', () => {
+    const suite = makeSuite('', [
+      makeSpec('test a'),
+      makeSpec('test b'),
+      makeSpec('skipped', {markedPending: true}),
+      makeSpec('todo', {markedTodo: true}),
+    ]);
     const result = buildCollectedTestResult({
       config: makeProjectConfig(),
       suite,
@@ -86,17 +129,18 @@ describe('buildCollectedTestResult', () => {
       testPath: '/path/to/test.js',
     });
 
-    expect(result.testResults).toHaveLength(2);
-    expect(result.numPendingTests).toBe(2);
-    expect(result.numPassingTests).toBe(0);
+    expect(result.testResults).toHaveLength(4);
+    expect(result.numPassingTests).toBe(2);
+    expect(result.numPendingTests).toBe(1);
+    expect(result.numTodoTests).toBe(1);
     expect(result.numFailingTests).toBe(0);
     expect(result.testFilePath).toBe('/path/to/test.js');
   });
 
   test('filters by testNamePattern string', () => {
     const suite = makeSuite('', [
-      makeSpec('match me', 'match me'),
-      makeSpec('skip me', 'skip me'),
+      makeSpec('match me', {fullName: 'match me'}),
+      makeSpec('skip me', {fullName: 'skip me'}),
     ]);
     const result = buildCollectedTestResult({
       config: makeProjectConfig(),
@@ -107,7 +151,7 @@ describe('buildCollectedTestResult', () => {
 
     expect(result.testResults).toHaveLength(1);
     expect(result.testResults[0].title).toBe('match me');
-    expect(result.numPendingTests).toBe(1);
+    expect(result.numPassingTests).toBe(1);
   });
 
   test('returns empty results for empty suite', () => {

--- a/packages/jest-jasmine2/src/__tests__/collectSpecs.test.ts
+++ b/packages/jest-jasmine2/src/__tests__/collectSpecs.test.ts
@@ -16,13 +16,23 @@ import {
 const makeSpec = (
   description: string,
   {
+    disabled,
     fullName,
+    id,
     markedPending,
     markedTodo,
-  }: {fullName?: string; markedPending?: boolean; markedTodo?: boolean} = {},
+  }: {
+    disabled?: boolean;
+    fullName?: string;
+    id?: string;
+    markedPending?: boolean;
+    markedTodo?: boolean;
+  } = {},
 ): SpecLike => ({
   description,
+  disabled,
   getFullName: () => fullName ?? description,
+  id,
   markedPending,
   markedTodo,
 });
@@ -30,11 +40,26 @@ const makeSpec = (
 const makeSuite = (
   description: string,
   children: Array<SuiteLike | SpecLike>,
-  markedPending = false,
-): SuiteLike => ({children, description, markedPending});
+  {id, markedPending = false}: {id?: string; markedPending?: boolean} = {},
+): SuiteLike => ({children, description, id, markedPending});
 
-const collect = (suite: SuiteLike, testNamePatternRE: RegExp | null = null) =>
-  collectSpecs(suite, {ancestors: [], parentPending: false, testNamePatternRE});
+const collect = (
+  suite: SuiteLike,
+  {
+    focusedRunnableIds = [],
+    testNamePatternRE = null,
+  }: {
+    focusedRunnableIds?: Array<string>;
+    testNamePatternRE?: RegExp | null;
+  } = {},
+) =>
+  collectSpecs(suite, {
+    ancestors: [],
+    focusedRunnableIds,
+    parentEnabled: focusedRunnableIds.length === 0,
+    parentPending: false,
+    testNamePatternRE,
+  });
 
 describe('collectSpecs', () => {
   test('resolves status per spec mode', () => {
@@ -55,7 +80,7 @@ describe('collectSpecs', () => {
 
   test('marks specs under a pending suite as pending', () => {
     const root = makeSuite('', [
-      makeSuite('skipped suite', [makeSpec('child')], true),
+      makeSuite('skipped suite', [makeSpec('child')], {markedPending: true}),
     ]);
     expect(collect(root)[0].status).toBe('pending');
   });
@@ -65,7 +90,7 @@ describe('collectSpecs', () => {
       makeSpec('matching test', {fullName: 'matching test'}),
       makeSpec('other test', {fullName: 'other test'}),
     ]);
-    const results = collect(root, /matching/i);
+    const results = collect(root, {testNamePatternRE: /matching/i});
 
     expect(results.map(r => ({status: r.status, title: r.title}))).toEqual([
       {status: 'passed', title: 'matching test'},
@@ -84,6 +109,51 @@ describe('collectSpecs', () => {
     expect(result.ancestorTitles).toEqual(['outer', 'inner']);
     expect(result.fullName).toBe('outer inner deep');
     expect(result.title).toBe('deep');
+  });
+
+  test('preserves source order across sibling suites', () => {
+    const root = makeSuite('', [
+      makeSuite('A', [makeSpec('first', {fullName: 'A first'})]),
+      makeSuite('B', [makeSpec('second', {fullName: 'B second'})]),
+    ]);
+
+    expect(collect(root).map(r => r.title)).toEqual(['first', 'second']);
+  });
+
+  test('reports specs not selected by focus as pending', () => {
+    // `fit('focused')` and a plain `it('unfocused')`: only the focused spec and
+    // a focused suite's descendants would run; everything else is pending. A
+    // todo deselected by focus is also pending, mirroring `Spec.status`.
+    const root = makeSuite('', [
+      makeSpec('focused spec', {id: 'spec-1'}),
+      makeSpec('unfocused spec', {id: 'spec-2'}),
+      makeSpec('unfocused todo', {id: 'spec-3', markedTodo: true}),
+      makeSuite('focused suite', [makeSpec('inside focus', {id: 'spec-4'})], {
+        id: 'suite-1',
+      }),
+    ]);
+    const results = collect(root, {focusedRunnableIds: ['spec-1', 'suite-1']});
+
+    expect(results.map(r => ({status: r.status, title: r.title}))).toEqual([
+      {status: 'passed', title: 'focused spec'},
+      {status: 'pending', title: 'unfocused spec'},
+      {status: 'pending', title: 'unfocused todo'},
+      {status: 'passed', title: 'inside focus'},
+    ]);
+  });
+
+  test('reports explicitly disabled specs as pending', () => {
+    const root = makeSuite('', [
+      makeSpec('runnable'),
+      makeSpec('disabled', {disabled: true}),
+    ]);
+
+    expect(
+      collect(root).map(r => ({status: r.status, title: r.title})),
+    ).toEqual([
+      {status: 'passed', title: 'runnable'},
+      {status: 'pending', title: 'disabled'},
+    ]);
   });
 });
 

--- a/packages/jest-jasmine2/src/__tests__/collectSpecs.test.ts
+++ b/packages/jest-jasmine2/src/__tests__/collectSpecs.test.ts
@@ -86,15 +86,17 @@ describe('collectSpecs', () => {
     expect(results[0].title).toBe('deep');
   });
 
-  test('filters by testNamePattern', () => {
+  test('reports testNamePattern-deselected specs as pending', () => {
     const root = makeSuite('', [
       makeSpec('matching test', {fullName: 'matching test'}),
       makeSpec('other test', {fullName: 'other test'}),
     ]);
     const results = collect(root, /matching/i);
 
-    expect(results).toHaveLength(1);
-    expect(results[0].title).toBe('matching test');
+    expect(results.map(r => ({status: r.status, title: r.title}))).toEqual([
+      {status: 'passed', title: 'matching test'},
+      {status: 'pending', title: 'other test'},
+    ]);
   });
 
   test('returns empty array for empty suite', () => {
@@ -137,7 +139,7 @@ describe('buildCollectedTestResult', () => {
     expect(result.testFilePath).toBe('/path/to/test.js');
   });
 
-  test('filters by testNamePattern string', () => {
+  test('counts testNamePattern-deselected specs as pending', () => {
     const suite = makeSuite('', [
       makeSpec('match me', {fullName: 'match me'}),
       makeSpec('skip me', {fullName: 'skip me'}),
@@ -149,9 +151,9 @@ describe('buildCollectedTestResult', () => {
       testPath: '/test.js',
     });
 
-    expect(result.testResults).toHaveLength(1);
-    expect(result.testResults[0].title).toBe('match me');
+    expect(result.testResults).toHaveLength(2);
     expect(result.numPassingTests).toBe(1);
+    expect(result.numPendingTests).toBe(1);
   });
 
   test('returns empty results for empty suite', () => {

--- a/packages/jest-jasmine2/src/__tests__/collectSpecs.test.ts
+++ b/packages/jest-jasmine2/src/__tests__/collectSpecs.test.ts
@@ -37,16 +37,6 @@ const collect = (suite: SuiteLike, testNamePatternRE: RegExp | null = null) =>
   collectSpecs(suite, {ancestors: [], parentPending: false, testNamePatternRE});
 
 describe('collectSpecs', () => {
-  test('collects flat runnable specs as passed', () => {
-    const root = makeSuite('', [makeSpec('test one'), makeSpec('test two')]);
-    const results = collect(root);
-
-    expect(results).toHaveLength(2);
-    expect(results[0].title).toBe('test one');
-    expect(results[0].status).toBe('passed');
-    expect(results[1].title).toBe('test two');
-  });
-
   test('resolves status per spec mode', () => {
     const root = makeSuite('', [
       makeSpec('runnable'),
@@ -60,30 +50,14 @@ describe('collectSpecs', () => {
       {status: 'pending', title: 'skipped'},
       {status: 'todo', title: 'todo'},
     ]);
+    expect(results[0].wouldRun).toBe(true);
   });
 
   test('marks specs under a pending suite as pending', () => {
     const root = makeSuite('', [
       makeSuite('skipped suite', [makeSpec('child')], true),
     ]);
-    const results = collect(root);
-
-    expect(results).toHaveLength(1);
-    expect(results[0].status).toBe('pending');
-  });
-
-  test('collects nested specs with ancestor titles', () => {
-    const root = makeSuite('', [
-      makeSuite('outer', [
-        makeSuite('inner', [makeSpec('deep', {fullName: 'outer inner deep'})]),
-      ]),
-    ]);
-    const results = collect(root);
-
-    expect(results).toHaveLength(1);
-    expect(results[0].ancestorTitles).toEqual(['outer', 'inner']);
-    expect(results[0].fullName).toBe('outer inner deep');
-    expect(results[0].title).toBe('deep');
+    expect(collect(root)[0].status).toBe('pending');
   });
 
   test('reports testNamePattern-deselected specs as pending', () => {
@@ -99,20 +73,17 @@ describe('collectSpecs', () => {
     ]);
   });
 
-  test('returns empty array for empty suite', () => {
-    const root = makeSuite('', []);
-    const results = collect(root);
-    expect(results).toHaveLength(0);
-  });
-
-  test('preserves order across sibling suites', () => {
+  test('collects nested specs with ancestor titles in order', () => {
     const root = makeSuite('', [
-      makeSuite('A', [makeSpec('first', {fullName: 'A first'})]),
-      makeSuite('B', [makeSpec('second', {fullName: 'B second'})]),
+      makeSuite('outer', [
+        makeSuite('inner', [makeSpec('deep', {fullName: 'outer inner deep'})]),
+      ]),
     ]);
-    const results = collect(root);
+    const [result] = collect(root);
 
-    expect(results.map(r => r.title)).toEqual(['first', 'second']);
+    expect(result.ancestorTitles).toEqual(['outer', 'inner']);
+    expect(result.fullName).toBe('outer inner deep');
+    expect(result.title).toBe('deep');
   });
 });
 
@@ -139,28 +110,10 @@ describe('buildCollectedTestResult', () => {
     expect(result.testFilePath).toBe('/path/to/test.js');
   });
 
-  test('counts testNamePattern-deselected specs as pending', () => {
-    const suite = makeSuite('', [
-      makeSpec('match me', {fullName: 'match me'}),
-      makeSpec('skip me', {fullName: 'skip me'}),
-    ]);
-    const result = buildCollectedTestResult({
-      config: makeProjectConfig(),
-      suite,
-      testNamePattern: 'match',
-      testPath: '/test.js',
-    });
-
-    expect(result.testResults).toHaveLength(2);
-    expect(result.numPassingTests).toBe(1);
-    expect(result.numPendingTests).toBe(1);
-  });
-
   test('returns empty results for empty suite', () => {
-    const suite = makeSuite('', []);
     const result = buildCollectedTestResult({
       config: makeProjectConfig(),
-      suite,
+      suite: makeSuite('', []),
       testNamePattern: undefined,
       testPath: '/test.js',
     });

--- a/packages/jest-jasmine2/src/__tests__/collectSpecs.test.ts
+++ b/packages/jest-jasmine2/src/__tests__/collectSpecs.test.ts
@@ -16,13 +16,11 @@ import {
 const makeSpec = (
   description: string,
   {
-    disabled,
     fullName,
     id,
     markedPending,
     markedTodo,
   }: {
-    disabled?: boolean;
     fullName?: string;
     id?: string;
     markedPending?: boolean;
@@ -30,7 +28,6 @@ const makeSpec = (
   } = {},
 ): SpecLike => ({
   description,
-  disabled,
   getFullName: () => fullName ?? description,
   id,
   markedPending,
@@ -139,20 +136,6 @@ describe('collectSpecs', () => {
       {status: 'pending', title: 'unfocused spec'},
       {status: 'pending', title: 'unfocused todo'},
       {status: 'passed', title: 'inside focus'},
-    ]);
-  });
-
-  test('reports explicitly disabled specs as pending', () => {
-    const root = makeSuite('', [
-      makeSpec('runnable'),
-      makeSpec('disabled', {disabled: true}),
-    ]);
-
-    expect(
-      collect(root).map(r => ({status: r.status, title: r.title})),
-    ).toEqual([
-      {status: 'passed', title: 'runnable'},
-      {status: 'pending', title: 'disabled'},
     ]);
   });
 });

--- a/packages/jest-jasmine2/src/index.ts
+++ b/packages/jest-jasmine2/src/index.ts
@@ -65,23 +65,23 @@ export const collectSpecs = (
       );
     } else {
       const fullName = child.getFullName();
-      if (
-        context.testNamePatternRE &&
-        !context.testNamePatternRE.test(fullName)
-      ) {
-        continue;
-      }
+      const deselected =
+        context.testNamePatternRE !== null &&
+        !context.testNamePatternRE.test(fullName);
 
-      // Mirror `Spec.status` without executing: skipped (`markedPending`) maps to
-      // `pending`, `markedTodo` to `todo`, otherwise the spec would run and is
-      // reported as it would resolve when passing.
+      // Mirror `Spec.status` without executing: skipped (`markedPending`) and
+      // pattern-deselected specs map to `pending` (an actual run still counts
+      // them), `markedTodo` to `todo`, otherwise the spec would run and is
+      // reported in the passed bucket and flagged as `wouldRun`.
       let status: Status;
-      if (context.parentPending || child.markedPending) {
+      let wouldRun: true | undefined;
+      if (context.parentPending || child.markedPending || deselected) {
         status = 'pending';
       } else if (child.markedTodo) {
         status = 'todo';
       } else {
         status = 'passed';
+        wouldRun = true;
       }
 
       results.push({
@@ -98,6 +98,7 @@ export const collectSpecs = (
         startAt: null,
         status,
         title: child.description,
+        wouldRun,
       });
     }
   }

--- a/packages/jest-jasmine2/src/index.ts
+++ b/packages/jest-jasmine2/src/index.ts
@@ -39,7 +39,6 @@ export type SuiteLike = {
 
 export type SpecLike = {
   description: string;
-  disabled?: boolean;
   getFullName: () => string;
   id?: string;
   markedPending?: boolean;
@@ -80,14 +79,14 @@ export const collectSpecs = (
         !context.testNamePatternRE.test(fullName);
 
       // Mirror `Spec.status` without executing, in the same precedence order: a
-      // spec not selected by focus (`fit`/`fdescribe`), explicitly disabled, or
-      // deselected by `--testNamePattern` reports as `pending` (an actual run
-      // still counts these); `markedTodo` reports as `todo`; a skipped
-      // (`markedPending`) spec reports as `pending`; otherwise the spec would
-      // run and is reported in the passed bucket and flagged as `wouldRun`.
+      // spec not selected by focus (`fit`/`fdescribe`) or deselected by
+      // `--testNamePattern` reports as `pending` (an actual run still counts
+      // these); `markedTodo` reports as `todo`; a skipped (`markedPending`) spec
+      // reports as `pending`; otherwise the spec would run and is reported in
+      // the passed bucket and flagged as `wouldRun`.
       let status: Status;
       let wouldRun: true | undefined;
-      if (!isEnabled(child) || child.disabled || deselected) {
+      if (!isEnabled(child) || deselected) {
         status = 'pending';
       } else if (child.markedTodo) {
         status = 'todo';

--- a/packages/jest-jasmine2/src/index.ts
+++ b/packages/jest-jasmine2/src/index.ts
@@ -10,8 +10,9 @@ import type {JestEnvironment} from '@jest/environment';
 import {getCallsite} from '@jest/source-map';
 import {
   type AssertionResult,
+  type Status,
   type TestResult,
-  createEmptyTestResult,
+  makeCollectedTestResult,
 } from '@jest/test-result';
 import type {Config, Global} from '@jest/types';
 import type Runtime from 'jest-runtime';
@@ -32,47 +33,72 @@ const jestEachBuildDir = path.dirname(require.resolve('jest-each'));
 export type SuiteLike = {
   children: Array<SuiteLike | SpecLike>;
   description: string;
+  markedPending?: boolean;
 };
 
 export type SpecLike = {
   description: string;
   getFullName: () => string;
+  markedPending?: boolean;
+  markedTodo?: boolean;
+};
+
+type CollectContext = {
+  ancestors: Array<string>;
+  parentPending: boolean;
+  testNamePatternRE: RegExp | null;
 };
 
 export const collectSpecs = (
   suite: SuiteLike,
-  ancestors: Array<string>,
-  testNamePatternRE: RegExp | null,
+  context: CollectContext,
 ): Array<AssertionResult> => {
   const results: Array<AssertionResult> = [];
   for (const child of suite.children) {
     if ('children' in child) {
       results.push(
-        ...collectSpecs(
-          child,
-          [...ancestors, child.description],
-          testNamePatternRE,
-        ),
+        ...collectSpecs(child, {
+          ...context,
+          ancestors: [...context.ancestors, child.description],
+          parentPending: context.parentPending || child.markedPending === true,
+        }),
       );
     } else {
       const fullName = child.getFullName();
-      if (!testNamePatternRE || testNamePatternRE.test(fullName)) {
-        results.push({
-          ancestorTitles: [...ancestors],
-          duration: null,
-          failing: false,
-          failureDetails: [],
-          failureMessages: [],
-          fullName,
-          invocations: 0,
-          location: null,
-          numPassingAsserts: 0,
-          retryReasons: [],
-          startAt: null,
-          status: 'pending',
-          title: child.description,
-        });
+      if (
+        context.testNamePatternRE &&
+        !context.testNamePatternRE.test(fullName)
+      ) {
+        continue;
       }
+
+      // Mirror `Spec.status` without executing: skipped (`markedPending`) maps to
+      // `pending`, `markedTodo` to `todo`, otherwise the spec would run and is
+      // reported as it would resolve when passing.
+      let status: Status;
+      if (context.parentPending || child.markedPending) {
+        status = 'pending';
+      } else if (child.markedTodo) {
+        status = 'todo';
+      } else {
+        status = 'passed';
+      }
+
+      results.push({
+        ancestorTitles: [...context.ancestors],
+        duration: null,
+        failing: false,
+        failureDetails: [],
+        failureMessages: [],
+        fullName,
+        invocations: 0,
+        location: null,
+        numPassingAsserts: 0,
+        retryReasons: [],
+        startAt: null,
+        status,
+        title: child.description,
+      });
     }
   }
   return results;
@@ -92,14 +118,15 @@ export const buildCollectedTestResult = ({
   const testNamePatternRE = testNamePattern
     ? new RegExp(testNamePattern, 'i')
     : null;
-  const assertionResults = collectSpecs(suite, [], testNamePatternRE);
-  return {
-    ...createEmptyTestResult(),
+  const assertionResults = collectSpecs(suite, {
+    ancestors: [],
+    parentPending: suite.markedPending === true,
+    testNamePatternRE,
+  });
+  return makeCollectedTestResult(assertionResults, {
     displayName: config.displayName,
-    numPendingTests: assertionResults.length,
     testFilePath: testPath,
-    testResults: assertionResults,
-  };
+  });
 };
 
 export default async function jasmine2(

--- a/packages/jest-jasmine2/src/index.ts
+++ b/packages/jest-jasmine2/src/index.ts
@@ -33,18 +33,23 @@ const jestEachBuildDir = path.dirname(require.resolve('jest-each'));
 export type SuiteLike = {
   children: Array<SuiteLike | SpecLike>;
   description: string;
+  id?: string;
   markedPending?: boolean;
 };
 
 export type SpecLike = {
   description: string;
+  disabled?: boolean;
   getFullName: () => string;
+  id?: string;
   markedPending?: boolean;
   markedTodo?: boolean;
 };
 
 type CollectContext = {
   ancestors: Array<string>;
+  focusedRunnableIds: Array<string>;
+  parentEnabled: boolean;
   parentPending: boolean;
   testNamePatternRE: RegExp | null;
 };
@@ -54,12 +59,17 @@ export const collectSpecs = (
   context: CollectContext,
 ): Array<AssertionResult> => {
   const results: Array<AssertionResult> = [];
+  const isEnabled = (node: SuiteLike | SpecLike): boolean =>
+    context.parentEnabled ||
+    (node.id != null && context.focusedRunnableIds.includes(node.id));
+
   for (const child of suite.children) {
     if ('children' in child) {
       results.push(
         ...collectSpecs(child, {
           ...context,
           ancestors: [...context.ancestors, child.description],
+          parentEnabled: isEnabled(child),
           parentPending: context.parentPending || child.markedPending === true,
         }),
       );
@@ -69,16 +79,20 @@ export const collectSpecs = (
         context.testNamePatternRE !== null &&
         !context.testNamePatternRE.test(fullName);
 
-      // Mirror `Spec.status` without executing: skipped (`markedPending`) and
-      // pattern-deselected specs map to `pending` (an actual run still counts
-      // them), `markedTodo` to `todo`, otherwise the spec would run and is
-      // reported in the passed bucket and flagged as `wouldRun`.
+      // Mirror `Spec.status` without executing, in the same precedence order: a
+      // spec not selected by focus (`fit`/`fdescribe`), explicitly disabled, or
+      // deselected by `--testNamePattern` reports as `pending` (an actual run
+      // still counts these); `markedTodo` reports as `todo`; a skipped
+      // (`markedPending`) spec reports as `pending`; otherwise the spec would
+      // run and is reported in the passed bucket and flagged as `wouldRun`.
       let status: Status;
       let wouldRun: true | undefined;
-      if (context.parentPending || child.markedPending || deselected) {
+      if (!isEnabled(child) || child.disabled || deselected) {
         status = 'pending';
       } else if (child.markedTodo) {
         status = 'todo';
+      } else if (context.parentPending || child.markedPending) {
+        status = 'pending';
       } else {
         status = 'passed';
         wouldRun = true;
@@ -107,11 +121,13 @@ export const collectSpecs = (
 
 export const buildCollectedTestResult = ({
   config,
+  focusedRunnableIds = [],
   suite,
   testNamePattern,
   testPath,
 }: {
   config: Config.ProjectConfig;
+  focusedRunnableIds?: Array<string>;
   suite: SuiteLike;
   testNamePattern: string | undefined;
   testPath: string;
@@ -121,6 +137,10 @@ export const buildCollectedTestResult = ({
     : null;
   const assertionResults = collectSpecs(suite, {
     ancestors: [],
+    focusedRunnableIds,
+    // With no focus the whole tree runs; with focus only the focused subtrees
+    // do, so the root suite is enabled only when nothing is focused.
+    parentEnabled: focusedRunnableIds.length === 0,
     parentPending: suite.markedPending === true,
     testNamePatternRE,
   });
@@ -307,6 +327,7 @@ export default async function jasmine2(
   if (globalConfig.collectTests) {
     return buildCollectedTestResult({
       config,
+      focusedRunnableIds: env.focusedRunnableIds(),
       suite: env.topSuite() as unknown as SuiteLike,
       testNamePattern: globalConfig.testNamePattern,
       testPath,

--- a/packages/jest-jasmine2/src/jasmine/Env.ts
+++ b/packages/jest-jasmine2/src/jasmine/Env.ts
@@ -57,6 +57,7 @@ export default function jasmineEnv(j$: Jasmine) {
     throwOnExpectationFailure: (value: unknown) => void;
     catchingExceptions: () => boolean;
     topSuite: () => Suite;
+    focusedRunnableIds: () => Array<string>;
     fail: (error: Error | AssertionErrorWithStack) => void;
     pending: (message: string) => void;
     afterAll: (afterAllFunction: QueueableFn['fn'], timeout?: number) => void;
@@ -428,6 +429,13 @@ export default function jasmineEnv(j$: Jasmine) {
       };
 
       const focusedRunnables: Array<string> = [];
+
+      // Ids of the runnables (`fit`/`fdescribe`) that focus execution. When
+      // non-empty, an actual run only executes these subtrees and reports the
+      // rest as pending. `--collectTests` reads this to mirror that selection.
+      this.focusedRunnableIds = function () {
+        return [...focusedRunnables];
+      };
 
       this.fdescribe = function (description, specDefinitions) {
         const suite = suiteFactory(description);

--- a/packages/jest-test-result/src/helpers.ts
+++ b/packages/jest-test-result/src/helpers.ts
@@ -201,37 +201,20 @@ export const makeCollectedTestResult = (
     testFilePath,
   }: {displayName: TestResult['displayName']; testFilePath: string},
 ): TestResult => {
-  let numFailingTests = 0;
-  let numPassingTests = 0;
-  let numPendingTests = 0;
-  let numTodoTests = 0;
-
-  for (const {status} of testResults) {
-    switch (status) {
-      case 'failed': {
-        numFailingTests += 1;
-        break;
-      }
-      case 'passed': {
-        numPassingTests += 1;
-        break;
-      }
-      case 'todo': {
-        numTodoTests += 1;
-        break;
-      }
-      default: {
-        numPendingTests += 1;
-      }
-    }
-  }
+  const count = (status: AssertionResult['status']) =>
+    testResults.filter(result => result.status === status).length;
+  const numFailingTests = count('failed');
+  const numPassingTests = count('passed');
+  const numTodoTests = count('todo');
 
   return {
     ...createEmptyTestResult(),
     displayName,
     numFailingTests,
     numPassingTests,
-    numPendingTests,
+    // Everything else (`pending`, `skipped`, …) counts as pending.
+    numPendingTests:
+      testResults.length - numFailingTests - numPassingTests - numTodoTests,
     numTodoTests,
     testFilePath,
     testResults,

--- a/packages/jest-test-result/src/helpers.ts
+++ b/packages/jest-test-result/src/helpers.ts
@@ -5,7 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import type {AggregatedResult, SerializableError, TestResult} from './types';
+import type {
+  AggregatedResult,
+  AssertionResult,
+  SerializableError,
+  TestResult,
+} from './types';
 
 export const makeEmptyAggregatedTestResult = (): AggregatedResult => ({
   numFailedTestSuites: 0,
@@ -184,3 +189,51 @@ export const createEmptyTestResult = (): TestResult => ({
   testFilePath: '',
   testResults: [],
 });
+
+// Build a single-file `TestResult` from already-resolved assertion results,
+// tallying the per-status counts. Used by the test runners' `--collect-tests`
+// paths, where test bodies are not executed but per-status counts must still
+// match what an actual run would report.
+export const makeCollectedTestResult = (
+  testResults: Array<AssertionResult>,
+  {
+    displayName,
+    testFilePath,
+  }: {displayName: TestResult['displayName']; testFilePath: string},
+): TestResult => {
+  let numFailingTests = 0;
+  let numPassingTests = 0;
+  let numPendingTests = 0;
+  let numTodoTests = 0;
+
+  for (const {status} of testResults) {
+    switch (status) {
+      case 'failed': {
+        numFailingTests += 1;
+        break;
+      }
+      case 'passed': {
+        numPassingTests += 1;
+        break;
+      }
+      case 'todo': {
+        numTodoTests += 1;
+        break;
+      }
+      default: {
+        numPendingTests += 1;
+      }
+    }
+  }
+
+  return {
+    ...createEmptyTestResult(),
+    displayName,
+    numFailingTests,
+    numPassingTests,
+    numPendingTests,
+    numTodoTests,
+    testFilePath,
+    testResults,
+  };
+};

--- a/packages/jest-test-result/src/helpers.ts
+++ b/packages/jest-test-result/src/helpers.ts
@@ -212,7 +212,8 @@ export const makeCollectedTestResult = (
     displayName,
     numFailingTests,
     numPassingTests,
-    // Everything else (`pending`, `skipped`, …) counts as pending.
+    // Anything that is neither passing, failing, nor todo (i.e. pending) counts
+    // as pending.
     numPendingTests:
       testResults.length - numFailingTests - numPassingTests - numTodoTests,
     numTodoTests,

--- a/packages/jest-test-result/src/index.ts
+++ b/packages/jest-test-result/src/index.ts
@@ -10,6 +10,7 @@ export {
   addResult,
   buildFailureTestResult,
   createEmptyTestResult,
+  makeCollectedTestResult,
   makeEmptyAggregatedTestResult,
 } from './helpers';
 export type {

--- a/packages/jest-types/src/TestResult.ts
+++ b/packages/jest-types/src/TestResult.ts
@@ -43,6 +43,12 @@ export type AssertionResult = {
   retryReasons?: Array<string>;
   status: Status;
   title: string;
+  /**
+   * Set by `jest --collectTests` on a test that was discovered as selected to
+   * run but never executed. Distinguishes a test reported in the `passed`
+   * bucket because it would run from one that actually passed.
+   */
+  wouldRun?: boolean;
 };
 
 export type SerializableError = {


### PR DESCRIPTION

#16006 added `--collectTests` to report test counts without actually running (potentially heavy) tests. I enhanced the logic to report correctly in more situations:

- `test.each`/`describe.each` expand to one entry per case
- skip / `describe.skip` / focus-deselected / `--testNamePattern`-deselected → `pending`; `test.todo` → `todo`; runnable → `passed` + new `wouldRun` flag

The tree also now annotates entries with`[skipped]`/`[todo]` and finishes with a summary line.

A suite with `it.each([...10 cases...])`, some `test.skip` and `test.todo`:

**Before** — `.each` counted as 1, everything lumped as pending, no summary:
```
my.test.js
  cases
    runs all the rows
  skipped later
  todo me
```

**After** — cases expanded, statuses resolved, summary line:
```
my.test.js
  cases
    runs all the rows: case 1
    ...
    runs all the rows: case 10
  skipped later [skipped]
  todo me [todo]

Test suites: 1
Tests:       12 total, 10 runnable, 1 skipped, 1 todo
```
