### PR TITLE
test: match Node prereleases in version gates

### DIFF
--- a/e2e/runJest.ts
+++ b/e2e/runJest.ts
@@ -12,18 +12,14 @@ import {stripVTControlCharacters as stripAnsi} from 'node:util';
 import dedent from 'dedent';
 import execa from 'execa';
 import * as fs from 'graceful-fs';
-import * as semver from 'semver';
 import {TestPathPatterns} from '@jest/pattern';
 import type {FormattedTestResults} from '@jest/test-result';
 import {normalizeIcons} from '@jest/test-utils';
 import type {Config} from '@jest/types';
 import {ErrorWithStack} from 'jest-util';
 
-export const useNativeTypeScript = semver.satisfies(
-  process.versions.node,
-  '^22.18.0 || >=23.6.0',
-  {includePrerelease: true},
-);
+// @ts-expect-error: Type assertion can be removed once @types/node is updated to 23 https://nodejs.org/api/process.html#processfeaturestypescript
+export const useNativeTypeScript = Boolean(process.features.typescript);
 
 const JEST_PATH = path.resolve(__dirname, '../packages/jest-cli/bin/jest.js');
 

--- a/e2e/runJest.ts
+++ b/e2e/runJest.ts
@@ -22,6 +22,7 @@ import {ErrorWithStack} from 'jest-util';
 export const useNativeTypeScript = semver.satisfies(
   process.versions.node,
   '^22.18.0 || >=23.6.0',
+  {includePrerelease: true},
 );
 
 const JEST_PATH = path.resolve(__dirname, '../packages/jest-cli/bin/jest.js');

--- a/packages/test-utils/src/ConditionalTest.ts
+++ b/packages/test-utils/src/ConditionalTest.ts
@@ -78,7 +78,11 @@ export function onNodeVersions(
   testBody: () => void,
 ): void {
   const description = `on node ${versionRange}`;
-  if (semver.satisfies(process.versions.node, versionRange)) {
+  if (
+    semver.satisfies(process.versions.node, versionRange, {
+      includePrerelease: true,
+    })
+  ) {
     describe(description, () => {
       testBody();
     });


### PR DESCRIPTION
## Summary

The nightly CI job has failed every day on all three OSes, shards 2/4 and 3/4, in `e2e/__tests__/typescriptConfigFile.test.ts`:

```
Error: Jest: Failed to parse the TypeScript config file /tmp/typescript-config-file/alpha.config.ts
  Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/tmp/typescript-config-file/common' imported from /tmp/typescript-config-file/alpha.config.ts
```

`useNativeTypeScript` decided whether Node can load a `.ts` config natively by comparing the version against `^22.18.0 || >=23.6.0`, while the implementation decides it by reading `process.features.typescript`. Two ways for those to disagree, and nightly hits the first:

- `semver.satisfies` excludes prereleases from a plain range, so on `26.0.0-nightly20260505ee37fcea08` the helper said "no native TypeScript" and the fixtures wrote an extensionless `import … from './common'` — which Node's native loader rejects.
- A supported version run with `--no-experimental-strip-types` was read as having native support, when the implementation falls back to a TS loader there.

The helper now reads the same flag the implementation reads, so the two cannot drift.

`onNodeVersions` had the version problem as well, in the other direction: with a plain range every version-gated block skipped on a nightly build, `>=26` and `<23.6` alike — nightly was running considerably less than it looked like. That gate is genuinely about versions, so it keeps semver and gains `includePrerelease`.

## Test plan

`process.features.typescript` tracks what the tests care about across the supported range:

```
v18.20.8   undefined
v20.20.2   undefined
v22.20.0   "strip"
v24.16.0   "strip"
v26.1.0    "strip"
$ node --no-experimental-strip-types -p "process.features.typescript"
false
```

The prerelease half needs a nightly binary, so the mechanism is shown directly:

```
$ node -e "const s=require('semver');const v='26.0.0-nightly20260505ee37fcea08';const r='^22.18.0 || >=23.6.0';console.log('plain:',s.satisfies(v,r),'includePrerelease:',s.satisfies(v,r,{includePrerelease:true}))"
plain: false includePrerelease: true
```

Affected suites on Node 26.7.0, native path:

```
$ yarn jest e2e/__tests__/typescriptConfigFile.test.ts e2e/__tests__/jest.config.ts.test.ts e2e/__tests__/readInitialOptions.test.ts
Test Suites: 3 passed, 3 total
Tests:       8 skipped, 20 passed, 28 total

$ yarn test-ts --selectProjects ts-integration
Test Suites: 1 passed, 1 total
Tests:       4 skipped, 30 passed, 34 total
```

And the loader path, which the old gate got wrong:

```
$ NODE_OPTIONS=--no-experimental-strip-types yarn jest e2e/__tests__/typescriptConfigFile.test.ts
Test Suites: 1 passed, 1 total
Tests:       1 skipped, 3 passed, 4 total
```

`yarn typecheck:tests` and `yarn lint` both exit 0. The real check for the prerelease half is the next scheduled nightly.