### PR TITLE
fix: only warn about a conflicting `globalsCleanup` mode when one was set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - `[jest-circus, jest-jasmine2, jest-message-util]` Serialize the inner errors of an `AggregateError` into `failureMessages`, `retryReasons` and `unhandledErrors`, so `--json` output and reporter annotations include them ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[jest-config]` Add missing `findRelatedTests`, `outputFile`, and `replname` entries to `ValidConfig` so they no longer trigger spurious "Unknown option" warnings ([#16224](https://github.com/jestjs/jest/pull/16224))
 - `[jest-config]` Use `--config` for the global config when multiple `--projects` are specified ([#16273](https://github.com/jestjs/jest/pull/16273))
+- `[jest-environment-node, jest-util]` Only warn about a conflicting `globalsCleanup` mode when one was explicitly configured, and follow the mode that is actually in effect ([#16322](https://github.com/jestjs/jest/pull/16322))
 - `[jest-haste-map]` Keep watch mode alive when an outside process briefly makes a file unreadable on Windows, instead of tearing the watcher down on `EPERM` ([#16295](https://github.com/jestjs/jest/pull/16295))
 - `[jest-message-util]` Print the inner errors of an `AggregateError` thrown inside a test ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[jest-message-util]` Indent nested `cause` and `AggregateError` sections of a test failure by one level per depth, so the nesting is legible instead of rendering flat ([#16316](https://github.com/jestjs/jest/pull/16316))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 - `[jest-circus, jest-jasmine2, jest-message-util]` Serialize the inner errors of an `AggregateError` into `failureMessages`, `retryReasons` and `unhandledErrors`, so `--json` output and reporter annotations include them ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[jest-config]` Add missing `findRelatedTests`, `outputFile`, and `replname` entries to `ValidConfig` so they no longer trigger spurious "Unknown option" warnings ([#16224](https://github.com/jestjs/jest/pull/16224))
 - `[jest-config]` Use `--config` for the global config when multiple `--projects` are specified ([#16273](https://github.com/jestjs/jest/pull/16273))
-- `[jest-environment-node, jest-util]` Only warn about a conflicting `globalsCleanup` mode when one was explicitly configured, and follow the mode that is actually in effect ([#16322](https://github.com/jestjs/jest/pull/16322))
+- `[jest-environment-node, jest-util]` Only warn about a conflicting `globalsCleanup` mode when one was explicitly configured, and follow the mode that is actually in effect ([#16323](https://github.com/jestjs/jest/pull/16323))
 - `[jest-haste-map]` Keep watch mode alive when an outside process briefly makes a file unreadable on Windows, instead of tearing the watcher down on `EPERM` ([#16295](https://github.com/jestjs/jest/pull/16295))
 - `[jest-message-util]` Print the inner errors of an `AggregateError` thrown inside a test ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[jest-message-util]` Indent nested `cause` and `AggregateError` sections of a test failure by one level per depth, so the nesting is legible instead of rendering flat ([#16316](https://github.com/jestjs/jest/pull/16316))

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -100,8 +100,10 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
   constructor(config: JestEnvironmentConfig, _context: EnvironmentContext) {
     const {projectConfig} = config;
 
-    const globalsCleanupMode = readGlobalsCleanupConfig(projectConfig);
-    initializeGarbageCollectionUtils(globalThis, globalsCleanupMode);
+    const globalsCleanupMode = initializeGarbageCollectionUtils(
+      globalThis,
+      readGlobalsCleanupConfig(projectConfig),
+    );
 
     this._globalProxy = new GlobalProxy();
     this.context = createContext(this._globalProxy.proxy());
@@ -370,7 +372,7 @@ class GlobalProxy implements ProxyHandler<typeof globalThis> {
 
 function readGlobalsCleanupConfig(
   projectConfig: Config.ProjectConfig,
-): DeletionMode {
+): DeletionMode | undefined {
   const rawConfig = projectConfig.testEnvironmentOptions.globalsCleanup;
   const config = rawConfig?.toString()?.toLowerCase();
   switch (config) {
@@ -386,7 +388,7 @@ function readGlobalsCleanupConfig(
           'Available options are: [on, soft, off]',
         );
       }
-      return 'soft';
+      return undefined;
     }
   }
 }

--- a/packages/jest-util/src/__tests__/garbage-collection-utils.test.ts
+++ b/packages/jest-util/src/__tests__/garbage-collection-utils.test.ts
@@ -5,7 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import {protectProperties} from '../garbage-collection-utils';
+import {
+  initializeGarbageCollectionUtils,
+  protectProperties,
+} from '../garbage-collection-utils';
 
 const omit = require('lodash').omit;
 
@@ -15,4 +18,47 @@ it('protection symbol doesnt leak', () => {
   expect(obj).toStrictEqual(obj);
   expect(omit(obj, 'a')).toStrictEqual({b: 2});
   expect({b: 2}).toStrictEqual(omit(obj, 'a'));
+});
+
+describe('initializeGarbageCollectionUtils', () => {
+  let globalObject: typeof globalThis;
+  let warn: jest.Spied<typeof console.warn>;
+
+  beforeEach(() => {
+    globalObject = {} as typeof globalThis;
+    warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  it('defaults to soft when no mode is given', () => {
+    expect(initializeGarbageCollectionUtils(globalObject)).toBe('soft');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('keeps the initialized mode when no mode is given', () => {
+    initializeGarbageCollectionUtils(globalObject, 'on');
+
+    expect(initializeGarbageCollectionUtils(globalObject)).toBe('on');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('does not warn when the same mode is given again', () => {
+    initializeGarbageCollectionUtils(globalObject, 'on');
+
+    expect(initializeGarbageCollectionUtils(globalObject, 'on')).toBe('on');
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('warns and keeps the initialized mode when a different mode is given', () => {
+    initializeGarbageCollectionUtils(globalObject, 'on');
+
+    expect(initializeGarbageCollectionUtils(globalObject, 'soft')).toBe('on');
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toMatch(
+      'garbage collection deletion mode already initialized',
+    );
+  });
 });

--- a/packages/jest-util/src/garbage-collection-utils.ts
+++ b/packages/jest-util/src/garbage-collection-utils.ts
@@ -30,26 +30,35 @@ export type DeletionMode = 'soft' | 'off' | 'on';
  * Initializes the garbage collection utils with the given deletion mode.
  *
  * @param globalObject the global object on which to store the deletion mode.
- * @param deletionMode the deletion mode to use.
+ * @param deletionMode the deletion mode to use, or `undefined` when none was configured.
+ *
+ * @returns the mode that is in effect, which is the already initialized one if there is one.
  */
 export function initializeGarbageCollectionUtils(
   globalObject: typeof globalThis,
-  deletionMode: DeletionMode,
-): void {
-  const currentMode = Reflect.get(globalObject, DELETION_MODE_SYMBOL);
-  if (currentMode && currentMode !== deletionMode) {
-    console.warn(
-      chalk.yellow(
-        [
-          '[jest-util] garbage collection deletion mode already initialized, ignoring new mode',
-          `  Current: '${currentMode}'`,
-          `  Given: '${deletionMode}'`,
-        ].join('\n'),
-      ),
-    );
-    return;
+  deletionMode?: DeletionMode,
+): DeletionMode {
+  const currentMode: DeletionMode | undefined = Reflect.get(
+    globalObject,
+    DELETION_MODE_SYMBOL,
+  );
+  if (currentMode) {
+    if (deletionMode !== undefined && currentMode !== deletionMode) {
+      console.warn(
+        chalk.yellow(
+          [
+            '[jest-util] garbage collection deletion mode already initialized, ignoring new mode',
+            `  Current: '${currentMode}'`,
+            `  Given: '${deletionMode}'`,
+          ].join('\n'),
+        ),
+      );
+    }
+    return currentMode;
   }
-  Reflect.set(globalObject, DELETION_MODE_SYMBOL, deletionMode);
+  const modeToUse = deletionMode ?? 'soft';
+  Reflect.set(globalObject, DELETION_MODE_SYMBOL, modeToUse);
+  return modeToUse;
 }
 
 /**


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

`readGlobalsCleanupConfig` turned an absent `globalsCleanup` option into 'soft', so an environment that never configured the option looked identical to one that deliberately disagreed with the mode the process was already in. Every environment created inside a running Jest process
- Jest's own tests, and any multi-project run where one project sets the option and another does not - printed the "already initialized" warning.

Make "not configured" representable: `initializeGarbageCollectionUtils` takes an optional mode and returns the mode in effect, and the 'soft' default moves there. The environment now uses that returned mode for `protectProperties` and `installCommonGlobals`, instead of continuing with a mode the process is not actually in.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

Green CI. Locally verified the annoying warning is no longer printed