### PR TITLE
fix: stop resolving lazy globals when setting up an environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 - `[jest-config]` Add missing `findRelatedTests`, `outputFile`, and `replname` entries to `ValidConfig` so they no longer trigger spurious "Unknown option" warnings ([#16224](https://github.com/jestjs/jest/pull/16224))
 - `[jest-config]` Use `--config` for the global config when multiple `--projects` are specified ([#16273](https://github.com/jestjs/jest/pull/16273))
 - `[jest-environment-node, jest-util]` Only warn about a conflicting `globalsCleanup` mode when one was explicitly configured, and follow the mode that is actually in effect ([#16323](https://github.com/jestjs/jest/pull/16323))
+- `[jest-environment-node, jest-util]` Stop resolving lazy globals when setting up an environment, so Node 26's builtin module globals are no longer loaded (and no longer emit their deprecation warnings) for every test file ([#16324](https://github.com/jestjs/jest/pull/16324))
 - `[jest-haste-map]` Keep watch mode alive when an outside process briefly makes a file unreadable on Windows, instead of tearing the watcher down on `EPERM` ([#16295](https://github.com/jestjs/jest/pull/16295))
 - `[jest-message-util]` Print the inner errors of an `AggregateError` thrown inside a test ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[jest-message-util]` Indent nested `cause` and `AggregateError` sections of a test failure by one level per depth, so the nesting is legible instead of rendering flat ([#16316](https://github.com/jestjs/jest/pull/16316))

--- a/packages/jest-environment-node/src/__tests__/node_environment.test.ts
+++ b/packages/jest-environment-node/src/__tests__/node_environment.test.ts
@@ -88,3 +88,88 @@ describe('NodeEnvironment', () => {
     expect(new TextEncoder().encode('abc')).toBeInstanceOf(Uint8Array);
   });
 });
+
+describe('globals cleanup', () => {
+  const makeEnvironment = (globalsCleanup: string) =>
+    new NodeEnvironment(
+      {
+        globalConfig: makeGlobalConfig(),
+        projectConfig: makeProjectConfig({
+          testEnvironmentOptions: {globalsCleanup},
+        }),
+      },
+      context,
+    );
+
+  it.each(['on', 'soft', 'off'])(
+    'leaves host globals intact after teardown in %s mode',
+    async globalsCleanup => {
+      const env = makeEnvironment(globalsCleanup);
+
+      await env.teardown();
+
+      expect(typeof process.nextTick).toBe('function');
+      expect(typeof console.log).toBe('function');
+      expect(typeof Object.prototype.hasOwnProperty).toBe('function');
+      expect(typeof Reflect.get).toBe('function');
+    },
+  );
+});
+
+describe('lazy globals', () => {
+  const property = 'lazyGlobalProbe';
+  let resolutions: number;
+
+  // Node 26 exposes the builtin modules as lazy globals, which must not be
+  // resolved just because an environment was constructed.
+  const loadEnvironmentWithLazyGlobal = () => {
+    resolutions = 0;
+    Object.defineProperty(globalThis, property, {
+      configurable: true,
+      enumerable: false,
+      get() {
+        resolutions++;
+        return {module: property};
+      },
+    });
+
+    let Environment: typeof NodeEnvironment;
+    jest.isolateModules(() => {
+      Environment = require('../').default;
+    });
+    return Environment!;
+  };
+
+  afterEach(() => {
+    // @ts-expect-error: probe property
+    delete globalThis[property];
+  });
+
+  it('does not resolve a lazy global when constructing an environment', () => {
+    const Environment = loadEnvironmentWithLazyGlobal();
+
+    const env = new Environment(
+      {globalConfig: makeGlobalConfig(), projectConfig: makeProjectConfig()},
+      context,
+    );
+
+    expect(env.global).toBeDefined();
+    expect(resolutions).toBe(0);
+    expect(
+      Object.getOwnPropertyDescriptor(globalThis, property),
+    ).toHaveProperty('get');
+  });
+
+  it('resolves a lazy global once it is read in the sandbox', () => {
+    const Environment = loadEnvironmentWithLazyGlobal();
+
+    const env = new Environment(
+      {globalConfig: makeGlobalConfig(), projectConfig: makeProjectConfig()},
+      context,
+    );
+
+    // @ts-expect-error: probe property
+    expect(env.global[property]).toEqual({module: property});
+    expect(resolutions).toBe(1);
+  });
+});

--- a/packages/jest-environment-node/src/index.ts
+++ b/packages/jest-environment-node/src/index.ts
@@ -117,8 +117,12 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
       Object.getOwnPropertyNames(global) as GlobalProperties,
     );
     for (const [nodeGlobalsKey, descriptor] of nodeGlobals) {
-      if (!storageGlobals.has(nodeGlobalsKey as string)) {
-        protectProperties(globalThis[nodeGlobalsKey]);
+      // Reading an accessor global resolves it - on Node 26 the builtin modules
+      // are lazy globals, so this would load every one of them (and emit their
+      // deprecation warnings) for each environment. Those are protected when the
+      // sandbox resolves them instead.
+      if ('value' in descriptor) {
+        protectProperties(descriptor.value);
       }
       if (!contextGlobals.has(nodeGlobalsKey)) {
         if (storageGlobals.has(nodeGlobalsKey as string)) {
@@ -141,6 +145,8 @@ export default class NodeEnvironment implements JestEnvironment<Timer> {
             enumerable: descriptor.enumerable,
             get() {
               const value = globalThis[nodeGlobalsKey];
+
+              protectProperties(value);
 
               // override lazy getter
               Object.defineProperty(global, nodeGlobalsKey, {

--- a/packages/jest-util/src/__tests__/garbage-collection-utils.test.ts
+++ b/packages/jest-util/src/__tests__/garbage-collection-utils.test.ts
@@ -20,6 +20,46 @@ it('protection symbol doesnt leak', () => {
   expect({b: 2}).toStrictEqual(omit(obj, 'a'));
 });
 
+describe('protectProperties', () => {
+  // `Object.prototype` itself gets protected, so a plain object inherits that
+  // protection and would not be walked at all.
+  const makeUnprotectedObject = <T extends object>(properties: T) =>
+    Object.assign(Object.create(null) as T, properties);
+
+  it('does not resolve accessors while protecting nested values', () => {
+    let resolutions = 0;
+    const obj = Object.create(null) as {lazy: unknown};
+    Object.defineProperty(obj, 'lazy', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        resolutions++;
+        return {};
+      },
+    });
+
+    protectProperties(obj);
+
+    expect(resolutions).toBe(0);
+  });
+
+  it('skips values that cannot be inspected', () => {
+    const throwOnInspection = () => {
+      throw new Error('cannot inspect');
+    };
+    const obj = makeUnprotectedObject({
+      nested: new Proxy(Object.create(null), {
+        defineProperty: throwOnInspection,
+        getOwnPropertyDescriptor: throwOnInspection,
+        has: throwOnInspection,
+        ownKeys: throwOnInspection,
+      }),
+    });
+
+    expect(() => protectProperties(obj)).not.toThrow();
+  });
+});
+
 describe('initializeGarbageCollectionUtils', () => {
   let globalObject: typeof globalThis;
   let warn: jest.Spied<typeof console.warn>;

--- a/packages/jest-util/src/garbage-collection-utils.ts
+++ b/packages/jest-util/src/garbage-collection-utils.ts
@@ -113,12 +113,17 @@ export function protectProperties<T>(
       writable: true,
     });
     for (const key of getProtectedKeys(value, properties)) {
-      // Reading an accessor resolves it, which both triggers deprecation
-      // warnings and defeats lazy globals. Its value is protected once
-      // whoever owns it resolves it.
-      const descriptor = Reflect.getOwnPropertyDescriptor(value, key);
-      if (descriptor && 'value' in descriptor) {
-        protectProperties(descriptor.value, [], depth - 1);
+      try {
+        // Reading an accessor resolves it, which both triggers deprecation
+        // warnings and defeats lazy globals. Its value is protected once
+        // whoever owns it resolves it.
+        const descriptor = Reflect.getOwnPropertyDescriptor(value, key);
+        if (descriptor && 'value' in descriptor) {
+          protectProperties(descriptor.value, [], depth - 1);
+        }
+      } catch {
+        // Inspecting exotic objects might fail, e.g. a proxy with a throwing trap.
+        // Instead of failing the entire process, we will skip the property.
       }
     }
     return result;

--- a/packages/jest-util/src/garbage-collection-utils.ts
+++ b/packages/jest-util/src/garbage-collection-utils.ts
@@ -101,38 +101,29 @@ export function protectProperties<T>(
     return false;
   }
 
-  // Reflect.get may cause deprecation warnings, so we disable them temporarily
-  const originalEmitWarning = process.emitWarning;
-
-  try {
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    process.emitWarning = () => {};
-    if (
-      depth >= 0 &&
-      canDeleteProperties(value) &&
-      !Reflect.has(value, PROTECT_SYMBOL)
-    ) {
-      const result = Reflect.defineProperty(value, PROTECT_SYMBOL, {
-        configurable: true,
-        enumerable: false,
-        value: properties,
-        writable: true,
-      });
-      for (const key of getProtectedKeys(value, properties)) {
-        try {
-          const nested = Reflect.get(value, key);
-          protectProperties(nested, [], depth - 1);
-        } catch {
-          // Reflect.get might fail in certain edge-cases
-          // Instead of failing the entire process, we will skip the property.
-        }
+  if (
+    depth >= 0 &&
+    canDeleteProperties(value) &&
+    !Reflect.has(value, PROTECT_SYMBOL)
+  ) {
+    const result = Reflect.defineProperty(value, PROTECT_SYMBOL, {
+      configurable: true,
+      enumerable: false,
+      value: properties,
+      writable: true,
+    });
+    for (const key of getProtectedKeys(value, properties)) {
+      // Reading an accessor resolves it, which both triggers deprecation
+      // warnings and defeats lazy globals. Its value is protected once
+      // whoever owns it resolves it.
+      const descriptor = Reflect.getOwnPropertyDescriptor(value, key);
+      if (descriptor && 'value' in descriptor) {
+        protectProperties(descriptor.value, [], depth - 1);
       }
-      return result;
     }
-    return false;
-  } finally {
-    process.emitWarning = originalEmitWarning;
+    return result;
   }
+  return false;
 }
 
 /**


### PR DESCRIPTION
## Summary

Node 26 exposes the builtin modules as lazy accessor globals (`fs`, `punycode`, `sys`, `wasi`, … — 48 of the 186 globals on my machine). Setting up a `NodeEnvironment` read every global to hand it to `protectProperties`, which resolved all of them. So every test file loaded every builtin module, and the ones that warn on load printed their warnings:

```
(node:51298) [DEP0040] DeprecationWarning: The `punycode` module is deprecated. Please use a userland alternative instead.
(node:51298) [DEP0025] DeprecationWarning: sys is deprecated. Use `node:util` instead.
(node:51298) ExperimentalWarning: WASI is an experimental feature and might change at any time
```

Two places walked globals eagerly, and both now skip accessors:

- the loop over the host globals in `NodeEnvironment`'s constructor, which now reads the value off the descriptor it already has instead of off `globalThis`
- `protectProperties`' recursion into nested values, which resolved the sandbox's own lazy globals (each one reading through to the host global)

Protection itself is unchanged for anything a test can touch: the sandbox getter that resolves a lazy global protects the value it resolved, so a global is protected exactly when it materializes rather than up front.

`protectProperties` no longer mutes `process.emitWarning` around its recursion either — that existed only because the recursion invoked getters, which it no longer does. It still skips properties it cannot inspect: the old `try/catch` wrapped the recursive call, so it covered the whole subtree walk rather than just the getter read, and a nested proxy with a throwing `ownKeys`, `getOwnPropertyDescriptor` or `defineProperty` trap still needs to be skipped rather than abort protection.

## Test plan

`packages/jest-environment-node/src/__tests__/node_environment.test.ts` gains a lazy-global probe: it installs an accessor global, loads a fresh copy of the environment module (so the global is part of its `nodeGlobals` snapshot), and asserts that constructing an environment never invokes the getter — plus that reading the global through the sandbox still resolves it, exactly once. It also gains a check that host `process`, `console`, `Object.prototype` and `Reflect` survive teardown under each `globalsCleanup` mode.

`packages/jest-util/src/__tests__/garbage-collection-utils.test.ts` covers `protectProperties` directly: it does not resolve accessors while walking nested values, and it does not throw on a value it cannot inspect.

Manually on Node 26.7.0, constructing an environment and nothing else:

```js
new NodeEnvironment(config, context);
```

before this change prints the three warnings above; after it, nothing.

`yarn jest packages` is green (254 suites), as are `yarn lint`, `yarn typecheck:tests` and `yarn check-changelog`.