### PR TITLE
fix(jest-resolve): look up manual mocks for node: protocol specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
 - `[jest-mock]` Remove the leftover own accessor descriptor when restoring a `spyOn` of an inherited getter or setter, so the instance keeps reflecting the prototype ([#16226](https://github.com/jestjs/jest/pull/16226))
 - `[jest-resolve]` Keep virtual and ordinary mock module IDs isolated across test files ([#16296](https://github.com/jestjs/jest/pull/16296))
+- `[jest-resolve]` Look up manual mocks for `node:` protocol specifiers under the unprefixed name ([#16339](https://github.com/jestjs/jest/pull/16339))
 - `[jest-resolve]` Guard missing `require.resolve.paths` ([#16052](https://github.com/jestjs/jest/pull/16052))
 - `[@jest/source-map]` Keep source map sources that name a scheme, such as `webpack:///`, instead of resolving them into a path that does not exist ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[@jest/source-map]` Look up `--testLocationInResults` positions at the right column, and keep a mapping to the first column instead of discarding it ([#16327](https://github.com/jestjs/jest/pull/16327))

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -692,9 +692,43 @@ describe('getMockModule', () => {
       path.dirname(src),
     );
   });
+
+  it('resolves a manual mock for a node: protocol specifier', () => {
+    const mockPath = path.join('/root', '__mocks__', 'fs.js');
+    const moduleMap = ModuleMap.create('/');
+    jest.spyOn(moduleMap, 'getMockModule').mockImplementation(name => {
+      return name === 'fs' ? mockPath : undefined;
+    });
+    const resolver = new Resolver(moduleMap, {
+      extensions: ['.js'],
+    } as ResolverConfig);
+    const src = require.resolve('../');
+
+    expect(resolver.getMockModule(src, 'node:fs')).toBe(mockPath);
+    expect(resolver.getMockModule(src, 'fs')).toBe(mockPath);
+  });
 });
 
 describe('getMockModuleAsync', () => {
+  it('resolves a manual mock for a node: protocol specifier', async () => {
+    const mockPath = path.join('/root', '__mocks__', 'fs.js');
+    const moduleMap = ModuleMap.create('/');
+    jest.spyOn(moduleMap, 'getMockModule').mockImplementation(name => {
+      return name === 'fs' ? mockPath : undefined;
+    });
+    const resolver = new Resolver(moduleMap, {
+      extensions: ['.js'],
+    } as ResolverConfig);
+    const src = require.resolve('../');
+
+    await expect(resolver.getMockModuleAsync(src, 'node:fs', {})).resolves.toBe(
+      mockPath,
+    );
+    await expect(resolver.getMockModuleAsync(src, 'fs', {})).resolves.toBe(
+      mockPath,
+    );
+  });
+
   it('is possible to use custom resolver to resolve deps inside mock modules with moduleNameMapper', async () => {
     mockUserResolverAsync.async.mockResolvedValue('module');
 

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -523,14 +523,14 @@ export default class Resolver {
     name: string,
     options?: Pick<ResolveModuleConfig, 'conditions'>,
   ): string | null {
-    const mock = this._moduleMap.getMockModule(name);
+    const mock = this._lookupManualMock(name);
     if (mock) {
       return mock;
-    } else {
-      const resolvedName = this.resolveStubModuleName(from, name, options);
-      if (resolvedName) {
-        return this._moduleMap.getMockModule(resolvedName) ?? null;
-      }
+    }
+
+    const resolvedName = this.resolveStubModuleName(from, name, options);
+    if (resolvedName) {
+      return this._lookupManualMock(resolvedName);
     }
     return null;
   }
@@ -540,17 +540,33 @@ export default class Resolver {
     name: string,
     options: Pick<ResolveModuleConfig, 'conditions'>,
   ): Promise<string | null> {
+    const mock = this._lookupManualMock(name);
+    if (mock) {
+      return mock;
+    }
+
+    const resolvedName = await this.resolveStubModuleNameAsync(
+      from,
+      name,
+      options,
+    );
+    if (resolvedName) {
+      return this._lookupManualMock(resolvedName);
+    }
+    return null;
+  }
+
+  // Manual mocks are stored as `fs`, not `node:fs` — a colon is not a legal
+  // filename on Windows, so look up the unprefixed core specifier as well.
+  private _lookupManualMock(name: string): string | null {
     const mock = this._moduleMap.getMockModule(name);
     if (mock) {
       return mock;
-    } else {
-      const resolvedName = await this.resolveStubModuleNameAsync(
-        from,
-        name,
-        options,
-      );
-      if (resolvedName) {
-        return this._moduleMap.getMockModule(resolvedName) ?? null;
+    }
+    if (this.isCoreModule(name)) {
+      const normalized = this.normalizeCoreModuleSpecifier(name);
+      if (normalized !== name) {
+        return this._moduleMap.getMockModule(normalized) ?? null;
       }
     }
     return null;


### PR DESCRIPTION
## Summary

`import`/`require('node:fs')` could not resolve a manual mock stored as `__mocks__/fs`, because `Resolver.getMockModule` looked the mock up under the raw specifier. A file named `node:fs` is not legal on Windows, so the mock has to live under the unprefixed name.

`getMockModule` / `getMockModuleAsync` now fall back to the normalized core specifier (`node:fs` → `fs`) when looking up `__mocks__`. `node:fs` and `fs` resolve the same manual mock.

Fixes #14040

## Test plan

- `yarn jest packages/jest-resolve/src/__tests__/resolve.test.ts e2e/__tests__/nodeURLManualMocks.test.js packages/jest-runtime/src/internals/__tests__/Resolution.test.ts`