### PR TITLE
Isolate expect.assertions state per test.concurrent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 ### Fixes
 
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
-- `[expect]` Isolate `expect.assertions` / `expect.hasAssertions` state per concurrent test so `test.concurrent` no longer shares assertion counts ([#14263](https://github.com/jestjs/jest/issues/14263))
+- `[expect]` Isolate `expect.assertions` / `expect.hasAssertions` state per concurrent test so `test.concurrent` no longer shares assertion counts ([#16340](https://github.com/jestjs/jest/pull/16340))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[jest-circus, jest-jasmine2, jest-message-util]` Serialize the inner errors of an `AggregateError` into `failureMessages`, `retryReasons` and `unhandledErrors`, so `--json` output and reporter annotations include them ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[@jest/create-cache-key-function]` Include the caller support flags in the generated key, so a transformer that emits ESM or CJS based on them no longer shares one cache entry between the two ([#16331](https://github.com/jestjs/jest/pull/16331))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Fixes
 
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
+- `[expect]` Isolate `expect.assertions` / `expect.hasAssertions` state per concurrent test so `test.concurrent` no longer shares assertion counts ([#14263](https://github.com/jestjs/jest/issues/14263))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[jest-circus, jest-jasmine2, jest-message-util]` Serialize the inner errors of an `AggregateError` into `failureMessages`, `retryReasons` and `unhandledErrors`, so `--json` output and reporter annotations include them ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[@jest/create-cache-key-function]` Include the caller support flags in the generated key, so a transformer that emits ESM or CJS based on them no longer shares one cache entry between the two ([#16331](https://github.com/jestjs/jest/pull/16331))

--- a/e2e/__tests__/circusConcurrent.test.ts
+++ b/e2e/__tests__/circusConcurrent.test.ts
@@ -49,6 +49,42 @@ describe('with skip', () => {
   });
 });
 
+describe('expect.assertions', () => {
+  it('passes when each concurrent test meets its own assertion budget', () => {
+    const {json, exitCode} = runWithJson('circus-concurrent', [
+      'concurrent-assertions.test.js',
+    ]);
+
+    expect(exitCode).toBe(0);
+    expect(json.numTotalTests).toBe(4);
+    expect(json.numPassedTests).toBe(4);
+    expect(json.numFailedTests).toBe(0);
+  });
+
+  it('fails only the concurrent test that exceeded its assertion budget', () => {
+    const {json, exitCode, stderr} = runWithJson('circus-concurrent', [
+      'concurrent-assertions-fail.test.js',
+    ]);
+
+    expect(exitCode).toBe(1);
+    expect(json.numTotalTests).toBe(2);
+    expect(json.numPassedTests).toBe(1);
+    expect(json.numFailedTests).toBe(1);
+    expect(stderr).toMatch(
+      /Expected one assertion to be called but received two assertion calls/,
+    );
+    expect(json.testResults[0].assertionResults).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({status: 'passed', title: 'ok sibling'}),
+        expect.objectContaining({
+          status: 'failed',
+          title: 'too many assertions',
+        }),
+      ]),
+    );
+  });
+});
+
 describe('with only', () => {
   it('runs the correct number of tests', () => {
     const {json, exitCode} = runWithJson('circus-concurrent', [

--- a/e2e/circus-concurrent/__tests__/concurrent-assertions-fail.test.js
+++ b/e2e/circus-concurrent/__tests__/concurrent-assertions-fail.test.js
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const {setTimeout} = require('timers/promises');
+
+test.concurrent('too many assertions', async () => {
+  expect.assertions(1);
+  await setTimeout(50);
+  expect(1).toBe(1);
+  expect(2).toBe(2);
+});
+
+test.concurrent('ok sibling', async () => {
+  expect.assertions(1);
+  await setTimeout(50);
+  expect(1).toBe(1);
+});

--- a/e2e/circus-concurrent/__tests__/concurrent-assertions.test.js
+++ b/e2e/circus-concurrent/__tests__/concurrent-assertions.test.js
@@ -1,0 +1,34 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+'use strict';
+
+const {setTimeout} = require('timers/promises');
+
+test.concurrent('assertions one', async () => {
+  expect.assertions(1);
+  await setTimeout(50);
+  expect(1).toBe(1);
+});
+
+test.concurrent('assertions two', async () => {
+  expect.assertions(1);
+  await setTimeout(50);
+  expect(2).toBe(2);
+});
+
+test.concurrent('hasAssertions', async () => {
+  expect.hasAssertions();
+  await setTimeout(50);
+  expect(3).toBe(3);
+});
+
+test('sequential assertions', async () => {
+  expect.assertions(1);
+  await setTimeout(50);
+  expect('seq').toBe('seq');
+});

--- a/packages/expect/src/__tests__/assertionCounts.test.ts
+++ b/packages/expect/src/__tests__/assertionCounts.test.ts
@@ -45,6 +45,85 @@ describe('.hasAssertions()', () => {
   it('hasAssertions not leaking to global state', () => {});
 });
 
+describe('concurrent isolation', () => {
+  const previousGetter = jestExpect.getState().currentConcurrentTestName;
+  let activeTest: string | undefined;
+
+  beforeEach(() => {
+    activeTest = undefined;
+    jestExpect.setState({
+      currentConcurrentTestName: () => activeTest ?? previousGetter?.(),
+    });
+  });
+
+  afterEach(() => {
+    activeTest = undefined;
+    jestExpect.setState({currentConcurrentTestName: previousGetter});
+    jestExpect.extractExpectedAssertionsErrors();
+  });
+
+  it('does not share assertion counts across concurrent tests', () => {
+    activeTest = 'A';
+    jestExpect.assertions(1);
+    jestExpect('a').toBe('a');
+
+    activeTest = 'B';
+    jestExpect.assertions(1);
+    jestExpect('b').toBe('b');
+
+    activeTest = 'A';
+    const errorsA = jestExpect.extractExpectedAssertionsErrors();
+    activeTest = 'B';
+    const errorsB = jestExpect.extractExpectedAssertionsErrors();
+
+    activeTest = undefined;
+    expect(errorsA).toEqual([]);
+    expect(errorsB).toEqual([]);
+  });
+
+  it('reports extra assertions only for the concurrent test that made them', () => {
+    activeTest = 'A';
+    jestExpect.assertions(1);
+    jestExpect('a').toBe('a');
+    jestExpect('aa').toBe('aa');
+
+    activeTest = 'B';
+    jestExpect.assertions(1);
+    jestExpect('b').toBe('b');
+
+    activeTest = 'A';
+    const errorsA = jestExpect.extractExpectedAssertionsErrors();
+    activeTest = 'B';
+    const errorsB = jestExpect.extractExpectedAssertionsErrors();
+
+    activeTest = undefined;
+    expect(errorsA).toHaveLength(1);
+    expect(errorsA[0].actual).toBe('2');
+    expect(errorsA[0].expected).toBe('1');
+    expect(errorsB).toEqual([]);
+  });
+
+  it('does not share hasAssertions across concurrent tests', () => {
+    activeTest = 'A';
+    jestExpect.hasAssertions();
+
+    activeTest = 'B';
+    jestExpect.hasAssertions();
+    jestExpect('b').toBe('b');
+
+    activeTest = 'A';
+    const errorsA = jestExpect.extractExpectedAssertionsErrors();
+    activeTest = 'B';
+    const errorsB = jestExpect.extractExpectedAssertionsErrors();
+
+    activeTest = undefined;
+    expect(errorsA).toHaveLength(1);
+    expect(errorsA[0].actual).toBe('none');
+    expect(errorsA[0].expected).toBe('at least one');
+    expect(errorsB).toEqual([]);
+  });
+});
+
 describe('numPassingAsserts', () => {
   it('verify the default value of numPassingAsserts', () => {
     const {numPassingAsserts} = jestExpect.getState();

--- a/packages/expect/src/jestMatchersObject.ts
+++ b/packages/expect/src/jestMatchersObject.ts
@@ -112,7 +112,8 @@ const createIsolatedStateView = (
     },
     set(target, prop, value, receiver) {
       if (isIsolatedStateKey(prop)) {
-        isolated[prop] = value;
+        // IsolatedMatcherState values are not a single assignable union.
+        (isolated as Record<IsolatedStateKey, unknown>)[prop] = value;
         return true;
       }
       return Reflect.set(target, prop, value, receiver);

--- a/packages/expect/src/jestMatchersObject.ts
+++ b/packages/expect/src/jestMatchersObject.ts
@@ -24,6 +24,101 @@ const JEST_MATCHERS_OBJECT = Symbol.for('$$jest-matchers-object');
 // Jest may override the stack trace of Errors thrown by internal matchers.
 export const INTERNAL_MATCHER_FLAG = Symbol.for('$$jest-internal-matcher');
 
+// Per-test fields that must not be shared when tests run concurrently.
+// `currentConcurrentTestName` (set by jest-circus via AsyncLocalStorage)
+// identifies the active test; everything else stays on the global state.
+type IsolatedMatcherState = {
+  assertionCalls: number;
+  currentTestName?: string;
+  expectedAssertionsNumber: number | null;
+  expectedAssertionsNumberError?: Error;
+  isExpectingAssertions: boolean;
+  isExpectingAssertionsError?: Error;
+  numPassingAsserts: number;
+  suppressedErrors: Array<Error>;
+  testFailing?: boolean;
+};
+
+const ISOLATED_STATE_KEYS = [
+  'assertionCalls',
+  'currentTestName',
+  'expectedAssertionsNumber',
+  'expectedAssertionsNumberError',
+  'isExpectingAssertions',
+  'isExpectingAssertionsError',
+  'numPassingAsserts',
+  'suppressedErrors',
+  'testFailing',
+] as const satisfies ReadonlyArray<keyof IsolatedMatcherState>;
+
+type IsolatedStateKey = (typeof ISOLATED_STATE_KEYS)[number];
+
+type IsolatedMatcherEntry = {
+  isolated: IsolatedMatcherState;
+  view: MatcherState;
+};
+
+type JestMatchersObject = {
+  customEqualityTesters: Array<Tester>;
+  isolatedMatcherStates: Map<string, IsolatedMatcherEntry>;
+  matchers: MatchersObject;
+  state: MatcherState;
+};
+
+const isolatedStateKeySet = new Set<string>(ISOLATED_STATE_KEYS);
+
+const isIsolatedStateKey = (key: string | symbol): key is IsolatedStateKey =>
+  typeof key === 'string' && isolatedStateKeySet.has(key);
+
+const createIsolatedMatcherState = (): IsolatedMatcherState => ({
+  assertionCalls: 0,
+  expectedAssertionsNumber: null,
+  isExpectingAssertions: false,
+  numPassingAsserts: 0,
+  suppressedErrors: [],
+});
+
+const createIsolatedStateView = (
+  globalState: MatcherState,
+  isolated: IsolatedMatcherState,
+): MatcherState =>
+  new Proxy(globalState, {
+    get(target, prop, receiver) {
+      if (isIsolatedStateKey(prop)) {
+        return isolated[prop];
+      }
+      return Reflect.get(target, prop, receiver);
+    },
+    getOwnPropertyDescriptor(target, prop) {
+      if (isIsolatedStateKey(prop)) {
+        return {
+          configurable: true,
+          enumerable: true,
+          value: isolated[prop],
+          writable: true,
+        };
+      }
+      return Reflect.getOwnPropertyDescriptor(target, prop);
+    },
+    has(target, prop) {
+      return isIsolatedStateKey(prop)
+        ? prop in isolated || prop in target
+        : Reflect.has(target, prop);
+    },
+    ownKeys(target) {
+      return [
+        ...new Set([...Reflect.ownKeys(target), ...Reflect.ownKeys(isolated)]),
+      ];
+    },
+    set(target, prop, value, receiver) {
+      if (isIsolatedStateKey(prop)) {
+        isolated[prop] = value;
+        return true;
+      }
+      return Reflect.set(target, prop, value, receiver);
+    },
+  });
+
 if (!Object.prototype.hasOwnProperty.call(globalThis, JEST_MATCHERS_OBJECT)) {
   const defaultState: MatcherState = {
     assertionCalls: 0,
@@ -35,19 +130,52 @@ if (!Object.prototype.hasOwnProperty.call(globalThis, JEST_MATCHERS_OBJECT)) {
   Object.defineProperty(globalThis, JEST_MATCHERS_OBJECT, {
     value: {
       customEqualityTesters: [],
+      isolatedMatcherStates: new Map(),
       matchers: Object.create(null),
       state: defaultState,
     },
   });
 }
 
-export const getState = <State extends MatcherState = MatcherState>(): State =>
-  (globalThis as any)[JEST_MATCHERS_OBJECT].state;
+const getMatchersObject = (): JestMatchersObject => {
+  const store = (globalThis as any)[JEST_MATCHERS_OBJECT] as JestMatchersObject;
+  // Another copy of `expect` may have created the registry without isolation.
+  if (store.isolatedMatcherStates == null) {
+    store.isolatedMatcherStates = new Map();
+  }
+  return store;
+};
+
+const getConcurrentTestName = (): string | undefined =>
+  getMatchersObject().state.currentConcurrentTestName?.();
+
+const getIsolatedStateView = (testName: string): MatcherState => {
+  const store = getMatchersObject();
+  const existing = store.isolatedMatcherStates.get(testName);
+  if (existing) {
+    return existing.view;
+  }
+
+  const isolated = createIsolatedMatcherState();
+  const view = createIsolatedStateView(store.state, isolated);
+  store.isolatedMatcherStates.set(testName, {isolated, view});
+  return view;
+};
+
+export const getState = <
+  State extends MatcherState = MatcherState,
+>(): State => {
+  const testName = getConcurrentTestName();
+  if (testName != null) {
+    return getIsolatedStateView(testName) as State;
+  }
+  return getMatchersObject().state as State;
+};
 
 export const setState = <State extends MatcherState = MatcherState>(
   state: Partial<State>,
 ): void => {
-  Object.assign((globalThis as any)[JEST_MATCHERS_OBJECT].state, state);
+  Object.assign(getState<State>(), state);
 };
 
 export const getMatchers = (): MatchersObject =>

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/concurrentAssertions.test.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/concurrentAssertions.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {afterEach, beforeEach, describe, expect, it} from '@jest/globals';
+import type {Circus} from '@jest/types';
+import {eventHandler} from '../jestAdapterInit';
+
+describe('expect.assertions with concurrent test names', () => {
+  const previousGetter = expect.getState().currentConcurrentTestName;
+  let activeTest: string | undefined;
+
+  beforeEach(() => {
+    activeTest = undefined;
+    expect.setState({
+      currentConcurrentTestName: () => activeTest ?? previousGetter?.(),
+    });
+  });
+
+  afterEach(() => {
+    activeTest = undefined;
+    expect.setState({currentConcurrentTestName: previousGetter});
+  });
+
+  it('does not leak assertion counts across concurrent tests', async () => {
+    const testA = {errors: []} as unknown as Circus.TestEntry;
+    const testB = {errors: []} as unknown as Circus.TestEntry;
+
+    activeTest = 'A';
+    expect.assertions(1);
+    expect(1).toBe(1);
+
+    activeTest = 'B';
+    expect.assertions(1);
+    expect(1).toBe(1);
+
+    activeTest = 'A';
+    await eventHandler({name: 'test_done', test: testA});
+
+    activeTest = 'B';
+    await eventHandler({name: 'test_done', test: testB});
+
+    activeTest = undefined;
+    expect(testA.errors).toEqual([]);
+    expect(testB.errors).toEqual([]);
+  });
+
+  it('keeps a sibling concurrent test passing when one exceeds its budget', async () => {
+    const testA = {errors: []} as unknown as Circus.TestEntry;
+    const testB = {errors: []} as unknown as Circus.TestEntry;
+
+    activeTest = 'A';
+    expect.assertions(1);
+    expect(1).toBe(1);
+    expect(2).toBe(2);
+
+    activeTest = 'B';
+    expect.assertions(1);
+    expect(1).toBe(1);
+
+    activeTest = 'A';
+    await eventHandler({name: 'test_done', test: testA});
+
+    activeTest = 'B';
+    await eventHandler({name: 'test_done', test: testB});
+
+    activeTest = undefined;
+    expect(testA.errors).toHaveLength(1);
+    expect(testB.errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

`expect.assertions(n)` and `expect.hasAssertions()` store their counters on a single global matcher state object. When two `test.concurrent` cases run at the same time, they increment and check the same `assertionCalls` field, so a pair of tests that each declare `expect.assertions(1)` fails with "Expected one assertion to be called but received two assertion calls."

jest-circus already exposes the active test id through `currentConcurrentTestName` (backed by `AsyncLocalStorage`). `expect.getState()` / `setState()` now keep assertion-related fields on a per-test view keyed by that name, so each concurrent test has its own budget.

Fixes #14263

## Test plan

- Unit tests in `packages/expect` interleave two synthetic concurrent names and assert that each test only sees its own assertion count / `hasAssertions` result.
- Unit tests in `jest-circus` drive `eventHandler` `test_done` for two overlapping concurrent names.
- e2e fixtures under `e2e/circus-concurrent` cover passing concurrent + sequential `expect.assertions` / `expect.hasAssertions`, and a sibling that exceeds its budget without failing the other test.
- `FORCE_COLOR=1 yarn jest packages/expect/src/__tests__/assertionCounts.test.ts packages/jest-circus/src/legacy-code-todo-rewrite/__tests__/concurrentAssertions.test.ts e2e/__tests__/circusConcurrent.test.ts`