### PR TITLE
feat(jest-runtime): resolve the `module-sync` export condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `[jest-haste-map]` Replace `NodeWatcher` and `FSEventsWatcher` with `@parcel/watcher` for the non-watchman watch path ([#16188](https://github.com/jestjs/jest/pull/16188))
 - `[jest-resolve]` Bump `unrs-resolver` to 1.12.1, remove `jest-pnp-resolver` and unnecessary checks ([#15721](https://github.com/jestjs/jest/pull/15721))
 - `[jest-resolve]` Honor Node's `--preserve-symlinks` / `NODE_PRESERVE_SYMLINKS` in the default resolver by passing `symlinks: false` to `unrs-resolver` ([#16260](https://github.com/jestjs/jest/pull/16260))
+- `[jest-runtime]` Resolve the `module-sync` export condition, so a package that exposes its ESM entry point for `require()` loads the same file Node would ([#16336](https://github.com/jestjs/jest/pull/16336))
 
 ### Fixes
 

--- a/docs/ECMAScriptModules.md
+++ b/docs/ECMAScriptModules.md
@@ -54,6 +54,8 @@ const {value, default: defaultExport} = require('./esm-module.mjs');
 
 Calling `require()` on an ESM file with top-level `await` (or whose graph contains TLA) throws `ERR_REQUIRE_ASYNC_MODULE`. Use `await import(...)` for those files.
 
+Packages resolve through the [`require` and `module-sync` conditions](https://nodejs.org/api/packages.html#community-conditions-definitions), as they do in Node. A package that exposes its ESM entry point under `module-sync` can therefore be `require()`d, and one that exposes it only under `import` cannot - Node refuses that too, with `ERR_PACKAGE_PATH_NOT_EXPORTED`. A `module-sync` entry point whose graph contains top-level `await` throws `ERR_REQUIRE_ASYNC_MODULE`.
+
 `jest.mock` does _not_ apply when the resolved file is ESM - `jest.mock` is for CJS targets. To mock an ESM file you `require()`, register the mock via `jest.unstable_mockModule` (the mock applies to transitive dependencies the loaded ESM imports).
 
 On Node versions older than v24.9, `require()` of an ESM file still throws `ERR_REQUIRE_ESM`.

--- a/e2e/__tests__/nativeEsmRequireModule.test.ts
+++ b/e2e/__tests__/nativeEsmRequireModule.test.ts
@@ -31,6 +31,17 @@ onNodeVersions('>=24.9.0', () => {
     expect(stderr).toContain('2 passed');
     expect(exitCode).toBe(0);
   });
+
+  test('require() resolves the "module-sync" condition and rejects a TLA graph', () => {
+    const {exitCode, stderr} = runJest(
+      DIR,
+      ['__tests__/require-module-sync-package.test.js'],
+      {nodeOptions: '--experimental-vm-modules --no-warnings'},
+    );
+
+    expect(stderr).toContain('2 passed');
+    expect(exitCode).toBe(0);
+  });
 });
 
 onNodeVersions('<24.9.0', () => {

--- a/e2e/native-esm-require-module/.gitignore
+++ b/e2e/native-esm-require-module/.gitignore
@@ -1,0 +1,1 @@
+!node_modules

--- a/e2e/native-esm-require-module/__tests__/require-module-sync-package.test.js
+++ b/e2e/native-esm-require-module/__tests__/require-module-sync-package.test.js
@@ -1,0 +1,19 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+test('require() resolves a package through its "module-sync" condition', () => {
+  const ns = require('module-sync-pkg');
+  expect(ns.condition).toBe('module-sync');
+});
+
+test('require() of a "module-sync" package with top-level await throws ERR_REQUIRE_ASYNC_MODULE', () => {
+  expect(() => require('module-sync-tla-pkg')).toThrow(
+    expect.objectContaining({code: 'ERR_REQUIRE_ASYNC_MODULE'}),
+  );
+});

--- a/e2e/native-esm-require-module/node_modules/module-sync-pkg/esm.js
+++ b/e2e/native-esm-require-module/node_modules/module-sync-pkg/esm.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const condition = 'import';

--- a/e2e/native-esm-require-module/node_modules/module-sync-pkg/package.json
+++ b/e2e/native-esm-require-module/node_modules/module-sync-pkg/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "module-sync-pkg",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "module-sync": "./sync.js",
+      "import": "./esm.js"
+    }
+  }
+}

--- a/e2e/native-esm-require-module/node_modules/module-sync-pkg/sync.js
+++ b/e2e/native-esm-require-module/node_modules/module-sync-pkg/sync.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const condition = 'module-sync';

--- a/e2e/native-esm-require-module/node_modules/module-sync-tla-pkg/package.json
+++ b/e2e/native-esm-require-module/node_modules/module-sync-tla-pkg/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "module-sync-tla-pkg",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "module-sync": "./tla.js"
+    }
+  }
+}

--- a/e2e/native-esm-require-module/node_modules/module-sync-tla-pkg/tla.js
+++ b/e2e/native-esm-require-module/node_modules/module-sync-tla-pkg/tla.js
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+// Node documents `module-sync` as ESM without top-level await in its graph, and
+// throws ERR_REQUIRE_ASYNC_MODULE for a package that breaks that expectation.
+export const value = await Promise.resolve('tla');

--- a/e2e/native-esm/__tests__/native-esm.test.js
+++ b/e2e/native-esm/__tests__/native-esm.test.js
@@ -60,12 +60,12 @@ test('should have correct import.meta', () => {
   expect(
     import.meta
       .resolve('colors')
-      .endsWith('jest/e2e/native-esm/node_modules/colors/lib/index.js'),
+      .endsWith('/e2e/native-esm/node_modules/colors/lib/index.js'),
   ).toBe(true);
   expect(
     import.meta
       .resolve('./native-esm.test')
-      .endsWith('jest/e2e/native-esm/__tests__/native-esm.test.js'),
+      .endsWith('/e2e/native-esm/__tests__/native-esm.test.js'),
   ).toBe(true);
 });
 

--- a/packages/jest-runtime/src/internals/Resolution.ts
+++ b/packages/jest-runtime/src/internals/Resolution.ts
@@ -8,6 +8,7 @@
 import * as path from 'node:path';
 import * as fs from 'graceful-fs';
 import Resolver from 'jest-resolve';
+import {supportsSyncEvaluate} from './nodeCapabilities';
 
 export const isWasm = (modulePath: string): boolean =>
   modulePath.endsWith('.wasm');
@@ -28,10 +29,19 @@ export class Resolution {
   ) {
     this.resolver = resolver;
     this.cjsConditions = [
-      ...new Set(['require', 'node', 'default', ...envExportConditions]),
+      ...new Set([
+        'require',
+        // Node only offers `module-sync` to `require()` when it can load ESM
+        // that way. Claiming it otherwise resolves dual packages to their ESM
+        // entry point, which we then cannot execute.
+        ...(supportsSyncEvaluate ? ['module-sync'] : []),
+        'node',
+        'default',
+        ...envExportConditions,
+      ]),
     ];
     this.esmConditions = [
-      ...new Set(['import', 'default', ...envExportConditions]),
+      ...new Set(['import', 'module-sync', 'default', ...envExportConditions]),
     ];
     this.extensionsToTreatAsEsm = extensionsToTreatAsEsm;
   }

--- a/packages/jest-runtime/src/internals/__tests__/Resolution.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/Resolution.test.ts
@@ -7,7 +7,12 @@
 
 import * as path from 'node:path';
 import * as fs from 'graceful-fs';
-import {testWithVmEsm} from '@jest/test-utils';
+import {
+  hasSyncEsm,
+  testWithSyncEsm,
+  testWithVmEsm,
+  testWithoutSyncEsm,
+} from '@jest/test-utils';
 import type Resolver from 'jest-resolve';
 import {Resolution} from '../Resolution';
 
@@ -16,8 +21,11 @@ jest.mock('graceful-fs', () => ({
   existsSync: jest.fn(() => false),
 }));
 
-const CJS = ['require', 'node', 'default'];
-const ESM = ['import', 'default'];
+// `module-sync` is only offered to `require()` when Node can load ESM that way.
+const CJS = hasSyncEsm
+  ? ['require', 'module-sync', 'node', 'default']
+  : ['require', 'node', 'default'];
+const ESM = ['import', 'module-sync', 'default'];
 
 function makeResolver(overrides: Partial<Resolver> = {}): Resolver {
   const base = {
@@ -44,20 +52,41 @@ function makeResolver(overrides: Partial<Resolver> = {}): Resolver {
 
 describe('Resolution', () => {
   describe('conditions', () => {
-    test('with no env conditions, uses Node defaults', () => {
-      const resolver = makeResolver();
-      const r = new Resolution(resolver, [], []);
+    testWithSyncEsm(
+      'with no env conditions, uses Node defaults including "module-sync"',
+      () => {
+        const resolver = makeResolver();
+        const r = new Resolution(resolver, [], []);
 
-      r.resolveCjs('/a', 'foo');
-      r.resolveEsm('/a', 'foo');
+        r.resolveCjs('/a', 'foo');
+        r.resolveEsm('/a', 'foo');
 
-      expect(resolver.resolveModule).toHaveBeenNthCalledWith(1, '/a', 'foo', {
-        conditions: CJS,
-      });
-      expect(resolver.resolveModule).toHaveBeenNthCalledWith(2, '/a', 'foo', {
-        conditions: ESM,
-      });
-    });
+        expect(resolver.resolveModule).toHaveBeenNthCalledWith(1, '/a', 'foo', {
+          conditions: ['require', 'module-sync', 'node', 'default'],
+        });
+        expect(resolver.resolveModule).toHaveBeenNthCalledWith(2, '/a', 'foo', {
+          conditions: ['import', 'module-sync', 'default'],
+        });
+      },
+    );
+
+    testWithoutSyncEsm(
+      'omits "module-sync" from the CJS conditions when require(esm) is unavailable',
+      () => {
+        const resolver = makeResolver();
+        const r = new Resolution(resolver, [], []);
+
+        r.resolveCjs('/a', 'foo');
+        r.resolveEsm('/a', 'foo');
+
+        expect(resolver.resolveModule).toHaveBeenNthCalledWith(1, '/a', 'foo', {
+          conditions: ['require', 'node', 'default'],
+        });
+        expect(resolver.resolveModule).toHaveBeenNthCalledWith(2, '/a', 'foo', {
+          conditions: ['import', 'module-sync', 'default'],
+        });
+      },
+    );
 
     test('appends env-provided conditions and de-dupes', () => {
       const resolver = makeResolver();
@@ -67,10 +96,10 @@ describe('Resolution', () => {
       r.resolveEsm('/a', 'foo');
 
       expect(resolver.resolveModule).toHaveBeenNthCalledWith(1, '/a', 'foo', {
-        conditions: ['require', 'node', 'default', 'browser'],
+        conditions: [...CJS, 'browser'],
       });
       expect(resolver.resolveModule).toHaveBeenNthCalledWith(2, '/a', 'foo', {
-        conditions: ['import', 'default', 'browser'],
+        conditions: [...ESM, 'browser'],
       });
     });
   });

--- a/packages/test-utils/src/ConditionalTest.ts
+++ b/packages/test-utils/src/ConditionalTest.ts
@@ -60,7 +60,7 @@ export function testWithVmEsm(
   return fn(...args);
 }
 
-const hasSyncEsm =
+export const hasSyncEsm =
   // @ts-expect-error - hasAsyncGraph is in Node v24.9+, not yet typed
   typeof SourceTextModule?.prototype.hasAsyncGraph === 'function';
 

--- a/packages/test-utils/src/index.ts
+++ b/packages/test-utils/src/index.ts
@@ -8,6 +8,7 @@
 export {alignedAnsiStyleSerializer} from './alignedAnsiStyleSerializer';
 
 export {
+  hasSyncEsm,
   isJestJasmineRun,
   isWatchmanAvailable,
   onNodeVersions,

--- a/scripts/cleanE2e.mjs
+++ b/scripts/cleanE2e.mjs
@@ -13,6 +13,7 @@ import fs from 'graceful-fs';
 const excludedModules = [
   'e2e/global-setup-node-modules/node_modules/',
   'e2e/native-esm-js-esm-syntax-fallback/node_modules/',
+  'e2e/native-esm-require-module/node_modules/',
   'e2e/presets/cjs/node_modules/',
   'e2e/presets/js/node_modules/',
   'e2e/presets/js-type-module/node_modules/',


### PR DESCRIPTION
## Summary

Jest builds its own export-condition lists in `jest-runtime`'s `Resolution`, and neither list contained `module-sync`:

```ts
cjsConditions = ["require", "node", "default", ...envExportConditions];
esmConditions = ["import", "default", ...envExportConditions];
```

`module-sync` is how a package exposes an ESM entry point that `require()` can load, and Node's ESM loader honours the condition too. Without it, such a package does not resolve in Jest at all — `Cannot find module` — even though plain Node loads it. For a package that also has an `import` branch, the two conditions can point at different files, so falling back to the ESM condition set is not equivalent:

```
["require","node","default"]                -> Cannot find module 'module-sync-pkg'   # before
["import","default"]                        -> ./index.js
["require","module-sync","node","default"]  -> ./sync.js                              # native Node
```

`module-sync` now goes into the ESM conditions unconditionally, and into the CJS conditions only when `supportsSyncEvaluate` reports that we can load ESM from `require()`. Claiming it without that support would resolve a dual package listing `module-sync` before `require` to its ESM entry point, which we then cannot execute — a regression on Node < 24.9 and without `--experimental-vm-modules`. On those versions the resolution is unchanged.

A `module-sync` entry point whose graph contains top-level `await` throws `ERR_REQUIRE_ASYNC_MODULE`, as Node documents. The sync graph walker decides that from `SourceTextModule#hasAsyncGraph()`, independent of which condition resolved the specifier.

Also drops a directory-name assumption in `e2e/native-esm`: two `import.meta.resolve` assertions required the checkout to be named `jest`, so they failed in any other directory (e.g. worktrees).

## Test plan

`Resolution.test.ts` asserts the literal condition arrays under both `testWithSyncEsm` and `testWithoutSyncEsm`, so each Node version checks the branch it actually takes. `hasSyncEsm` is now exported from `@jest/test-utils` for the shared expectation — test-utils has its own copy of the capability check, so the assertion does not just mirror `nodeCapabilities.ts`.

The e2e fixture ships two checked-in packages under `e2e/native-esm-require-module/node_modules`. `module-sync-pkg` maps `module-sync` to `sync.js` and `import` to `esm.js`, each exporting a different value, so the test proves the `module-sync` branch is selected rather than `import`. `module-sync-tla-pkg` exposes only a `module-sync` entry with a top-level `await`.

```
$ yarn jest packages/jest-runtime/src/internals/__tests__/Resolution.test.ts
Tests:       4 skipped, 26 passed, 30 total

$ NODE_OPTIONS="--experimental-vm-modules --no-warnings" yarn jest packages/jest-runtime/src/internals/__tests__/Resolution.test.ts
Tests:       1 skipped, 29 passed, 30 total

$ yarn jest e2e/__tests__/nativeEsmRequireModule.test.ts
Tests:       1 skipped, 3 passed, 4 total

$ yarn jest packages/jest-runtime packages/jest-resolve
Tests:       86 skipped, 401 passed, 487 total

$ yarn jest-runtime-vm-modules
Tests:       4 skipped, 402 passed, 406 total

$ yarn jest e2e/__tests__/resolveConditions.test.ts e2e/__tests__/nativeEsm.test.ts e2e/__tests__/nativeEsmCjsRequire.test.ts e2e/__tests__/nativeEsmJsEsmSyntaxFallback.test.ts e2e/__tests__/nativeEsmSyncLinker.test.ts e2e/__tests__/moduleNameMapper.test.ts
Tests:       2 skipped, 20 passed, 22 total
```

Without `--experimental-vm-modules`, `require('module-sync-pkg')` still fails with `Cannot find module`, confirming the gate.