### PR TITLE
feat(jest-resolve): honor `--preserve-symlinks` / `NODE_PRESERVE_SYMLINKS` in the default resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `[@jest/expect-utils, jest-mock]` Add `mockFn.whenCalledWith(...args)` for configuring return values per argument list, with first-class asymmetric-matcher support ([#16053](https://github.com/jestjs/jest/pull/16053))
 - `[@jest/expect-utils]` Export `AsymmetricMatcher` and `FunctionParameters` types (previously private to `expect`) ([#16053](https://github.com/jestjs/jest/pull/16053))
 - `[jest-resolve]` Bump `unrs-resolver` to 1.12.1, remove `jest-pnp-resolver` and unnecessary checks ([#15721](https://github.com/jestjs/jest/pull/15721))
+- `[jest-resolve]` Honor Node's `--preserve-symlinks` / `NODE_PRESERVE_SYMLINKS` in the default resolver by passing `symlinks: false` to `unrs-resolver` ([#16260](https://github.com/jestjs/jest/pull/16260))
 
 ### Fixes
 

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -8,6 +8,7 @@
 
 import * as fs from 'graceful-fs';
 import {type IModuleMap, ModuleMap} from 'jest-haste-map';
+import {tmpdir} from 'os';
 import * as path from 'path';
 import {pathToFileURL} from 'url';
 
@@ -391,7 +392,10 @@ describe('findNodeModule', () => {
           conditions: [],
         });
       }).toThrow(
-        `Package import specifier "#something-else" is not defined in package ${path.join(importsRoot, 'foo-import/package.json')}`,
+        `Package import specifier "#something-else" is not defined in package ${path.join(
+          importsRoot,
+          'foo-import/package.json',
+        )}`,
       );
     });
   });
@@ -907,5 +911,99 @@ describe('canResolveSync', () => {
       resolver: require.resolve('../__mocks__/userResolverAsync'),
     } as ResolverConfig);
     expect(resolver.canResolveSync()).toBe(false);
