### PR TITLE
fix: detect Jest's own stack frames without assuming a directory name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - `[jest-message-util]` Print the inner errors of an `AggregateError` thrown inside a test ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[jest-message-util]` Indent nested `cause` and `AggregateError` sections of a test failure by one level per depth, so the nesting is legible instead of rendering flat ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[jest-message-util]` Color stack traces line by line so blank lines stay blank ([#16316](https://github.com/jestjs/jest/pull/16316))
+- `[jest-message-util]` Detect Jest's own frames by package name rather than a hardcoded `jest/packages` path, and cover `@jest/*` packages, so stack traces and code frames point at user code ([#16326](https://github.com/jestjs/jest/pull/16326))
 - `[jest-mock]` `mockResolvedValue` / `mockRejectedValue` now see all overload return types, so a Promise-returning overload survives even when a later overload returns a non-Promise (e.g. `pg.Client['end']`) ([#16237](https://github.com/jestjs/jest/pull/16237))
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
 - `[jest-mock]` Remove the leftover own accessor descriptor when restoring a `spyOn` of an inherited getter or setter, so the instance keeps reflecting the prototype ([#16226](https://github.com/jestjs/jest/pull/16226))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 - `[jest-message-util]` Print the inner errors of an `AggregateError` thrown inside a test ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[jest-message-util]` Indent nested `cause` and `AggregateError` sections of a test failure by one level per depth, so the nesting is legible instead of rendering flat ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[jest-message-util]` Color stack traces line by line so blank lines stay blank ([#16316](https://github.com/jestjs/jest/pull/16316))
-- `[jest-message-util]` Detect Jest's own frames by package name rather than a hardcoded `jest/packages` path, and cover `@jest/*` packages, so stack traces and code frames point at user code ([#16326](https://github.com/jestjs/jest/pull/16326))
+- `[jest-message-util]` Detect Jest's own frames without assuming the checkout directory's name, and cover `@jest/*` packages, so stack traces and code frames point at user code ([#16326](https://github.com/jestjs/jest/pull/16326))
 - `[jest-mock]` `mockResolvedValue` / `mockRejectedValue` now see all overload return types, so a Promise-returning overload survives even when a later overload returns a non-Promise (e.g. `pg.Client['end']`) ([#16237](https://github.com/jestjs/jest/pull/16237))
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
 - `[jest-mock]` Remove the leftover own accessor descriptor when restoring a `spyOn` of an inherited getter or setter, so the instance keeps reflecting the prototype ([#16226](https://github.com/jestjs/jest/pull/16226))

--- a/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
+++ b/packages/jest-message-util/src/__tests__/__snapshots__/messages.test.ts.snap
@@ -181,12 +181,12 @@ exports[`should return the error cause if there is one 1`] = `
 
     Test exception
 
-      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:567:17)</intensity>
+      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:570:17)</intensity>
 
     Cause:
      Cause Error
 
-          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:568:12)</intensity>
+          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:571:12)</intensity>
 "
 `;
 
@@ -195,16 +195,16 @@ exports[`should return the inner errors of an AggregateError 1`] = `
 
     AggregateError:
 
-      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:585:20)</intensity>
+      <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:588:20)</intensity>
 
     Errors contained in AggregateError:
      Err 1
 
-          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:585:40)</intensity>
+          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:588:40)</intensity>
 
      Err 2
 
-          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:585:60)</intensity>
+          <dim>at Object.<anonymous> (</intensity>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:588:60)</intensity>
 "
 `;
 
@@ -213,16 +213,16 @@ exports[`should return the inner errors of an AggregateError test failure with t
 
     AggregateError:
 
-<dim>      <dim>at Object.<anonymous> (</intensity><dim>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:629:20)</intensity><dim></intensity>
+<dim>      <dim>at Object.<anonymous> (</intensity><dim>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:632:20)</intensity><dim></intensity>
 
     Errors contained in AggregateError:
         inner reason A
 
-    <dim>      <dim>at Object.<anonymous> (</intensity><dim>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:630:5)</intensity><dim></intensity>
+    <dim>      <dim>at Object.<anonymous> (</intensity><dim>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:633:5)</intensity><dim></intensity>
 
         inner reason B
 
-    <dim>      <dim>at Object.<anonymous> (</intensity><dim>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:631:5)</intensity><dim></intensity>
+    <dim>      <dim>at Object.<anonymous> (</intensity><dim>packages/jest-message-util/src/__tests__/messages.test.ts<dim>:634:5)</intensity><dim></intensity>
 "
 `;
 

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -6,6 +6,8 @@
  *
  */
 
+import * as path from 'path';
+import {stripVTControlCharacters} from 'util';
 import {readFileSync} from 'graceful-fs';
 import slash from 'slash';
 import tempy from 'tempy';
@@ -15,6 +17,7 @@ import {
   formatExecError,
   formatResultsErrors,
   formatStackTrace,
+  getStackTraceLines,
   getTopFrame,
   hasNestedErrors,
 } from '..';
@@ -959,5 +962,73 @@ describe('cyclic errors in the styled renderers', () => {
     ['a self-referential AggregateError', buildCyclicAggregate],
   ])('formatResultsErrors survives %s', (_label, build) => {
     expect(() => formatAggregateErrorFailure(build(), true)).not.toThrow();
+  });
+});
+
+describe('frame classification', () => {
+  const checkoutPackagesDir = path.resolve(__dirname, '..', '..', '..');
+  const testFile = `${slash(rootDir)}/__tests__/x.test.js`;
+  const frameFor = (file: string) => `    at someFn (${file}:1:1)`;
+
+  const internalFiles: Array<[string, string]> = [
+    ['a published jest package', '/app/node_modules/jest-circus/build/run.js'],
+    [
+      'a scoped @jest package',
+      '/app/node_modules/@jest/globals/build/index.js',
+    ],
+    [
+      'a third-party jest integration',
+      '/app/node_modules/babel-jest/build/index.js',
+    ],
+    [
+      'a package of this checkout',
+      `${checkoutPackagesDir}/expect/build/index.js`,
+    ],
+    [
+      'a windows-style path',
+      String.raw`C:\app\node_modules\@jest\globals\build\index.js`,
+    ],
+  ];
+
+  const externalFiles: Array<[string, string]> = [
+    [
+      'build output under a jest-ish directory',
+      '/home/me/jest-helpers/src/util/build/app.js',
+    ],
+    [
+      'a monorepo named after jest',
+      '/work/jest-clone/packages/app/__tests__/x.test.js',
+    ],
+  ];
+
+  const format = (...files: Array<string>) =>
+    stripVTControlCharacters(
+      formatStackTrace(
+        ['Error: boom', ...files.map(frameFor)].join('\n'),
+        {rootDir, testMatch: []},
+        {noStackTrace: false},
+      ),
+    );
+
+  beforeEach(() => {
+    jest.mocked(readFileSync).mockImplementation(file => `source of ${file}`);
+  });
+
+  it.each(internalFiles)('drops a frame in %s', (_label, file) => {
+    // the first frame of a stack is kept even when it is Jest's own, so the
+    // frame under test needs one ahead of it
+    expect(format(testFile, file)).not.toContain(path.relative(rootDir, file));
+  });
+
+  it.each(externalFiles)('keeps a frame in %s', (_label, file) => {
+    expect(format(testFile, file)).toContain(path.relative(rootDir, file));
+  });
+
+  it.each(internalFiles)('renders no code frame for %s', (_label, file) => {
+    expect(format(file, testFile)).toContain(`source of ${testFile}`);
+  });
+
+  it.each(externalFiles)('renders the code frame of %s', (_label, file) => {
+    expect(format(file, testFile)).toContain(`source of ${file}`);
   });
 });

--- a/packages/jest-message-util/src/__tests__/messages.test.ts
+++ b/packages/jest-message-util/src/__tests__/messages.test.ts
@@ -982,7 +982,7 @@ describe('frame classification', () => {
     ],
     [
       'a package of this checkout',
-      `${checkoutPackagesDir}/expect/build/index.js`,
+      path.join(checkoutPackagesDir, 'expect', 'build', 'index.js'),
     ],
     [
       'a windows-style path',
@@ -1017,11 +1017,15 @@ describe('frame classification', () => {
   it.each(internalFiles)('drops a frame in %s', (_label, file) => {
     // the first frame of a stack is kept even when it is Jest's own, so the
     // frame under test needs one ahead of it
-    expect(format(testFile, file)).not.toContain(path.relative(rootDir, file));
+    expect(format(testFile, file)).not.toContain(
+      slash(path.relative(rootDir, file)),
+    );
   });
 
   it.each(externalFiles)('keeps a frame in %s', (_label, file) => {
-    expect(format(testFile, file)).toContain(path.relative(rootDir, file));
+    expect(format(testFile, file)).toContain(
+      slash(path.relative(rootDir, file)),
+    );
   });
 
   it.each(internalFiles)('renders no code frame for %s', (_label, file) => {

--- a/packages/jest-message-util/src/__tests__/tsconfig.json
+++ b/packages/jest-message-util/src/__tests__/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "extends": "../../../../tsconfig.test.json",
+  "compilerOptions": {
+    "types": ["@jest/test-globals", "node"]
+  },
   "include": ["./**/*"],
   "references": [{"path": "../../"}]
 }

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -43,17 +43,30 @@ export type StackTraceOptions = {
 };
 
 const PATH_NODE_MODULES = `${path.sep}node_modules${path.sep}`;
-const PATH_JEST_PACKAGES = `${path.sep}jest${path.sep}packages${path.sep}`;
+// In a checkout of this repo the packages sit next to each other, and frames
+// from any of them — not just the `jest-` prefixed ones — are internal. Derive
+// that directory rather than matching its name, so it holds whatever the
+// checkout is called. An install resolves to `node_modules`, covered above.
+const ownGrandparentDir = path.resolve(__dirname, '..', '..');
+const PATH_JEST_PACKAGES =
+  path.basename(ownGrandparentDir) === 'packages'
+    ? ownGrandparentDir + path.sep
+    : null;
 
 // filter for noisy stack trace lines
 const JASMINE_IGNORE =
   /^\s+at(?:(?:.jasmine-)|\s+jasmine\.buildExpectationResult)/;
 const JEST_INTERNALS_IGNORE =
-  /^\s+at.*?jest(-.*?)?(\/|\\)(build|node_modules|packages)(\/|\\)/;
-const ANONYMOUS_FN_IGNORE = /^\s+at <anonymous>.*$/;
-const ANONYMOUS_PROMISE_IGNORE = /^\s+at (new )?Promise \(<anonymous>\).*$/;
-const ANONYMOUS_GENERATOR_IGNORE = /^\s+at Generator.next \(<anonymous>\).*$/;
-const NATIVE_NEXT_IGNORE = /^\s+at next \(native\).*$/;
+  /^\s+at(?:.*[/\\])?(?:@jest[/\\][^/\\]+|[^/\\]*jest[^/\\]*)[/\\](?:build|node_modules|packages)[/\\]/;
+// `packages` matches this repo's own checkout, so it is too broad to decide
+// where a code frame points: a user monorepo named `jest-something` would lose
+// every frame and end up without one.
+const JEST_PACKAGE_BUILD_IGNORE =
+  /^\s+at(?:.*[/\\])?(?:@jest[/\\][^/\\]+|[^/\\]*jest[^/\\]*)[/\\](?:build|node_modules)[/\\]/;
+const ANONYMOUS_FN_IGNORE = /^\s+at <anonymous>/;
+const ANONYMOUS_PROMISE_IGNORE = /^\s+at (?:new )?Promise \(<anonymous>\)/;
+const ANONYMOUS_GENERATOR_IGNORE = /^\s+at Generator\.next \(<anonymous>\)/;
+const NATIVE_NEXT_IGNORE = /^\s+at next \(native\)/;
 const TITLE_INDENT = '  ';
 const MESSAGE_INDENT = '    ';
 const STACK_INDENT = '      ';
@@ -357,7 +370,11 @@ export function getStackTraceLines(
 
 export function getTopFrame(lines: Array<string>): Frame | null {
   for (const line of lines) {
-    if (line.includes(PATH_NODE_MODULES) || line.includes(PATH_JEST_PACKAGES)) {
+    if (
+      line.includes(PATH_NODE_MODULES) ||
+      (PATH_JEST_PACKAGES !== null && line.includes(PATH_JEST_PACKAGES)) ||
+      JEST_PACKAGE_BUILD_IGNORE.test(line)
+    ) {
       continue;
     }
 

--- a/packages/jest-message-util/src/index.ts
+++ b/packages/jest-message-util/src/index.ts
@@ -47,21 +47,16 @@ const PATH_NODE_MODULES = `${path.sep}node_modules${path.sep}`;
 // from any of them — not just the `jest-` prefixed ones — are internal. Derive
 // that directory rather than matching its name, so it holds whatever the
 // checkout is called. An install resolves to `node_modules`, covered above.
-const ownGrandparentDir = path.resolve(__dirname, '..', '..');
+const maybePackagesDir = path.resolve(__dirname, '..', '..');
 const PATH_JEST_PACKAGES =
-  path.basename(ownGrandparentDir) === 'packages'
-    ? ownGrandparentDir + path.sep
+  path.basename(maybePackagesDir) === 'packages'
+    ? maybePackagesDir + path.sep
     : null;
 
 // filter for noisy stack trace lines
 const JASMINE_IGNORE =
   /^\s+at(?:(?:.jasmine-)|\s+jasmine\.buildExpectationResult)/;
 const JEST_INTERNALS_IGNORE =
-  /^\s+at(?:.*[/\\])?(?:@jest[/\\][^/\\]+|[^/\\]*jest[^/\\]*)[/\\](?:build|node_modules|packages)[/\\]/;
-// `packages` matches this repo's own checkout, so it is too broad to decide
-// where a code frame points: a user monorepo named `jest-something` would lose
-// every frame and end up without one.
-const JEST_PACKAGE_BUILD_IGNORE =
   /^\s+at(?:.*[/\\])?(?:@jest[/\\][^/\\]+|[^/\\]*jest[^/\\]*)[/\\](?:build|node_modules)[/\\]/;
 const ANONYMOUS_FN_IGNORE = /^\s+at <anonymous>/;
 const ANONYMOUS_PROMISE_IGNORE = /^\s+at (?:new )?Promise \(<anonymous>\)/;
@@ -88,6 +83,10 @@ const colorStackLines = (stack: string): string =>
     .split('\n')
     .map(line => (line === '' ? line : STACK_TRACE_COLOR(line)))
     .join('\n');
+
+const isJestInternalFrame = (line: string) =>
+  JEST_INTERNALS_IGNORE.test(line) ||
+  (PATH_JEST_PACKAGES !== null && line.includes(PATH_JEST_PACKAGES));
 
 const trim = (string: string) => (string || '').trim();
 
@@ -328,7 +327,7 @@ const removeInternalStackEntries = (
       return false;
     }
 
-    if (JEST_INTERNALS_IGNORE.test(line)) {
+    if (isJestInternalFrame(line)) {
       return false;
     }
 
@@ -370,11 +369,7 @@ export function getStackTraceLines(
 
 export function getTopFrame(lines: Array<string>): Frame | null {
   for (const line of lines) {
-    if (
-      line.includes(PATH_NODE_MODULES) ||
-      (PATH_JEST_PACKAGES !== null && line.includes(PATH_JEST_PACKAGES)) ||
-      JEST_PACKAGE_BUILD_IGNORE.test(line)
-    ) {
+    if (line.includes(PATH_NODE_MODULES) || isJestInternalFrame(line)) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

Two constants decided which stack frames belong to Jest, and both assumed something about where Jest lives on disk.

`getTopFrame` — which picks the frame the code frame renders — skipped anything under `node_modules` or under a literal `/jest/packages/` path. That only matches when the checkout directory is named `jest`. Since `removeInternalStackEntries` deliberately keeps the first stack line even when it comes from Jest, in a worktree, a fork, or a vendored copy that frame won, and the code frame rendered Jest's own build output instead of the test:

```
  ● require after done

    ReferenceError: You are trying to `require` a file outside of the scope of the test code.

      2708 |   throwIfBetweenTests(message) {
      2709 |     if (this.state === 'betweenTests') {
    > 2710 |       throw new ReferenceError(message);
           |             ^
      2711 |     }
```

`JEST_INTERNALS_IGNORE` — which drops internal frames from printed stacks — let its optional `-.*?` suffix run across path separators, so any user directory starting with `jest` above a `build/`, `packages/` or `node_modules/` segment counted as internal. A frame in `/home/me/jest-helpers/src/util/build/app.js` was silently dropped.

Both now ask one question through `isJestInternalFrame`: is this frame in a `jest*` or `@jest/*` package's build output, or under this checkout's packages directory?

The checkout's packages directory is derived (`path.resolve(__dirname, '..', '..')`, used only when its basename is `packages`) rather than matched by name. That keeps first-party packages without a `jest` prefix — `expect`, `pretty-format` — internal whatever the directory is called, which is what the old literal was really doing, while leaving a user monorepo named `jest-something` alone. In an install the same expression lands on `node_modules`, and in a browser bundle webpack mocks `__dirname` to `/`, so the guard declines and matching falls back to the package-name regex.

The regex itself now binds the package segment to a single path component and matches the `@jest/*` scoped packages it never covered. Names that merely contain `jest` — `babel-jest`, `ts-jest`, `jest-preset-angular` — keep matching as before.

The e2e suites asserting on these code frames only passed because CI checks out into `jest/`.

## Test plan

Behaviour was diffed frame by frame against `main`, driving the built package directly:

| frame | stack filter | code frame |
| --- | --- | --- |
| user test file | keep → keep | keep → keep |
| user code under a `jest`-ish dir | **drop → keep** | keep → keep |
| user monorepo named `jest-clone` | **drop → keep** | keep → keep |
| `node_modules/jest-circus/build/…` | drop → drop | drop → drop |
| `node_modules/@jest/globals/build/…` | **keep → drop** | drop → drop |
| `node_modules/babel-jest/build/…` | drop → drop | drop → drop |
| this checkout, `packages/jest-runtime/build/…` | drop → drop | **keep → drop** |
| this checkout, `packages/expect/build/…` | drop → drop | **keep → drop** |

Every change is intended: `@jest/*` frames are now recognized, user code under a `jest`-ish directory is left alone, and the code frame stops landing on Jest's own build output.

Full suite (`yarn jest`): 4 failures, all of which reproduce with these changes reverted — `showConfig` carries its own hardcoded `jest`-directory normalizer, and `jestChangedFiles` / `onlyChanged` want `hg`/`sl` installed. `nativeEsm` fails the same way before and after.

`yarn typecheck:tests` exits 0. `jest-message-util`, `jest-snapshot`, `jest-reporters`, `jest-circus` and the `stackTrace`, `toMatchInlineSnapshot`, `failures` and teardown e2e suites pass — 478 tests, covering all three callers of `getTopFrame`: `formatStackTrace`, `GitHubActionsReporter`, and the inline-snapshot frame lookup in `jest-snapshot`'s `State`. That last one is the reason the code frame keeps a narrower notion of "internal" than a checkout-wide one would give: a project named `jest-something` would otherwise lose every candidate frame and fail `toMatchInlineSnapshot` with "Couldn't infer stack frame".