### PR TITLE
[Bug]: failure of import of ESM package when called from CJS project

### DIFF
--- a/packages/jest-runtime/src/internals/CjsLoader.ts
+++ b/packages/jest-runtime/src/internals/CjsLoader.ts
@@ -91,7 +91,19 @@ export class CjsLoader {
     }
 
     if (!modulePath) {
-      modulePath = this.resolution.resolveCjs(from, moduleName);
+      try {
+        modulePath = this.resolution.resolveCjs(from, moduleName);
+      } catch (cjsResolveError) {
+        // ESM-only packages (with only an "import" export condition and no
+        // "require"/"default" fallback) cannot be resolved with CJS conditions.
+        // On Node 24.9+ we can load them via the sync ESM graph walker, so
+        // retry with ESM conditions before giving up.
+        if (supportsSyncEvaluate) {
+          modulePath = this.resolution.resolveEsm(from, moduleName);
+        } else {
+          throw cjsResolveError;
+        }
+      }
     }
 
     // On Node 24.9+ we can require() ESM natively. On older Node, fall

--- a/packages/jest-runtime/src/internals/__tests__/CjsLoader.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/CjsLoader.test.ts
@@ -220,6 +220,32 @@ describe('CjsLoader.requireModule', () => {
   );
 
   testWithSyncEsm(
+    'falls back to ESM resolution when CJS resolution fails for an ESM-only package',
+    () => {
+      const {loader, stubs} = makeLoader({
+        registries: {
+          getActiveCjsRegistry: jest.fn(() => new Map()),
+          getActiveEsmRegistry: jest.fn(() => new Map()),
+        } as unknown as jest.Mocked<ModuleRegistries>,
+        resolution: {
+          getCjsMockModule: jest.fn(() => null),
+          getModule: jest.fn(() => null),
+          isCoreModule: jest.fn(() => false),
+          resolveCjs: jest.fn(() => {
+            throw new Error('Package path . is not exported');
+          }),
+          resolveEsm: jest.fn(() => '/m.mjs'),
+          shouldLoadAsEsm: jest.fn(() => true),
+        } as unknown as jest.Mocked<Resolution>,
+      });
+
+      stubs.requireEsm.mockReturnValue('esm-result' as any);
+      expect(loader.requireModule('/from.js', 'esm-only-pkg')).toBe('esm-result');
+      expect(stubs.requireEsm).toHaveBeenCalledWith('/m.mjs');
+    },
+  );
+
+  testWithSyncEsm(
     'returns the raw namespace on the ESM cache-hit fast path when there is no "module.exports" export',
     () => {
       const namespace = {named: 'x'};


### PR DESCRIPTION
in `CjsLoader.requireModule`, catch `resolveCjs` failures and retry with `resolveEsm` when `supportsSyncEvaluate` is true, allowing `require()` of ESM-only packages (with only `"import"` export condition) to work on Node 24.9+

Found via automated repo scanning, fix written and reviewed before opening.
