### PR TITLE
ci: exercise watchman on Node LTS

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -188,6 +188,40 @@ jobs:
           directory: ./coverage
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  test-watchman:
+    name: Node LTS on Ubuntu with watchman
+    runs-on: ubuntu-latest
+    needs: prepare-yarn-cache-ubuntu
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Use Node.js LTS
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: lts/*
+          cache: yarn
+      - name: install watchman
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y watchman
+          watchman --version
+      - name: install
+        run: yarn --immutable
+      - name: build
+        run: yarn build:js
+      - name: Get number of CPU cores
+        id: cpu-cores
+        uses: SimenB/github-actions-cpu-cores@97330871fe1b7d3529392ea000e3d2c4b357e403 # v3
+      - name: run watchman tests
+        uses: nick-fields/retry@ad984534de44a9489a53aefd81eb77f87c70dc60 # v4
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          retry_on: error
+          command: yarn test-watchman --max-workers ${{ steps.cpu-cores.outputs.count }}
+
   test-coverage:
     name: Node LTS on Ubuntu with coverage (${{ matrix.shard }})
     strategy:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@
 - `[jest-haste-map]` Refactor massive class into multiple files ([#16180](https://github.com/jestjs/jest/pull/16180))
 - `[jest-haste-map]` Drop `walker` dependency; replace hand-rolled directory recursion in the JS crawler and watcher startup with `fdir` ([#16187](https://github.com/jestjs/jest/pull/16187))
 - `[jest-runtime]` Avoid magical `null` value in ESM loader ([#16160](https://github.com/jestjs/jest/pull/16160))
+- `[@jest/test-utils]` Add `skipSuiteWithoutWatchman` and run watch mode against a real watchman daemon on CI ([#16319](https://github.com/jestjs/jest/pull/16319))
 
 ## 30.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@
 - `[jest-haste-map]` Refactor massive class into multiple files ([#16180](https://github.com/jestjs/jest/pull/16180))
 - `[jest-haste-map]` Drop `walker` dependency; replace hand-rolled directory recursion in the JS crawler and watcher startup with `fdir` ([#16187](https://github.com/jestjs/jest/pull/16187))
 - `[jest-runtime]` Avoid magical `null` value in ESM loader ([#16160](https://github.com/jestjs/jest/pull/16160))
-- `[@jest/test-utils]` Add `skipSuiteWithoutWatchman` and run watch mode against a real watchman daemon on CI ([#16319](https://github.com/jestjs/jest/pull/16319))
 
 ## 30.4.2
 

--- a/e2e/__tests__/watchModeWatchman.test.ts
+++ b/e2e/__tests__/watchModeWatchman.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as os from 'os';
+import * as path from 'path';
+import {skipSuiteOnWindows, skipSuiteWithoutWatchman} from '@jest/test-utils';
+import * as fs from 'graceful-fs';
+import {cleanup, writeFiles} from '../Utils';
+import {runContinuous} from '../runJest';
+
+skipSuiteOnWindows();
+skipSuiteWithoutWatchman();
+
+// `realpathSync` because watchman reports real paths: with the macOS tmpdir
+// (`/var` -> `/private/var`) unresolved, event paths would not be relative to
+// the watched root.
+const DIR = path.resolve(fs.realpathSync(os.tmpdir()), 'watch-mode-watchman');
+
+describe('watch mode with watchman', () => {
+  let testRun: ReturnType<typeof runContinuous> | undefined;
+
+  beforeEach(() => {
+    cleanup(DIR);
+    writeFiles(DIR, {
+      '.watchmanconfig': '{}',
+      '__tests__/first.test.js': `
+        test('first', () => { expect(1).toBe(1); });
+      `,
+      'package.json': JSON.stringify({jest: {testEnvironment: 'node'}}),
+    });
+  });
+
+  afterEach(async () => {
+    if (testRun) {
+      await testRun.end();
+      testRun = undefined;
+    }
+  });
+
+  afterAll(() => cleanup(DIR));
+
+  const numberOfTestRuns = (stderr: string): number =>
+    stderr.match(/Ran all test suites\./g)?.length ?? 0;
+
+  test('re-runs when a watched file changes', async () => {
+    testRun = runContinuous(DIR, ['--watchAll']);
+
+    await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 1);
+    expect(testRun.getCurrentOutput().stderr).toContain(
+      'Test Suites: 1 passed, 1 total',
+    );
+    // A failed crawl falls back to the node crawler, which would make the rest
+    // of this suite pass without watchman ever being exercised.
+    expect(testRun.getCurrentOutput().stdout).not.toContain(
+      'Watchman crawl failed',
+    );
+
+    fs.appendFileSync(
+      path.join(DIR, '__tests__', 'first.test.js'),
+      "test('second', () => { expect(2).toBe(2); });\n",
+    );
+
+    await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 2);
+    expect(testRun.getCurrentOutput().stderr).toContain(
+      'Tests:       2 passed, 2 total',
+    );
+  });
+
+  test('picks up a test file added while watching', async () => {
+    testRun = runContinuous(DIR, ['--watchAll']);
+
+    await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 1);
+
+    fs.writeFileSync(
+      path.join(DIR, '__tests__', 'added.test.js'),
+      "test('added', () => { expect(1).toBe(1); });\n",
+    );
+
+    await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 2);
+    expect(testRun.getCurrentOutput().stderr).toContain(
+      'Test Suites: 2 passed, 2 total',
+    );
+  });
+
+  test('drops a test file deleted while watching', async () => {
+    testRun = runContinuous(DIR, ['--watchAll']);
+
+    await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 1);
+
+    fs.writeFileSync(
+      path.join(DIR, '__tests__', 'extra.test.js'),
+      "test('extra', () => { expect(1).toBe(1); });\n",
+    );
+    await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 2);
+
+    fs.unlinkSync(path.join(DIR, '__tests__', 'extra.test.js'));
+
+    await testRun.waitUntil(({stderr}) => numberOfTestRuns(stderr) === 3);
+    expect(testRun.getCurrentOutput().stderr).toContain(
+      'Test Suites: 1 passed, 1 total',
+    );
+  });
+});

--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "test-leak": "yarn jest -i --detectLeaks --color jest-mock jest-diff pretty-format",
     "test-ts": "yarn jest --config jest.config.ts.mjs",
     "test-types": "tstyche",
+    "test-watchman": "yarn jest --color --config jest.config.ci.mjs e2e/__tests__/watchModeWatchman.test.ts packages/jest-haste-map",
     "test-with-type-info": "yarn jest e2e/__tests__/jest.config.ts.test.ts",
     "test": "yarn lint && yarn jest",
     "typecheck": "yarn typecheck:examples && yarn typecheck:tests",

--- a/packages/test-utils/src/ConditionalTest.ts
+++ b/packages/test-utils/src/ConditionalTest.ts
@@ -7,12 +7,26 @@
 
 /* eslint-disable jest/no-focused-tests */
 
