### PR TITLE
fix(jest-resolve): load a user resolver written as an ES module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - `[jest-mock]` Remove the leftover own accessor descriptor when restoring a `spyOn` of an inherited getter or setter, so the instance keeps reflecting the prototype ([#16226](https://github.com/jestjs/jest/pull/16226))
 - `[jest-resolve]` Keep virtual and ordinary mock module IDs isolated across test files ([#16296](https://github.com/jestjs/jest/pull/16296))
 - `[jest-resolve]` Guard missing `require.resolve.paths` ([#16052](https://github.com/jestjs/jest/pull/16052))
-- `[jest-resolve]` Load a user resolver written as an ES module, whose resolver arrives on `default` ([#PRNUM](https://github.com/jestjs/jest/pull/PRNUM))
+- `[jest-resolve]` Load a user resolver written as an ES module, whose resolver arrives on `default` ([#16332](https://github.com/jestjs/jest/pull/16332))
 - `[@jest/source-map]` Keep source map sources that name a scheme, such as `webpack:///`, instead of resolving them into a path that does not exist ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[@jest/source-map]` Look up `--testLocationInResults` positions at the right column, and keep a mapping to the first column instead of discarding it ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[@jest/source-map]` Warn when a source map cannot be parsed, instead of silently leaving its frames untranslated ([#16327](https://github.com/jestjs/jest/pull/16327))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - `[jest-mock]` Remove the leftover own accessor descriptor when restoring a `spyOn` of an inherited getter or setter, so the instance keeps reflecting the prototype ([#16226](https://github.com/jestjs/jest/pull/16226))
 - `[jest-resolve]` Keep virtual and ordinary mock module IDs isolated across test files ([#16296](https://github.com/jestjs/jest/pull/16296))
 - `[jest-resolve]` Guard missing `require.resolve.paths` ([#16052](https://github.com/jestjs/jest/pull/16052))
-- `[jest-resolve, jest-config, jest-runner]` Support a user resolver written as an ES module, including one with a top-level await, by loading it ahead of resolution ([#16332](https://github.com/jestjs/jest/pull/16332))
+- `[jest-resolve, jest-config, jest-runner]` Support a user resolver written as an ES module ([#16332](https://github.com/jestjs/jest/pull/16332))
 - `[@jest/source-map]` Keep source map sources that name a scheme, such as `webpack:///`, instead of resolving them into a path that does not exist ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[@jest/source-map]` Look up `--testLocationInResults` positions at the right column, and keep a mapping to the first column instead of discarding it ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[@jest/source-map]` Warn when a source map cannot be parsed, instead of silently leaving its frames untranslated ([#16327](https://github.com/jestjs/jest/pull/16327))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,7 @@
 - `[jest-mock]` Remove the leftover own accessor descriptor when restoring a `spyOn` of an inherited getter or setter, so the instance keeps reflecting the prototype ([#16226](https://github.com/jestjs/jest/pull/16226))
 - `[jest-resolve]` Keep virtual and ordinary mock module IDs isolated across test files ([#16296](https://github.com/jestjs/jest/pull/16296))
 - `[jest-resolve]` Guard missing `require.resolve.paths` ([#16052](https://github.com/jestjs/jest/pull/16052))
-- `[jest-resolve]` Load a user resolver written as an ES module, whose resolver arrives on `default` ([#16332](https://github.com/jestjs/jest/pull/16332))
+- `[jest-resolve, jest-config, jest-runner]` Support a user resolver written as an ES module, including one with a top-level await, by loading it ahead of resolution ([#16332](https://github.com/jestjs/jest/pull/16332))
 - `[@jest/source-map]` Keep source map sources that name a scheme, such as `webpack:///`, instead of resolving them into a path that does not exist ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[@jest/source-map]` Look up `--testLocationInResults` positions at the right column, and keep a mapping to the first column instead of discarding it ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[@jest/source-map]` Warn when a source map cannot be parsed, instead of silently leaving its frames untranslated ([#16327](https://github.com/jestjs/jest/pull/16327))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@
 - `[jest-mock]` Remove the leftover own accessor descriptor when restoring a `spyOn` of an inherited getter or setter, so the instance keeps reflecting the prototype ([#16226](https://github.com/jestjs/jest/pull/16226))
 - `[jest-resolve]` Keep virtual and ordinary mock module IDs isolated across test files ([#16296](https://github.com/jestjs/jest/pull/16296))
 - `[jest-resolve]` Guard missing `require.resolve.paths` ([#16052](https://github.com/jestjs/jest/pull/16052))
+- `[jest-resolve]` Load a user resolver written as an ES module, whose resolver arrives on `default` ([#PRNUM](https://github.com/jestjs/jest/pull/PRNUM))
 - `[@jest/source-map]` Keep source map sources that name a scheme, such as `webpack:///`, instead of resolving them into a path that does not exist ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[@jest/source-map]` Look up `--testLocationInResults` positions at the right column, and keep a mapping to the first column instead of discarding it ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[@jest/source-map]` Warn when a source map cannot be parsed, instead of silently leaving its frames untranslated ([#16327](https://github.com/jestjs/jest/pull/16327))

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1492,6 +1492,8 @@ This option allows the use of a custom resolver. This resolver must be a module 
 1. a function expecting a string as the first argument for the path to resolve and an options object as the second argument. The function should either return a path to the module that should be resolved or throw an error if the module can't be found. _or_
 2. an object containing `async` and/or `sync` properties. The `sync` property should be a function with the shape explained above, and the `async` property should also be a function that accepts the same arguments, but returns a promise which resolves with the path to the module or rejects with an error.
 
+The resolver may be written as either CommonJS or an ES module, including one that uses a top-level await. An ES module can export the function or the `sync`/`async` object as its `default` export, or expose `sync` and `async` as named exports.
+
 The options object provided to resolvers has the shape:
 
 ```ts

--- a/e2e/__tests__/customResolverEsm.test.ts
+++ b/e2e/__tests__/customResolverEsm.test.ts
@@ -11,3 +11,15 @@ test('use a custom resolver written as an ES module', () => {
   const result = runJest('custom-resolver-esm');
   expect(result.exitCode).toBe(0);
 });
+
+// The main process loads the resolver in `normalize`, but a worker only ever
+// receives its path, so it has to load the resolver itself. `shouldRunInBand`
+// gives way to `workerIdleMemoryLimit` before it looks at the test or worker
+// count, which makes this the one flag that pins the run to workers.
+test('use a custom resolver written as an ES module in workers', () => {
+  const result = runJest('custom-resolver-esm', [
+    '--max-workers=2',
+    '--workerIdleMemoryLimit=1GB',
+  ]);
+  expect(result.exitCode).toBe(0);
+});

--- a/e2e/__tests__/customResolverEsm.test.ts
+++ b/e2e/__tests__/customResolverEsm.test.ts
@@ -1,0 +1,13 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import runJest from '../runJest';
+
+test('use a custom resolver written as an ES module', () => {
+  const result = runJest('custom-resolver-esm');
+  expect(result.exitCode).toBe(0);
+});

--- a/e2e/custom-resolver-esm/__tests__/customResolverEsm.test.js
+++ b/e2e/custom-resolver-esm/__tests__/customResolverEsm.test.js
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+test('should use the custom ES module resolver', () => {
+  expect(require('bar')).toBe('bar');
+});
+
+test('should fall through to the default resolver', () => {
+  expect(require('../foo')).toBeInstanceOf(Function);
+});

--- a/e2e/custom-resolver-esm/bar.js
+++ b/e2e/custom-resolver-esm/bar.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = 'bar';

--- a/e2e/custom-resolver-esm/foo.js
+++ b/e2e/custom-resolver-esm/foo.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+module.exports = () => {};

--- a/e2e/custom-resolver-esm/package.json
+++ b/e2e/custom-resolver-esm/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "custom-resolver-esm",
+  "jest": {
+    "resolver": "./resolver.mjs",
+    "transformIgnorePatterns": [
+      "/node_modules/",
+      "/packages/"
+    ]
+  }
+}

--- a/e2e/custom-resolver-esm/resolver.mjs
+++ b/e2e/custom-resolver-esm/resolver.mjs
@@ -1,0 +1,29 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {fileURLToPath} from 'node:url';
+
+// A top-level await, so this module can never be loaded by `require` - not on
+// any version of Node. It has to go through `import()`.
+const exportedModules = await Promise.resolve(
+  new Map([
+    ['foo', 'foo'],
+    ['bar', 'bar'],
+  ]),
+);
+
+const dirname = fileURLToPath(new URL('.', import.meta.url));
+
+export default (name, options) => {
+  const resolution = exportedModules.get(name);
+
+  if (resolution) {
+    return `${dirname}${resolution}.js`;
+  }
+
+  return options.defaultResolver(name, options);
+};

--- a/packages/jest-config/src/normalize.ts
+++ b/packages/jest-config/src/normalize.ts
@@ -16,6 +16,7 @@ import {TestPathPatterns} from '@jest/pattern';
 import type {Config} from '@jest/types';
 import {replacePathSepForRegex} from 'jest-regex-util';
 import Resolver, {
+  preloadResolver,
   resolveRunner,
   resolveSequencer,
   resolveTestEnvironment,
@@ -621,6 +622,9 @@ export default async function normalize(
       key: 'resolver',
       rootDir: options.rootDir,
     });
+    // Resolution itself is synchronous, so the resolver has to be in memory
+    // before it starts. This is the only place it can be awaited.
+    await preloadResolver(newOptions.resolver);
   }
 
   validateExtensionsToTreatAsEsm(options.extensionsToTreatAsEsm);

--- a/packages/jest-resolve/src/__mocks__/userResolverEsm.js
+++ b/packages/jest-resolve/src/__mocks__/userResolverEsm.js
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+// Shape of an ES module resolver once it has been loaded through `require`:
+// a module namespace object exposing the resolver as `default`.
+module.exports = {
+  __esModule: true,
+  default: function userResolver(path, options) {
+    return 'module';
+  },
+};

--- a/packages/jest-resolve/src/__mocks__/userResolverEsmAsync.js
+++ b/packages/jest-resolve/src/__mocks__/userResolverEsmAsync.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+// An ES module resolver whose default export is a `sync`/`async` object.
+module.exports = {
+  __esModule: true,
+  default: {
+    async: function userResolverAsync(path, options) {
+      return Promise.resolve('module');
+    },
+  },
+};

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -16,7 +16,7 @@ import userResolver from '../__mocks__/userResolver';
 import userResolverAsync from '../__mocks__/userResolverAsync';
 import defaultResolver, {defaultAsyncResolver} from '../defaultResolver';
 import nodeModulesPaths from '../nodeModulesPaths';
-import Resolver from '../resolver';
+import Resolver, {preloadResolver} from '../resolver';
 import type {ResolverConfig} from '../types';
 
 jest.mock('../__mocks__/userResolver').mock('../__mocks__/userResolverAsync');
@@ -85,12 +85,17 @@ describe('isCoreModule', () => {
 });
 
 describe('findNodeModule', () => {
-  it('is possible to override the default resolver with an ES module', () => {
+  it('is possible to override the default resolver with an ES module', async () => {
+    const resolver = require.resolve('../__mocks__/userResolverEsm');
+
+    // As `normalize` and the test worker's `setup` do, before resolving.
+    await preloadResolver(resolver);
+
     const newPath = Resolver.findNodeModule('test', {
       basedir: '/',
       extensions: ['js'],
       moduleDirectory: ['node_modules'],
-      resolver: require.resolve('../__mocks__/userResolverEsm'),
+      resolver,
     });
 
     expect(newPath).toBe('module');
@@ -414,11 +419,15 @@ describe('findNodeModule', () => {
 
 describe('findNodeModuleAsync', () => {
   it('is possible to override the default resolver with an ES module', async () => {
+    const resolver = require.resolve('../__mocks__/userResolverEsmAsync');
+
+    await preloadResolver(resolver);
+
     const newPath = await Resolver.findNodeModuleAsync('test', {
       basedir: '/',
       extensions: ['js'],
       moduleDirectory: ['node_modules'],
-      resolver: require.resolve('../__mocks__/userResolverEsmAsync'),
+      resolver,
     });
 
     expect(newPath).toBe('module');
@@ -998,10 +1007,14 @@ describe('canResolveSync', () => {
     expect(resolver.canResolveSync()).toBe(false);
   });
 
-  it('returns true when the user resolver is an ES module exporting a function as `default`', () => {
+  it('returns true when the user resolver is an ES module exporting a function as `default`', async () => {
+    const resolverPath = require.resolve('../__mocks__/userResolverEsm');
+
+    await preloadResolver(resolverPath);
+
     const moduleMap = ModuleMap.create('/');
     const resolver = new Resolver(moduleMap, {
-      resolver: require.resolve('../__mocks__/userResolverEsm'),
+      resolver: resolverPath,
     } as ResolverConfig);
     expect(resolver.canResolveSync()).toBe(true);
   });

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -85,6 +85,17 @@ describe('isCoreModule', () => {
 });
 
 describe('findNodeModule', () => {
+  it('is possible to override the default resolver with an ES module', () => {
+    const newPath = Resolver.findNodeModule('test', {
+      basedir: '/',
+      extensions: ['js'],
+      moduleDirectory: ['node_modules'],
+      resolver: require.resolve('../__mocks__/userResolverEsm'),
+    });
+
+    expect(newPath).toBe('module');
+  });
+
   it('should resolve builtin modules as-is', () => {
     expect(
       Resolver.findNodeModule('url', {
@@ -402,6 +413,17 @@ describe('findNodeModule', () => {
 });
 
 describe('findNodeModuleAsync', () => {
+  it('is possible to override the default resolver with an ES module', async () => {
+    const newPath = await Resolver.findNodeModuleAsync('test', {
+      basedir: '/',
+      extensions: ['js'],
+      moduleDirectory: ['node_modules'],
+      resolver: require.resolve('../__mocks__/userResolverEsmAsync'),
+    });
+
+    expect(newPath).toBe('module');
+  });
+
   it('is possible to override the default resolver', async () => {
     const cwd = process.cwd();
     const resolvedCwd = fs.realpathSync(cwd) || cwd;
@@ -974,6 +996,14 @@ describe('canResolveSync', () => {
       resolver: require.resolve('../__mocks__/userResolverAsync'),
     } as ResolverConfig);
     expect(resolver.canResolveSync()).toBe(false);
+  });
+
+  it('returns true when the user resolver is an ES module exporting a function as `default`', () => {
+    const moduleMap = ModuleMap.create('/');
+    const resolver = new Resolver(moduleMap, {
+      resolver: require.resolve('../__mocks__/userResolverEsm'),
+    } as ResolverConfig);
+    expect(resolver.canResolveSync()).toBe(true);
   });
 });
 

--- a/packages/jest-resolve/src/index.ts
+++ b/packages/jest-resolve/src/index.ts
@@ -17,6 +17,7 @@ export type {
   ResolveModuleConfig,
   ResolverObject as JestResolver,
 } from './resolver';
+export {preloadResolver} from './resolver';
 export type {PackageJSON} from './types';
 export * from './utils';
 

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -962,6 +962,25 @@ type ResolverSyncObject = {sync: SyncResolver; async?: AsyncResolver};
 type ResolverAsyncObject = {sync?: SyncResolver; async: AsyncResolver};
 export type ResolverObject = ResolverSyncObject | ResolverAsyncObject;
 
+function asResolver(
+  loadedResolver: unknown,
+): SyncResolver | ResolverObject | null {
+  if (typeof loadedResolver === 'function') {
+    return loadedResolver as SyncResolver;
+  }
+
+  if (
+    typeof loadedResolver === 'object' &&
+    loadedResolver != null &&
+    ((loadedResolver as ResolverObject).sync != null ||
+      (loadedResolver as ResolverObject).async != null)
+  ) {
+    return loadedResolver as ResolverObject;
+  }
+
+  return null;
+}
+
 function loadResolver(
   resolver: string | undefined | null,
 ): SyncResolver | ResolverObject {
@@ -975,15 +994,20 @@ function loadResolver(
     throw new Error(`Resolver located at ${resolver} does not export anything`);
   }
 
-  if (typeof loadedResolver === 'function') {
-    return loadedResolver as SyncResolver;
+  const resolverModule = asResolver(loadedResolver);
+
+  if (resolverModule != null) {
+    return resolverModule;
   }
 
-  if (
-    typeof loadedResolver === 'object' &&
-    (loadedResolver.sync != null || loadedResolver.async != null)
-  ) {
-    return loadedResolver as ResolverObject;
+  // An ES module resolver is seen as a module namespace object, with the
+  // resolver assigned to `default`, so look there before giving up.
+  if (typeof loadedResolver === 'object' && loadedResolver.default != null) {
+    const defaultExport = asResolver(loadedResolver.default);
+
+    if (defaultExport != null) {
+      return defaultExport;
+    }
   }
 
   throw new Error(

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -10,7 +10,7 @@ import * as path from 'node:path';
 import chalk from 'chalk';
 import slash from 'slash';
 import type {IModuleMap} from 'jest-haste-map';
-import {tryRealpath} from 'jest-util';
+import {requireOrImportModule, tryRealpath} from 'jest-util';
 import ModuleNotFoundError from './ModuleNotFoundError';
 import defaultResolver, {
   type AsyncResolver,
@@ -981,15 +981,10 @@ function asResolver(
   return null;
 }
 
-function loadResolver(
-  resolver: string | undefined | null,
+function toResolver(
+  resolver: string,
+  loadedResolver: unknown,
 ): SyncResolver | ResolverObject {
-  if (resolver == null) {
-    return defaultResolver;
-  }
-
-  const loadedResolver = require(resolver);
-
   if (loadedResolver == null) {
     throw new Error(`Resolver located at ${resolver} does not export anything`);
   }
@@ -1000,10 +995,12 @@ function loadResolver(
     return resolverModule;
   }
 
-  // An ES module resolver is seen as a module namespace object, with the
-  // resolver assigned to `default`, so look there before giving up.
-  if (typeof loadedResolver === 'object' && loadedResolver.default != null) {
-    const defaultExport = asResolver(loadedResolver.default);
+  // An ES module is seen as a module namespace object, so a resolver written
+  // as `export default` arrives on `default`. Look there before giving up.
+  if (typeof loadedResolver === 'object') {
+    const defaultExport = asResolver(
+      (loadedResolver as {default?: unknown}).default,
+    );
 
     if (defaultExport != null) {
       return defaultExport;
@@ -1013,4 +1010,66 @@ function loadResolver(
   throw new Error(
     `Resolver located at ${resolver} does not export a function or an object with "sync" and "async" props`,
   );
+}
+
+// `Resolver.findNodeModule` is synchronous, but an ES module resolver can only
+// be loaded asynchronously - and one with a top-level await can never be
+// `require`d at all. Resolvers are therefore loaded ahead of time, once per
+// process, and read back out of here when resolution actually runs.
+const preloadedResolvers = new Map<string, SyncResolver | ResolverObject>();
+
+/**
+ * Load a user resolver so that later synchronous resolution can use it.
+ * Called from `normalize` in the main process and from the test worker's
+ * `setup`, both of which run before any module is resolved.
+ */
+export async function preloadResolver(
+  resolver: string | undefined | null,
+): Promise<void> {
+  if (resolver == null || preloadedResolvers.has(resolver)) {
+    return;
+  }
+
+  preloadedResolvers.set(
+    resolver,
+    toResolver(
+      resolver,
+      // Keep the namespace object intact: a resolver may expose `sync`/`async`
+      // as named exports rather than a default export.
+      await requireOrImportModule<unknown>(resolver, false),
+    ),
+  );
+}
+
+function loadResolver(
+  resolver: string | undefined | null,
+): SyncResolver | ResolverObject {
+  if (resolver == null) {
+    return defaultResolver;
+  }
+
+  const preloaded = preloadedResolvers.get(resolver);
+
+  if (preloaded != null) {
+    return preloaded;
+  }
+
+  // Not preloaded - an embedder built a `Resolver` without going through
+  // `normalize`. CommonJS still works; ES modules cannot, so say so plainly
+  // instead of surfacing a bare ERR_REQUIRE_ESM.
+  try {
+    return toResolver(resolver, require(resolver));
+  } catch (error: any) {
+    if (
+      error.code === 'ERR_REQUIRE_ESM' ||
+      error.code === 'ERR_REQUIRE_ASYNC_MODULE'
+    ) {
+      throw new Error(
+        `Jest: resolver located at ${resolver} is an ES module and must be loaded before resolution starts. Call \`preloadResolver\` from "jest-resolve" first.`,
+        {cause: error},
+      );
+    }
+
+    throw error;
+  }
 }

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -1030,15 +1030,11 @@ export async function preloadResolver(
     return;
   }
 
-  preloadedResolvers.set(
-    resolver,
-    toResolver(
-      resolver,
-      // Keep the namespace object intact: a resolver may expose `sync`/`async`
-      // as named exports rather than a default export.
-      await requireOrImportModule<unknown>(resolver, false),
-    ),
-  );
+  // Keep the namespace object intact: a resolver may expose `sync`/`async`
+  // as named exports rather than a default export.
+  const loadedResolver = await requireOrImportModule<unknown>(resolver, false);
+
+  preloadedResolvers.set(resolver, toResolver(resolver, loadedResolver));
 }
 
 function loadResolver(
@@ -1055,8 +1051,8 @@ function loadResolver(
   }
 
   // Not preloaded - an embedder built a `Resolver` without going through
-  // `normalize`. CommonJS still works; ES modules cannot, so say so plainly
-  // instead of surfacing a bare ERR_REQUIRE_ESM.
+  // `normalize`. `require` still covers CommonJS, and ES modules too on the
+  // versions of Node that can `require` them.
   try {
     return toResolver(resolver, require(resolver));
   } catch (error: any) {
@@ -1065,7 +1061,7 @@ function loadResolver(
       error.code === 'ERR_REQUIRE_ASYNC_MODULE'
     ) {
       throw new Error(
-        `Jest: resolver located at ${resolver} is an ES module and must be loaded before resolution starts. Call \`preloadResolver\` from "jest-resolve" first.`,
+        `Jest: resolver located at ${resolver} could not be loaded synchronously. Call \`preloadResolver\` from "jest-resolve" before resolving - a resolver with a top-level await always needs it, and so does any ES module on Node older than 20.19 / 22.12.`,
         {cause: error},
       );
     }

--- a/packages/jest-runner/src/testWorker.ts
+++ b/packages/jest-runner/src/testWorker.ts
@@ -15,7 +15,7 @@ import type {
 import type {Config} from '@jest/types';
 import HasteMap, {type SerializableModuleMap} from 'jest-haste-map';
 import {separateMessageFromStack} from 'jest-message-util';
-import type Resolver from 'jest-resolve';
+import {type default as Resolver, preloadResolver} from 'jest-resolve';
 import Runtime from 'jest-runtime';
 import {messageParent} from 'jest-worker';
 import runTest from './runTest';
@@ -70,9 +70,9 @@ const getResolver = (config: Config.ProjectConfig) => {
   return resolver;
 };
 
-export function setup(setupData: {
+export async function setup(setupData: {
   serializableResolvers: Array<SerializableResolver>;
-}): void {
+}): Promise<void> {
   // Module maps that will be needed for the test runs are passed.
   for (const {
     config,
@@ -81,6 +81,9 @@ export function setup(setupData: {
     const moduleMap = HasteMap.getStatic(config).getModuleMapFromJSON(
       serializableModuleMap,
     );
+    // `normalize` ran in the main process, so this worker has the resolver's
+    // path but has never loaded it. Do that now, while we can still await.
+    await preloadResolver(config.resolver);
     resolvers.set(config.id, Runtime.createResolver(config, moduleMap));
   }
 }


### PR DESCRIPTION
## Summary

Fixes #16284.

`loadResolver` accepts a resolver that is either a function or an object carrying a `sync`/`async` hook, and throws otherwise:

```js
const loadedResolver = require(resolver);
if (typeof loadedResolver === 'function') return loadedResolver;
if (typeof loadedResolver === 'object' && (loadedResolver.sync != null || loadedResolver.async != null)) return loadedResolver;
throw new Error(`Resolver located at ${resolver} does not export a function or an object with "sync" and "async" props`);
```

An ES module resolver satisfies neither. `require` of an ES module hands back a module namespace object, so `export default function resolve() {}` arrives as `{default: fn}` and configuring it fails with that error. There is no way to write the resolver as ESM today: keeping it CJS fails the other direction once the surrounding project is native ESM, which is what @birdofpreyru hit in the issue.

## Approach

Pulled the two shape checks into a small `asResolver` helper and, when the module itself is not a resolver, applied them again to `default`.

Deliberately placed after the existing checks rather than unwrapping `default` up front, so the only inputs that reach the new branch are ones that throw today. A CJS resolver that happens to expose a `default` property alongside a `sync`/`async` hook still returns the object, unchanged. That keeps this from being a behaviour change for anything that currently loads.

I matched the issue's suggested patch in effect but not in shape — checking `default` for both supported forms rather than just re-testing for a function, so an ESM resolver exporting `{sync, async}` as its default works too.

## Test plan

Two fixtures next to the existing `userResolver*` ones, shaped the way a loaded ES module looks (`__esModule: true` plus the resolver on `default`) — one exporting a function, one exporting an `async` hook.

Three tests, one per relevant describe block:

- `findNodeModule` — an ESM resolver actually resolves, `'module'`
- `findNodeModuleAsync` — same for an ESM `async` resolver
- `canResolveSync` — reports `true` for an ESM resolver exporting a function

All three fail on `main` and pass with the change; `packages/jest-resolve` goes 70 → 73 passing.

Worth noting why the functional tests are there rather than only the `canResolveSync` one: `canResolveSync` catches a throwing `loadResolver` and returns `false`, so a test asserting `false` for a broken ESM resolver passes on `main` for the wrong reason. I wrote one that way first and dropped it when it did not fail on old code.

`yarn build:ts` reports no errors in `resolver.ts`, and eslint is clean on the changed files.
