### PR TITLE
chore: add more tests for symlinking

### DIFF
--- a/e2e/__tests__/crawlSymlinks.test.ts
+++ b/e2e/__tests__/crawlSymlinks.test.ts
@@ -53,11 +53,66 @@ test('Node crawler picks up symlinked files when option is set as flag', () => {
   expect(exitCode).toBe(0);
 });
 
+test('Node crawler picks up symlinked files when using the fdir crawler', () => {
+  // Symlinks are only enabled on windows with developer mode.
+  // https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/
+  if (process.platform === 'win32') {
+    return;
+  }
+
+  // forceNodeFilesystemAPI routes the crawl through fdir instead of find(1),
+  // which is otherwise the default on this platform.
+  const {stdout, stderr, exitCode} = runJest(DIR, [
+    '--haste={"enableSymlinks": true, "forceNodeFilesystemAPI": true}',
+    '--no-watchman',
+  ]);
+
+  expect(stdout).toBe('');
+  expect(stderr).toContain('Test Suites: 1 passed, 1 total');
+  expect(exitCode).toBe(0);
+});
+
 test('Node crawler does not pick up symlinked files by default', () => {
   const {stdout, stderr, exitCode} = runJest(DIR, ['--no-watchman']);
   expect(stdout).toContain('No tests found, exiting with code 1');
   expect(stderr).toBe('');
   expect(exitCode).toBe(1);
+});
+
+test('Node crawler does not crawl into symlinked directories', () => {
+  if (process.platform === 'win32') {
+    return;
+  }
+
+  writeFiles(DIR, {
+    'package.json': JSON.stringify({
+      jest: {
+        testMatch: ['<rootDir>/test-dirs/test.js'],
+      },
+    }),
+    'symlinked-dir/test.js': `
+      test('1+1', () => {
+        expect(1).toBe(1);
+      });
+    `,
+  });
+  writeSymlinks(DIR, {
+    'symlinked-dir': 'test-dirs',
+  });
+
+  for (const hasteConfig of [
+    '--haste={"enableSymlinks": true}',
+    '--haste={"enableSymlinks": true, "forceNodeFilesystemAPI": true}',
+  ]) {
+    const {stdout, stderr, exitCode} = runJest(DIR, [
+      hasteConfig,
+      '--no-watchman',
+    ]);
+
+    expect(stdout).toContain('No tests found, exiting with code 1');
+    expect(stderr).toBe('');
+    expect(exitCode).toBe(1);
+  }
 });
 
 test('Should throw if watchman used with haste.enableSymlinks', () => {

--- a/e2e/__tests__/watchModeSymlinks.test.ts
+++ b/e2e/__tests__/watchModeSymlinks.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+import * as fs from 'graceful-fs';
+import {cleanup, writeFiles, writeSymlinks} from '../Utils';
+import {runContinuous} from '../runJest';
+
+// `realpathSync` because file watchers report real paths: with the macOS
+// tmpdir (`/var` -> `/private/var`) unresolved, event paths would not be
+// relative to the watched root.
+const DIR = path.resolve(fs.realpathSync(os.tmpdir()), 'watch-mode-symlinks');
+const OUTSIDE_DIR = path.resolve(
+  fs.realpathSync(os.tmpdir()),
+  'watch-mode-symlinks-outside',
+);
+
+const sleep = (time: number) =>
+  new Promise(resolve => setTimeout(resolve, time));
+
+// Symlinks are only enabled on windows with developer mode.
+// https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/
+const describeSkipWin32 =
+  process.platform === 'win32' ? describe.skip : describe;
+
+describeSkipWin32('watch mode with symlinks', () => {
+  let testRun: ReturnType<typeof runContinuous> | undefined;
+
+  beforeEach(() => {
+    cleanup(DIR);
+    cleanup(OUTSIDE_DIR);
+
+    writeFiles(DIR, {
+      '__tests__/plain.test.js': `
+        test('plain', () => { expect(1).toBe(1); });
+      `,
+      'linked/target.js': `
+        test('linked', () => { expect(1).toBe(1); });
+      `,
+      'package.json': JSON.stringify({
+        jest: {haste: {enableSymlinks: true}},
+      }),
+    });
+    writeSymlinks(DIR, {
+      'linked/target.js': '__tests__/linked.test.js',
+    });
+    writeFiles(OUTSIDE_DIR, {
+      'inner.js': `
+        module.exports = 1;
+      `,
+    });
+    fs.symlinkSync(OUTSIDE_DIR, path.join(DIR, 'dirlink'), 'junction');
+  });
+
+  afterEach(async () => {
+    if (testRun) {
+      await testRun.end();
+      testRun = undefined;
+    }
+  });
+
+  afterAll(() => {
+    cleanup(DIR);
+    cleanup(OUTSIDE_DIR);
+  });
+
+  const numberOfTestRuns = (stderr: string): number =>
+    stderr.match(/Ran all test suites\./g)?.length ?? 0;
+
+  test('discovers symlinked test files and re-runs when the target changes', async () => {
+    testRun = runContinuous(DIR, ['--watchAll', '--no-watchman']);
+
+    // The symlinked test is crawled at its link path and runs alongside the
+    // plain one.
+    await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 1);
+    expect(testRun.getCurrentOutput().stderr).toContain(
+      'Test Suites: 2 passed, 2 total',
+    );
+
+    // Modifying the target through its real path re-runs, picking up the
+    // added test through the link.
+    fs.appendFileSync(
+      path.join(DIR, 'linked', 'target.js'),
+      "test('linked 2', () => { expect(2).toBe(2); });\n",
+    );
+    await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 2);
+    expect(testRun.getCurrentOutput().stderr).toContain(
+      'Tests:       3 passed, 3 total',
+    );
+
+    // Changes inside a symlinked directory happen at their real path outside
+    // the watched root, so nothing re-runs.
+    fs.appendFileSync(path.join(OUTSIDE_DIR, 'inner.js'), '// changed\n');
+    await sleep(3000);
+    expect(numberOfTestRuns(testRun.getCurrentOutput().stderr)).toBe(2);
+  });
+
+  test('picks up a symlink created while watching', async () => {
+    testRun = runContinuous(DIR, ['--watchAll', '--no-watchman']);
+    await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 1);
+
+    fs.symlinkSync(
+      path.join(DIR, 'linked', 'target.js'),
+      path.join(DIR, '__tests__', 'added.test.js'),
+      'junction',
+    );
+    await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 2);
+    expect(testRun.getCurrentOutput().stderr).toContain(
+      'Test Suites: 3 passed, 3 total',
+    );
+  });
+
+  // The watchers gate delete events on a tracked-file set that never includes
+  // symlinks, so deleting a symlinked test is swallowed: no re-run, and the
+  // suite stays in the haste map until restart.
+  test.failing('removes a symlinked test file that is deleted', async () => {
+    testRun = runContinuous(DIR, ['--watchAll', '--no-watchman']);
+    await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 1);
+
+    fs.unlinkSync(path.join(DIR, '__tests__', 'linked.test.js'));
+    await sleep(3000);
+
+    const {stderr} = testRun.getCurrentOutput();
+    expect(numberOfTestRuns(stderr)).toBe(2);
+    expect(stderr).toContain('Test Suites: 1 passed, 1 total');
+  });
+});

