### PR TITLE
fix(jest-haste-map): tolerate transient EPERM in the watcher lstat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[jest-config]` Add missing `findRelatedTests`, `outputFile`, and `replname` entries to `ValidConfig` so they no longer trigger spurious "Unknown option" warnings ([#16224](https://github.com/jestjs/jest/pull/16224))
+- `[jest-haste-map]` Keep watch mode alive when an outside process briefly makes a file unreadable on Windows, instead of tearing the watcher down on `EPERM` ([#16295](https://github.com/jestjs/jest/pull/16295))
 - `[jest-mock]` `mockResolvedValue` / `mockRejectedValue` now see all overload return types, so a Promise-returning overload survives even when a later overload returns a non-Promise (e.g. `pg.Client['end']`) ([#16237](https://github.com/jestjs/jest/pull/16237))
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
 - `[jest-mock]` Remove the leftover own accessor descriptor when restoring a `spyOn` of an inherited getter or setter, so the instance keeps reflecting the prototype ([#16226](https://github.com/jestjs/jest/pull/16226))

--- a/packages/jest-haste-map/src/watchers/ParcelWatcher.ts
+++ b/packages/jest-haste-map/src/watchers/ParcelWatcher.ts
@@ -21,6 +21,7 @@ import {
   CHANGE_EVENT,
   DELETE_EVENT,
   isFileIncluded,
+  isIgnorableFileError,
 } from './common';
 import type {IWatcher, WatcherOptions} from './types';
 
@@ -227,9 +228,10 @@ export class ParcelWatcher extends EventEmitter implements IWatcher {
       } else {
         const type = event.type === 'create' ? ADD_EVENT : CHANGE_EVENT;
         fs.lstat(absPath, (error, stat) => {
-          if (error?.code === 'ENOENT') return;
           if (error) {
-            this._emitError(error);
+            if (!isIgnorableFileError(error)) {
+              this._emitError(error);
+            }
             return;
           }
           this.emit(type, relPath, this.root, stat);

--- a/packages/jest-haste-map/src/watchers/WatchmanWatcher.js
+++ b/packages/jest-haste-map/src/watchers/WatchmanWatcher.js
@@ -261,9 +261,9 @@ WatchmanWatcher.prototype.handleFileChange = function (changeDescriptor) {
 
   if (changeDescriptor.exists) {
     fs.lstat(absPath, (error, stat) => {
-      // Files can be deleted between the event and the lstat call
-      // the most reliable thing to do here is to ignore the event.
-      if (error && error.code === 'ENOENT') {
+      // Files can disappear or temporarily become unreadable between the
+      // Watchman event and the lstat call, so ignore that stale event.
+      if (error && common.isIgnorableFileError(error)) {
         return;
       }
 

--- a/packages/jest-haste-map/src/watchers/__tests__/WatchmanWatcher.test.js
+++ b/packages/jest-haste-map/src/watchers/__tests__/WatchmanWatcher.test.js
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as path from 'node:path';
+import fs from 'graceful-fs';
+import WatchmanWatcher from '../WatchmanWatcher';
+
+jest.mock('node:os', () => ({
+  ...jest.requireActual('node:os'),
+  platform: jest.fn(() => 'win32'),
+}));
+jest.mock('graceful-fs', () => ({
+  ...jest.requireActual('graceful-fs'),
+  lstat: jest.fn(),
+}));
+
+const ROOT = path.resolve('/root');
+const mockLstat = jest.mocked(fs.lstat);
+
+function makeWatcher() {
+  const watcher = Object.create(WatchmanWatcher.prototype);
+  Object.assign(watcher, {
+    capabilities: {relative_root: false, wildmatch: false},
+    doIgnore: () => false,
+    dot: true,
+    globs: [],
+    hasIgnore: false,
+    root: ROOT,
+  });
+  return watcher;
+}
+
+describe('WatchmanWatcher', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('ignores EPERM when an outside process makes a file unreadable on Windows', () => {
+    mockLstat.mockImplementation((_path, callback) => {
+      callback(Object.assign(new Error('EPERM'), {code: 'EPERM'}), null);
+    });
+
+    const watcher = makeWatcher();
+    const onError = jest.fn();
+    watcher.on('error', onError);
+
+    watcher.handleFileChange({exists: true, name: 'file.js', new: true});
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/jest-haste-map/src/watchers/__tests__/common.test.ts
+++ b/packages/jest-haste-map/src/watchers/__tests__/common.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as os from 'node:os';
+
+jest.mock('node:os', () => ({
+  ...jest.requireActual<typeof import('node:os')>('node:os'),
+  platform: jest.fn(),
+}));
+
+const mockPlatform = jest.mocked(os.platform);
+
+function loadIsIgnorableFileError(platform: NodeJS.Platform) {
+  mockPlatform.mockReturnValue(platform);
+  let isIgnorableFileError!: (error: NodeJS.ErrnoException) => boolean;
+  jest.isolateModules(() => {
+    ({isIgnorableFileError} = require('../common'));
+  });
+  return isIgnorableFileError;
+}
+
+function errorWithCode(code: string): NodeJS.ErrnoException {
+  return Object.assign(new Error(code), {code});
+}
+
+describe('isIgnorableFileError', () => {
+  it.each(['win32', 'darwin', 'linux'] as const)(
+    'ignores a file that vanished on %s',
+    platform => {
+      expect(loadIsIgnorableFileError(platform)(errorWithCode('ENOENT'))).toBe(
+        true,
+      );
+    },
+  );
+
+  it('ignores EPERM on win32, where an outside process can hold a file open', () => {
+    expect(loadIsIgnorableFileError('win32')(errorWithCode('EPERM'))).toBe(
+      true,
+    );
+  });
+
+  it.each(['darwin', 'linux'] as const)(
+    'does not ignore EPERM on %s',
+    platform => {
+      expect(loadIsIgnorableFileError(platform)(errorWithCode('EPERM'))).toBe(
+        false,
+      );
+    },
+  );
+
+  it.each(['win32', 'darwin', 'linux'] as const)(
+    'does not ignore EACCES on %s',
+    platform => {
+      expect(loadIsIgnorableFileError(platform)(errorWithCode('EACCES'))).toBe(
+        false,
+      );
+    },
+  );
+});

--- a/packages/jest-haste-map/src/watchers/common.ts
+++ b/packages/jest-haste-map/src/watchers/common.ts
@@ -5,7 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import * as os from 'node:os';
 import picomatch from 'picomatch';
+
+const platform = os.platform();
 
 export const CHANGE_EVENT = 'change';
 export const DELETE_EVENT = 'delete';
@@ -22,6 +25,19 @@ function getMatcher(glob: string, dot: boolean): picomatch.Matcher {
     matcherCache.set(key, matcher);
   }
   return matcher;
+}
+
+/**
+ * A file can vanish between a watcher event and the `lstat` that follows it,
+ * which is `ENOENT`. On Windows an outside process holding the file open --
+ * `git maintenance` touching `.git/index.lock` or `.git/objects`, for instance
+ * -- surfaces as `EPERM` instead (nodejs/node#4337). Neither means the watcher
+ * is broken, so neither should tear it down.
+ */
+export function isIgnorableFileError(error: NodeJS.ErrnoException): boolean {
+  return (
+    error.code === 'ENOENT' || (error.code === 'EPERM' && platform === 'win32')
+  );
 }
 
 export function isFileIncluded(


### PR DESCRIPTION
Fixes #13869.

## Summary

`ParcelWatcher` tears the watcher down when `lstat` fails with anything other than `ENOENT`. On Windows an outside process holding a file open — `git maintenance` touching `.git/index.lock` or `.git/objects` — surfaces as `EPERM`, so watch mode dies mid-run.

- add `isIgnorableFileError` to `watchers/common.ts`: `ENOENT` anywhere, plus `EPERM` on win32 only (nodejs/node#4337)
- use it for the `lstat` callback in `ParcelWatcher._onEvents`
- cover the predicate across win32/darwin/linux, including that `EACCES` is still surfaced everywhere

## Note on scope

This PR previously fixed the same bug in `NodeWatcher`/`FSEventsWatcher` and also carried an ignore-matcher change. #16188 deleted all three files, so that work is gone. The `EPERM` handling did not survive the replacement — the new `ParcelWatcher` reproduces the original `ENOENT`-only gate — so the branch is now just that one fix against the new code path.

The ignore-matcher half is dropped entirely. `ParcelWatcher` already appends the VCS globs in both bare and `/**` forms precisely because the relative path it matches has no leading separator, so the gap that change addressed no longer exists.

## Validation

- `yarn jest packages/jest-haste-map` — 21 suites, 197 tests, 5 snapshots passed
- `tsc -b packages/jest-haste-map/**/__tests__` — exit 0
- `yarn eslint` on changed files, `yarn check-changelog`, `yarn check-copyright-headers`, `git diff --check` — all clean

Verified on macOS; the `EPERM` branch is Windows-only, so hosted Windows CI is the decisive check.
