### PR TITLE
ci: run the test matrix on Node 26

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,7 +45,7 @@ cd e2e/<test-directory>
 node ../../packages/jest-cli/bin/jest.js --no-cache
 ```
 
-CI runs the test matrix with `nick-fields/retry` (10-min timeout, up to 3 retries on flake) across Ubuntu/macOS/Windows × Node 18/20/22/24/25. If a test is consistently failing locally but green in CI, suspect a retry-masked flake.
+CI runs the test matrix with `nick-fields/retry` (10-min timeout, up to 3 retries on flake) across Ubuntu/macOS/Windows × Node 18/20/22/24/25/26. If a test is consistently failing locally but green in CI, suspect a retry-masked flake.
 
 ### Test gotchas worth memorizing
 

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -154,7 +154,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x, 25.x]
+        node-version: [18.x, 20.x, 22.x, 24.x, 25.x, 26.x]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test-nightly.yml
+++ b/.github/workflows/test-nightly.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Use Node.js nightly build
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 26-nightly
+          node-version: 27-nightly
           cache: yarn
       - name: install
         run: yarn --immutable
@@ -57,7 +57,7 @@ jobs:
       - name: Use Node.js nightly build
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: 26-nightly
+          node-version: 27-nightly
           cache: yarn
       - name: install
         run: yarn --immutable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x, 22.x, 24.x, 25.x]
+        node-version: [18.x, 20.x, 22.x, 24.x, 25.x, 26.x]
     name: Node v${{ matrix.node-version }}
     runs-on: ${{ inputs.os }}
 

--- a/e2e/__tests__/fakeTimersTemporal.test.ts
+++ b/e2e/__tests__/fakeTimersTemporal.test.ts
@@ -9,9 +9,9 @@ import runJest from '../runJest';
 
 // Temporal needs ICU4X at Node's configure time, so a Node version that should
 // have it can still ship without the global.
-const hasTemporal = 'Temporal' in globalThis;
+const testTemporal = 'Temporal' in globalThis ? test : test.skip;
 
-(hasTemporal ? test : test.skip)(
+testTemporal(
   'useFakeTimers({now}) and setSystemTime accept Temporal instances',
   () => {
     const result = runJest('fake-timers-temporal');

--- a/e2e/__tests__/fakeTimersTemporal.test.ts
+++ b/e2e/__tests__/fakeTimersTemporal.test.ts
@@ -5,12 +5,16 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {onNodeVersions} from '@jest/test-utils';
 import runJest from '../runJest';
 
-onNodeVersions('>=26', () => {
-  test('useFakeTimers({now}) and setSystemTime accept Temporal instances', () => {
+// Temporal needs ICU4X at Node's configure time, so a Node version that should
+// have it can still ship without the global.
+const hasTemporal = 'Temporal' in globalThis;
+
+(hasTemporal ? test : test.skip)(
+  'useFakeTimers({now}) and setSystemTime accept Temporal instances',
+  () => {
     const result = runJest('fake-timers-temporal');
     expect(result.exitCode).toBe(0);
-  });
-});
+  },
+);


### PR DESCRIPTION
## Summary

Node 26 has been Current since May, and only the nightly job covered it. This adds `26.x` to the test matrix and to the `test-runtime-vm-modules` matrix, and moves nightly up to `27-nightly`. `25.x` stays. `engines` needs no change — the root range already ends in `>=24.0.0`.

The Temporal e2e test gated on `onNodeVersions('>=26')`, which assumes the version implies the global. It does not: Temporal needs ICU4X at Node's configure time, so a Node 26 built without it exposes no `Temporal` — that is true of Homebrew's build today (`process.config.variables.v8_enable_temporal_support` is `0`, against `1` on nodejs.org's), and nodesource/distributions#1945 reports the same for EL8. The test now sniffs for the global, so it runs where Temporal exists and skips where it does not, instead of failing.

The `on node >=26` describe block goes away with the gate. Nothing on disk was keyed to it.

## Test plan

Green CI

The Temporal gate, both directions:

```
$ node -p "'Temporal' in globalThis"          # Homebrew 26.7.0
false
$ yarn jest e2e/__tests__/fakeTimersTemporal.test.ts
Test Suites: 1 skipped, 0 of 1 total
Tests:       1 skipped, 1 total

$ node -p "'Temporal' in globalThis"          # nodejs.org 26.1.0
true
$ yarn jest e2e/__tests__/fakeTimersTemporal.test.ts
Test Suites: 1 passed, 1 total
Tests:       1 passed, 1 total
```

`yarn lint` and `yarn typecheck:tests` exit 0. The matrices themselves are verified by this PR's own run.