+  });
+});
+
+describe('preserveSymlinks', () => {
+  const ORIGINAL_NODE_PRESERVE_SYMLINKS = process.env.NODE_PRESERVE_SYMLINKS;
+  const ORIGINAL_NODE_OPTIONS = process.env.NODE_OPTIONS;
+  const ORIGINAL_EXEC_ARGV = process.execArgv;
+
+  let appDir: string;
+  let realModuleEntry: string;
+  let symlinkedModuleEntry: string;
+  let tempDir: string;
+
+  beforeAll(() => {
+    // `app/node_modules/dep` is a symlink to the real `packages/dep` module.
+    // `realpathSync` avoids macOS `/var` -> `/private/var` discrepancies.
+    tempDir = fs.realpathSync(
+      fs.mkdtempSync(path.join(tmpdir(), 'jest-resolve-preserve-symlinks-')),
+    );
+    const realModuleDir = path.join(tempDir, 'packages', 'dep');
+    appDir = path.join(tempDir, 'app');
+
+    fs.mkdirSync(realModuleDir, {recursive: true});
+    fs.mkdirSync(path.join(appDir, 'node_modules'), {recursive: true});
+    fs.writeFileSync(
+      path.join(realModuleDir, 'package.json'),
+      JSON.stringify({main: 'index.js', name: 'dep', version: '1.0.0'}),
+    );
+    fs.writeFileSync(
+      path.join(realModuleDir, 'index.js'),
+      'module.exports = 1;\n',
+    );
+
+    const symlinkedModuleDir = path.join(appDir, 'node_modules', 'dep');
+    // `junction` works on Windows without elevated privileges.
+    fs.symlinkSync(realModuleDir, symlinkedModuleDir, 'junction');
+
+    realModuleEntry = path.join(realModuleDir, 'index.js');
+    symlinkedModuleEntry = path.join(symlinkedModuleDir, 'index.js');
+  });
+
+  afterAll(() => {
+    fs.rmSync(tempDir, {force: true, recursive: true});
+  });
+
+  beforeEach(() => {
+    delete process.env.NODE_PRESERVE_SYMLINKS;
+    delete process.env.NODE_OPTIONS;
+    process.execArgv = [];
+  });
+
+  afterEach(() => {
+    if (ORIGINAL_NODE_PRESERVE_SYMLINKS === undefined) {
+      delete process.env.NODE_PRESERVE_SYMLINKS;
+    } else {
+      process.env.NODE_PRESERVE_SYMLINKS = ORIGINAL_NODE_PRESERVE_SYMLINKS;
+    }
+    if (ORIGINAL_NODE_OPTIONS === undefined) {
+      delete process.env.NODE_OPTIONS;
+    } else {
+      process.env.NODE_OPTIONS = ORIGINAL_NODE_OPTIONS;
+    }
+    process.execArgv = ORIGINAL_EXEC_ARGV;
+  });
+
+  const findDep = () => Resolver.findNodeModule('dep', {basedir: appDir});
+
+  it('realpaths symlinked modules by default', () => {
+    expect(findDep()).toBe(realModuleEntry);
+  });
+
+  it('preserves symlinks when NODE_PRESERVE_SYMLINKS=1', () => {
+    process.env.NODE_PRESERVE_SYMLINKS = '1';
+    expect(findDep()).toBe(symlinkedModuleEntry);
+  });
+
+  it('preserves symlinks when started with --preserve-symlinks', () => {
+    process.execArgv = ['--preserve-symlinks'];
+    expect(findDep()).toBe(symlinkedModuleEntry);
+  });
+
+  it('preserves symlinks when --preserve-symlinks is set via NODE_OPTIONS', () => {
+    process.env.NODE_OPTIONS = '--preserve-symlinks';
+    expect(findDep()).toBe(symlinkedModuleEntry);
+  });
+
+  it('ignores NODE_PRESERVE_SYMLINKS values other than "1"', () => {
+    process.env.NODE_PRESERVE_SYMLINKS = '2';
+    expect(findDep()).toBe(realModuleEntry);
+  });
+
+  it('does not treat --preserve-symlinks-main as --preserve-symlinks', () => {
+    process.execArgv = ['--preserve-symlinks-main'];
+    expect(findDep()).toBe(realModuleEntry);
   });
 });

--- a/packages/jest-resolve/src/defaultResolver.ts
+++ b/packages/jest-resolve/src/defaultResolver.ts
@@ -60,6 +60,23 @@ const handleResolveResult = (result: ResolveResult) => {
   return result.path!;
 };
 
