### PR TITLE
[jest-circus] Clear the current test after skipped and todo tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
+- `[jest-circus]` Clear `currentlyRunningTest` after skipped and todo tests ([#16342](https://github.com/jestjs/jest/pull/16342))
 - `[jest-circus, jest-jasmine2, jest-message-util]` Serialize the inner errors of an `AggregateError` into `failureMessages`, `retryReasons` and `unhandledErrors`, so `--json` output and reporter annotations include them ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[@jest/create-cache-key-function]` Include the caller support flags in the generated key, so a transformer that emits ESM or CJS based on them no longer shares one cache entry between the two ([#16331](https://github.com/jestjs/jest/pull/16331))
 - `[@jest/create-cache-key-function]` Include the stringified project config in the generated key, so editing a transformer's own settings invalidates what it cached ([#16331](https://github.com/jestjs/jest/pull/16331))

--- a/packages/jest-circus/src/__tests__/eventHandler.test.ts
+++ b/packages/jest-circus/src/__tests__/eventHandler.test.ts
@@ -8,7 +8,9 @@
 // addEventHandler and removeEventHandler are provided in the ./index
 import {addEventHandler, removeEventHandler} from '../index';
 // dispatch comes from the ./state
-import {dispatch} from '../state';
+import eventHandler from '../eventHandler';
+import {dispatch, getState, resetState} from '../state';
+import {makeTest} from '../utils';
 
 test('addEventHandler and removeEventHandler control handlers', async () => {
   const spy: any = jest.fn();
@@ -22,4 +24,29 @@ test('addEventHandler and removeEventHandler control handlers', async () => {
   expect(spy).not.toHaveBeenCalledWith({name: 'unknown2'}, expect.anything());
   await dispatch({name: 'unknown2' as any});
   expect(spy).not.toHaveBeenCalledWith({name: 'unknown2'}, expect.anything());
+});
+
+test('clears the currently running test when a test is skipped or todo', async () => {
+  resetState();
+  const state = getState();
+  const circusTest = makeTest(
+    () => {},
+    undefined,
+    false,
+    'test',
+    state.rootDescribeBlock,
+    undefined,
+    new Error(),
+    false,
+  );
+
+  state.currentlyRunningTest = circusTest;
+  await eventHandler({name: 'test_skip', test: circusTest}, state);
+  expect(circusTest.status).toBe('skip');
+  expect(state.currentlyRunningTest).toBeNull();
+
+  state.currentlyRunningTest = circusTest;
+  await eventHandler({name: 'test_todo', test: circusTest}, state);
+  expect(circusTest.status).toBe('todo');
+  expect(state.currentlyRunningTest).toBeNull();
 });

--- a/packages/jest-circus/src/eventHandler.ts
+++ b/packages/jest-circus/src/eventHandler.ts
@@ -184,10 +184,12 @@ const eventHandler: Circus.EventHandler = (event, state) => {
     }
     case 'test_skip': {
       event.test.status = 'skip';
+      state.currentlyRunningTest = null;
       break;
     }
     case 'test_todo': {
       event.test.status = 'todo';
+      state.currentlyRunningTest = null;
       break;
     }
     case 'test_done': {


### PR DESCRIPTION
## Summary

`test_start` sets `currentlyRunningTest`, but skipped and todo tests return
without a `test_done` event. Clear the current test in `test_skip` and
`test_todo` so later errors are not attributed to a test that never ran.

Add a focused event-handler regression test covering both terminal states.

## Test plan

- `corepack yarn jest packages/jest-circus/src/__tests__/eventHandler.test.ts --runInBand`
- `corepack yarn jest packages/jest-circus --runInBand`
- `corepack yarn build`
- `corepack yarn typecheck:tests`
- `corepack yarn lint`
- `corepack yarn check-copyright-headers`
- `corepack yarn check-changelog`
- `corepack yarn constraints`
- `corepack yarn dedupe --check`
- `corepack yarn verify-pnp`