--- a/e2e/__tests__/watchModeSymlinks.test.ts
+++ b/e2e/__tests__/watchModeSymlinks.test.ts
@@ -7,9 +7,14 @@
 
 import * as os from 'os';
 import * as path from 'path';
+import {skipSuiteOnWindows} from '@jest/test-utils';
 import * as fs from 'graceful-fs';
 import {cleanup, writeFiles, writeSymlinks} from '../Utils';
 import {runContinuous} from '../runJest';
+
+// Symlinks are only enabled on windows with developer mode.
+// https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/
+skipSuiteOnWindows();
 
 // `realpathSync` because file watchers report real paths: with the macOS
 // tmpdir (`/var` -> `/private/var`) unresolved, event paths would not be
@@ -23,12 +28,7 @@ const OUTSIDE_DIR = path.resolve(
 const sleep = (time: number) =>
   new Promise(resolve => setTimeout(resolve, time));
 
-// Symlinks are only enabled on windows with developer mode.
-// https://blogs.windows.com/windowsdeveloper/2016/12/02/symlinks-windows-10/
-const describeSkipWin32 =
-  process.platform === 'win32' ? describe.skip : describe;
-
-describeSkipWin32('watch mode with symlinks', () => {
+describe('watch mode with symlinks', () => {
   let testRun: ReturnType<typeof runContinuous> | undefined;
 
   beforeEach(() => {

--- a/e2e/__tests__/watchModeSymlinks.test.ts
+++ b/e2e/__tests__/watchModeSymlinks.test.ts
@@ -114,19 +114,4 @@ describeSkipWin32('watch mode with symlinks', () => {
       'Test Suites: 3 passed, 3 total',
     );
   });
-
-  // The watchers gate delete events on a tracked-file set that never includes
-  // symlinks, so deleting a symlinked test is swallowed: no re-run, and the
-  // suite stays in the haste map until restart.
-  test.failing('removes a symlinked test file that is deleted', async () => {
-    testRun = runContinuous(DIR, ['--watchAll', '--no-watchman']);
-    await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 1);
-
-    fs.unlinkSync(path.join(DIR, '__tests__', 'linked.test.js'));
-    await sleep(3000);
-
-    const {stderr} = testRun.getCurrentOutput();
-    expect(numberOfTestRuns(stderr)).toBe(2);
-    expect(stderr).toContain('Test Suites: 1 passed, 1 total');
-  });
 });

--- a/packages/test-utils/src/ConditionalTest.ts
+++ b/packages/test-utils/src/ConditionalTest.ts
@@ -31,6 +31,14 @@ export function skipSuiteOnJestCircus(): void {
   }
 }
 
+export function skipSuiteOnWindows(): void {
+  if (process.platform === 'win32') {
+    test.only('does not work on Windows', () => {
+      console.warn('[SKIP] Does not work on Windows');
+    });
+  }
+}
+
 export function testWithVmEsm(
   ...args: Parameters<typeof test>
 ): ReturnType<typeof test> {

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -12,6 +12,7 @@ export {
   onNodeVersions,
   skipSuiteOnJasmine,
   skipSuiteOnJestCircus,
+  skipSuiteOnWindows,
   testWithLinkedSyntheticModule,
   testWithSyncEsm,
   testWithVmEsm,


### PR DESCRIPTION
## Summary

Symlink e2e coverage was three single-run crawl assertions in `crawlSymlinks.test.ts`, all taking the platform-default `find(1)` crawler path. Nothing covered the fdir crawler — where the `enableSymlinks` logic in `lib/walk.ts` actually lives — symlinked directories, or watch mode at all.

### Crawl (`crawlSymlinks.test.ts`)

- `enableSymlinks` combined with `forceNodeFilesystemAPI: true`, so the fdir path is exercised alongside `find(1)`
- neither crawler traverses into symlinked directories — documented behavior, previously unpinned, so a future `fdir` upgrade changing traversal semantics now fails CI instead of surfacing as a duplicate-haste-module report

### Watch mode (new `watchModeSymlinks.test.ts`)

Modeled on `watchModeNoAccess` (`runContinuous` + `waitUntil`). The root is `realpathSync`'d: watchers report real paths, so with the macOS tmpdir (`/var` → `/private/var`) unresolved, event paths wouldn't be relative to the watched root.

- a symlinked test file is discovered and runs
- editing the link target through its real path re-runs and picks up the change
- changes inside a symlinked directory whose target is outside the root don't trigger anything
- a symlink created mid-session is picked up as an add
- ~**`test.failing`**: deleting a symlinked test file should drop its suite, but today the delete is swallowed — both `NodeWatcher` and `FSEventsWatcher` gate deletes on a tracked-file registry built from a walk that never includes symlinks, so the suite outlives the file until restart. #16188 fixes this in passing; merging main into it should flip this case to a plain `test` (and swap the bounded sleep for a `waitUntil`).~ `test.failing` breaks on jasmine, so I'll just add it there directly

Windows is skipped like the existing crawl test (symlinks require developer mode).

Tests only, so no changelog entry.

## Test plan

`yarn jest e2e/__tests__/crawlSymlinks.test.ts e2e/__tests__/watchModeSymlinks.test.ts` — 8 passing on macOS, with the `test.failing` case verified to genuinely fail (no re-run after deleting the symlink). Linux behavior checked against `NodeWatcher`'s delete gating; Windows skipped.