### PR TITLE
fix(pretty-format): move the react-is aliases into the `@jest` scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,7 @@
 - `[jest-runtime, @jest/transform]` Surface actionable `ERR_REQUIRE_ESM` error for files with untransformed ESM syntax instead of the generic "unexpected token" message ([#16244](https://github.com/jestjs/jest/pull/16244))
 - `[jest-runtime]` Support older test environments whose `moduleMocker` does not implement `clearMocksOnScope` ([#16169](https://github.com/jestjs/jest/pull/16169))
 - `[jest-runtime]` Support CJS-in-ESM exports via `"module.exports"` named exports ([#16277](https://github.com/jestjs/jest/pull/16277))
-- `[pretty-format]` Move the `react-is` aliases into the `@jest` scope, so they cannot be shadowed by unrelated packages published under the alias names ([#PRNUM](https://github.com/jestjs/jest/pull/PRNUM))
+- `[pretty-format]` Move the `react-is` aliases into the `@jest` scope, so they cannot be shadowed by unrelated packages published under the alias names ([#16333](https://github.com/jestjs/jest/pull/16333))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@
 - `[jest-runtime, @jest/transform]` Surface actionable `ERR_REQUIRE_ESM` error for files with untransformed ESM syntax instead of the generic "unexpected token" message ([#16244](https://github.com/jestjs/jest/pull/16244))
 - `[jest-runtime]` Support older test environments whose `moduleMocker` does not implement `clearMocksOnScope` ([#16169](https://github.com/jestjs/jest/pull/16169))
 - `[jest-runtime]` Support CJS-in-ESM exports via `"module.exports"` named exports ([#16277](https://github.com/jestjs/jest/pull/16277))
+- `[pretty-format]` Move the `react-is` aliases into the `@jest` scope, so they cannot be shadowed by unrelated packages published under the alias names ([#PRNUM](https://github.com/jestjs/jest/pull/PRNUM))
 
 ### Chore & Maintenance
 

--- a/packages/pretty-format/package.json
+++ b/packages/pretty-format/package.json
@@ -21,10 +21,10 @@
   },
   "author": "James Kyle <me@thejameskyle.com>",
   "dependencies": {
+    "@jest/react-is-18": "npm:react-is@^18.3.1",
+    "@jest/react-is-19": "npm:react-is@^19.2.5",
     "@jest/schemas": "workspace:*",
-    "ansi-styles": "^5.2.0",
-    "react-is-18": "npm:react-is@^18.3.1",
-    "react-is-19": "npm:react-is@^19.2.5"
+    "ansi-styles": "^5.2.0"
   },
   "devDependencies": {
     "@types/react": "^19.2.18",

--- a/packages/pretty-format/src/plugins/ReactElement.ts
+++ b/packages/pretty-format/src/plugins/ReactElement.ts
@@ -5,8 +5,8 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-import * as ReactIs18 from 'react-is-18';
-import * as ReactIs19 from 'react-is-19';
+import * as ReactIs18 from '@jest/react-is-18';
+import * as ReactIs19 from '@jest/react-is-19';
 import type {Config, NewPlugin, Printer, Refs} from '../types';
 import {
   printChildren,

--- a/packages/pretty-format/src/react-is-modules.d.ts
+++ b/packages/pretty-format/src/react-is-modules.d.ts
@@ -5,12 +5,12 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-declare module 'react-is-18' {
+declare module '@jest/react-is-18' {
   // eslint-disable-next-line import-x/no-extraneous-dependencies
   export * from 'react-is';
 }
 
-declare module 'react-is-19' {
+declare module '@jest/react-is-19' {
   // eslint-disable-next-line import-x/no-extraneous-dependencies
   export * from 'react-is';
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4488,6 +4488,20 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@jest/react-is-18@npm:react-is@^18.3.1, react-is@npm:^16.12.0 || ^17.0.0 || ^18.0.0, react-is@npm:^18.0.0, react-is@npm:^18.3.1":
+  version: 18.3.1
+  resolution: "react-is@npm:18.3.1"
+  checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
+  languageName: node
+  linkType: hard
+
+"@jest/react-is-19@npm:react-is@^19.2.5, react-is@npm:^19.2.8":
+  version: 19.2.8
+  resolution: "react-is@npm:19.2.8"
+  checksum: 10/09d053ff36e0ba4d47164baf9eab1c7772791f0371aa92281f0e547e0f6a5a5c8a1eb939aadd1a08b3c565958dd63ee59c746b6ac0d5ccb14ad742ac0314ab15
+  languageName: node
+  linkType: hard
+
 "@jest/reporters@workspace:*, @jest/reporters@workspace:packages/jest-reporters":
   version: 0.0.0-use.local
   resolution: "@jest/reporters@workspace:packages/jest-reporters"
@@ -19396,6 +19410,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "pretty-format@workspace:packages/pretty-format"
   dependencies:
+    "@jest/react-is-18": "npm:react-is@^18.3.1"
+    "@jest/react-is-19": "npm:react-is@^19.2.5"
     "@jest/schemas": "workspace:*"
     "@types/react": "npm:^19.2.18"
     "@types/react-is": "npm:^19.0.0"
@@ -19407,8 +19423,6 @@ __metadata:
     react-17: "npm:react@^17.0.2"
     react-18: "npm:react@^18.3.1"
     react-19: "npm:react@^19.2.3"
-    react-is-18: "npm:react-is@^18.3.1"
-    react-is-19: "npm:react-is@^19.2.5"
     react-test-renderer: "npm:^19.2.3"
     react-test-renderer-17: "npm:react-test-renderer@^17.0.2"
     react-test-renderer-18: "npm:react-test-renderer@^18.3.1"
@@ -19781,20 +19795,6 @@ __metadata:
     react: ^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
   checksum: 10/76854c3a9220e1adc7b4aece55926146583d43b6bf08905d8cb6a7e3ee0ac60f7a03b285c2bb6c4aa3110e8d048e5dee4e3bdcea9c4b9b5c00db67ba002b95ce
-  languageName: node
-  linkType: hard
-
-"react-is-18@npm:react-is@^18.3.1, react-is@npm:^16.12.0 || ^17.0.0 || ^18.0.0, react-is@npm:^18.0.0, react-is@npm:^18.3.1":
-  version: 18.3.1
-  resolution: "react-is@npm:18.3.1"
-  checksum: 10/d5f60c87d285af24b1e1e7eaeb123ec256c3c8bdea7061ab3932e3e14685708221bf234ec50b21e10dd07f008f1b966a2730a0ce4ff67905b3872ff2042aec22
-  languageName: node
-  linkType: hard
-
-"react-is-19@npm:react-is@^19.2.5, react-is@npm:^19.2.8":
-  version: 19.2.8
-  resolution: "react-is@npm:19.2.8"
-  checksum: 10/09d053ff36e0ba4d47164baf9eab1c7772791f0371aa92281f0e547e0f6a5a5c8a1eb939aadd1a08b3c565958dd63ee59c746b6ac0d5ccb14ad742ac0314ab15
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Fixes #16280.

`pretty-format` pulls in two copies of `react-is` through npm aliases:

```json
"react-is-18": "npm:react-is@^18.3.1",
"react-is-19": "npm:react-is@^19.2.5"
```

Both of those names were published to npm on 2026-07-05 by an unrelated author, at versions that mirror `react-is` (18.3.1 and 19.2.7) and with no description:

```
$ npm view react-is-18 version   # 18.3.1, created 2026-07-05
$ npm view react-is-19 version   # 19.2.7, created 2026-07-05
```

An alias key is only a local name, so installs still fetch real `react-is` and nothing is executed from those packages. But the key is what ends up in `node_modules` and in the dependency lists scanners read, so tooling that does not follow the alias matches the name against the registry and finds those packages instead. @avfarooq and @Xiantongc612 both report them being flagged as malicious. `pretty-format` is a transitive dependency of most Jest installs, so it surfaces widely.

## Approach

Renamed the aliases to `@jest/react-is-18` and `@jest/react-is-19`.

I went with the scope rather than a fresh unscoped name (`react-is-v18` and so on) because an unscoped name can be claimed the same way next week — it would reset the clock rather than close the hole. `@jest` is controlled by the project, so nobody else can publish a package that shadows these names.

The trade-off is that a scanner which does not follow aliases will now find nothing published under `@jest/react-is-18` instead of finding a stranger's package. Unresolvable seems clearly better than resolving to something unrelated, but if you would rather keep the names unscoped, the same change works with any other key and I am happy to redo it.

Only the two `dependencies` are renamed. The devDependency aliases (`react-17`, `react-test-renderer-17`, …) do not reach consumers, and while `react-17` and `react-test-renderer-17` are also published names, both predate this by years and look like abandoned placeholders rather than the same thing. Happy to fold them in if you want them consistent.

## Test plan

- `yarn jest packages/pretty-format` — 8 suites, 384 tests, 35 snapshots, all passing.
- `ReactVersions.test.ts` is the one that matters here, since it renders and formats elements from React 17, 18 and 19 against the real installed copies. It passes, so element detection still works across versions.
- Confirmed both aliases still resolve to the genuine package after the rename: `@jest/react-is-18` → `react-is@18.3.1`, `@jest/react-is-19` → `react-is@19.2.8`.
- `yarn.lock` regenerated by `yarn install`; eslint clean on the changed files.
