### PR TITLE
docs: clarify website README working directory

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -37,6 +37,7 @@ Alternatively, from the root of the Jest monorepo, you can run:
 ```bash
 yarn workspace jest-website start
 ```
+
 ## Publish the website
 
 The site is deployed on each PR merged to main by Netlify:

--- a/website/README.md
+++ b/website/README.md
@@ -14,20 +14,29 @@ yarn
 
 in the root directory.
 
-Fetch `backers.json` file by running
+Change to the `website` directory:
+
+```bash
+cd website
+```
+
+Fetch the `backers.json` file by running:
 
 ```bash
 node fetchSupporters.js
 ```
 
-Then, run the server via
+Then start the development server:
 
 ```bash
 yarn start
 ```
 
-Note, you can also use `yarn workspace jest-website start` from the root of the Jest monorepo.
+Alternatively, from the root of the Jest monorepo, you can run:
 
+```bash
+yarn workspace jest-website start
+```
 ## Publish the website
 
 The site is deployed on each PR merged to main by Netlify:


### PR DESCRIPTION
## Summary

Clarifies that the website development commands should be run from the `website` directory.

## Problem

The README instructed users to run:

```bash
node fetchSupporters.js
yarn start
```

after installing dependencies from the repository root, but it didn't explicitly state that these commands should be run from the `website` directory.

Running `yarn start` from the repository root results in:

```text
Usage Error: Couldn't find a script named "start".
```

## Solution

Added an explicit `cd website` step before the website-specific commands to make the working directory clear.