### PR TITLE
[Bug]: Untested files are missing when collecting coverage in multi-project configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixes
 
+- `[jest-reporters]` Find untested files matching `collectCoverageFrom` that live outside every project's `hasteFS` in a multi-project configuration ([#16328](https://github.com/jestjs/jest/pull/16328))
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[jest-circus, jest-jasmine2, jest-message-util]` Serialize the inner errors of an `AggregateError` into `failureMessages`, `retryReasons` and `unhandledErrors`, so `--json` output and reporter annotations include them ([#16316](https://github.com/jestjs/jest/pull/16316))

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -111,20 +111,45 @@ export default class CoverageReporter extends BaseReporter {
   ): Promise<void> {
     const files: Array<{config: Config.ProjectConfig; path: string}> = [];
 
-    for (const context of testContexts) {
-      const config = context.config;
-      if (
-        this._globalConfig.collectCoverageFrom &&
-        this._globalConfig.collectCoverageFrom.length > 0
-      ) {
+    if (
+      this._globalConfig.collectCoverageFrom &&
+      this._globalConfig.collectCoverageFrom.length > 0
+    ) {
+      const seenFiles = new Set<string>();
+      const contexts = [...testContexts];
+
+      for (const context of contexts) {
+        const config = context.config;
         for (const filePath of context.hasteFS.matchFilesWithGlob(
           this._globalConfig.collectCoverageFrom,
           this._globalConfig.rootDir,
-        ))
-          files.push({
-            config,
-            path: filePath,
-          });
+        )) {
+          if (!seenFiles.has(filePath)) {
+            seenFiles.add(filePath);
+            files.push({config, path: filePath});
+          }
+        }
+      }
+
+      // Also find files matching collectCoverageFrom that are not in any
+      // project's hasteFS (e.g. shared files outside all project roots in a
+      // multi-project setup).
+      if (contexts.length > 0) {
+        const firstConfig = contexts[0].config;
+        const globbedFiles = await glob(
+          this._globalConfig.collectCoverageFrom,
+          {
+            absolute: true,
+            cwd: this._globalConfig.rootDir,
+            windowsPathsNoEscape: true,
+          },
+        );
+        for (const filePath of globbedFiles) {
+          if (!seenFiles.has(filePath)) {
+            seenFiles.add(filePath);
+            files.push({config: firstConfig, path: filePath});
+          }
+        }
       }
     }
 


### PR DESCRIPTION
add glob-based fallback in `_addUntestedFiles` to find untested files outside all project roots in multi-project coverage collection

Found via automated repo scanning, fix written and reviewed before opening.