+import {spawnSync} from 'node:child_process';
 import {SourceTextModule, SyntheticModule} from 'node:vm';
 import * as semver from 'semver';
 import {describe, test} from '@jest/globals';
 
 export function isJestJasmineRun(): boolean {
   return process.env.JEST_JASMINE === '1';
+}
+
+export function isWatchmanAvailable(): boolean {
+  const {error, status} = spawnSync('watchman', ['--version']);
+  return error == null && status === 0;
+}
+
+export function skipSuiteWithoutWatchman(): void {
+  if (!isWatchmanAvailable()) {
+    test.only('requires watchman', () => {
+      console.warn('[SKIP] Requires watchman to be installed');
+    });
+  }
 }
 
 export function skipSuiteOnJasmine(): void {

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -9,10 +9,12 @@ export {alignedAnsiStyleSerializer} from './alignedAnsiStyleSerializer';
 
 export {
   isJestJasmineRun,
+  isWatchmanAvailable,
   onNodeVersions,
   skipSuiteOnJasmine,
   skipSuiteOnJestCircus,
   skipSuiteOnWindows,
+  skipSuiteWithoutWatchman,
   testWithLinkedSyntheticModule,
   testWithSyncEsm,
   testWithVmEsm,


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Watchman has never been installed on CI, so `shouldUseWatchman` always resolved false there and `crawlers/watchman.ts` and `WatchmanWatcher` only ever ran against mocked `fb-watchman`. Every watch-mode e2e test passes `--no-watchman`, so none of them covered the daemon either.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->


Add a Ubuntu job that installs watchman and runs a new watch-mode e2e suite against a live daemon, plus `jest-haste-map`. The suite is gated on watchman being present so it skips for contributors without it, and it asserts the run did not fall back to the node crawler — otherwise a silent fallback would let it pass without touching watchman at all.