+/**
+ * Whether Node was started with `--preserve-symlinks` / `NODE_PRESERVE_SYMLINKS`.
+ *
+ * @see https://nodejs.org/api/cli.html#--preserve-symlinks
+ */
+function shouldPreserveSymlinks(): boolean {
+  // `NODE_PRESERVE_SYMLINKS` is on only when exactly `1`, and `--preserve-symlinks`
+  // is matched exactly so `--preserve-symlinks-main` (entry point only) is excluded.
+  return (
+    process.env.NODE_PRESERVE_SYMLINKS === '1' ||
+    process.execArgv.includes('--preserve-symlinks') ||
+    (process.env.NODE_OPTIONS ?? '')
+      .split(/\s+/)
+      .includes('--preserve-symlinks')
+  );
+}
+
 function baseResolver(path: string, options: ResolverOptions): string;
 function baseResolver(
   path: string,
@@ -103,6 +120,9 @@ function baseResolver(
     extensions: extensions as Array<string> | undefined,
     modules,
     roots: roots || (rootDir ? [rootDir] : undefined),
+    // Honor Node's `--preserve-symlinks`; `unrs-resolver` realpaths by default.
+    // An explicit `symlinks` option still wins via the `...rest` spread below.
+    ...(shouldPreserveSymlinks() ? {symlinks: false} : {}),
     ...rest,
   };
 


### PR DESCRIPTION
## Summary

Jest's default resolver routes through `unrs-resolver`, which realpaths symlinks unconditionally (its `symlinks` option defaults to `true`). This PR makes the default resolver pass `symlinks: false` to `unrs-resolver` when Node itself was started in preserve-symlinks mode, so Jest's module resolution matches Node's own `require`/`import` for symlinked `node_modules` layouts.

Preserve mode is detected when **any** of the following is true:

- `NODE_PRESERVE_SYMLINKS` is exactly `"1"` (Node only honors `1`; `2`/`true`/empty do not enable it),
- `--preserve-symlinks` is present in `process.execArgv` (the CLI flag; `--preserve-symlinks-main` is deliberately excluded since it only affects the entry point), or
- `--preserve-symlinks` appears as a token in `process.env.NODE_OPTIONS` (Node honors the flag there but it does **not** surface in `process.execArgv`, so it must be checked separately).

It is a no-op otherwise, and an explicit `symlinks` option supplied by a caller still wins.

## Motivation

Jest's default resolver has **always** realpathed symlinks: pre-30 via the `resolve` package with a hardcoded `preserveSymlinks: false` and a custom `realpathSync`, and since #15619 (Jest 30.0.0) via `unrs-resolver`'s default `symlinks: true`. Neither path has ever honored Node's `--preserve-symlinks`.

What #15619 changed is that there is no longer any way to opt out — realpathing is now unconditional. As a result the default resolver diverges from Node's `require`/`import` and breaks symlinked `node_modules` layouts (npm/yarn `link`, pnpm, Bazel sandboxes). This is especially visible for **config modules** — e.g. `testEnvironment` and custom `reporters` always resolve through the default resolver (bypassing any custom `resolver`) — where a realpath into a per-package directory can no longer find its siblings.

This PR therefore **adds new, opt-in support** for Node's preserve-symlinks flags to the default resolver — it is a feature, not a restoration of prior behavior. Keying off Node's own flags (rather than introducing a parallel Jest config knob) is intentional: the resolver should mirror Node's `require`/`import` resolution, which is itself process-flag-driven, so the same flags are the correct and least-surprising trigger.

## Changes

- `packages/jest-resolve/src/defaultResolver.ts`
  - Add a private `shouldPreserveSymlinks()` helper that checks `NODE_PRESERVE_SYMLINKS === '1'`, `process.execArgv`, and `NODE_OPTIONS`.
  - In `baseResolver`, spread `...(shouldPreserveSymlinks() ? {symlinks: false} : {})` into the `unrs-resolver` options **before** `...rest`, so an explicit `symlinks` option still wins. `resolveOptions` is rebuilt and re-applied via `cloneWithOptions` on every call, so the flag is read at resolution time; the fix covers both `defaultResolver` (sync) and `defaultAsyncResolver`, which both delegate to `baseResolver`.
- `packages/jest-resolve/src/__tests__/resolve.test.ts`
  - Add a `describe('preserveSymlinks')` block backed by a real symlinked `node_modules` fixture (a `junction`, which works on Windows without elevation; the tmpdir is `realpathSync`'d to avoid macOS `/var`→`/private/var` noise).

## Test plan

`yarn jest packages/jest-resolve` — the new `preserveSymlinks` suite covers:

- realpaths symlinked modules by default,
- preserves symlinks when `NODE_PRESERVE_SYMLINKS=1`,
- preserves symlinks when started with `--preserve-symlinks`,
- preserves symlinks when `--preserve-symlinks` is set via `NODE_OPTIONS`,
- ignores `NODE_PRESERVE_SYMLINKS` values other than `"1"`,
- does not treat `--preserve-symlinks-main` as `--preserve-symlinks`.

All pass, alongside the existing `jest-resolve` suite (67 tests total). `eslint` and `yarn build:ts` are clean.
