### PR TITLE
[jest-circus] Isolate done callback state between invocations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
+- `[jest-circus]` Prevent late `done()` callbacks from affecting later test or hook invocations ([#16343](https://github.com/jestjs/jest/pull/16343))
 - `[jest-circus, jest-jasmine2, jest-message-util]` Serialize the inner errors of an `AggregateError` into `failureMessages`, `retryReasons` and `unhandledErrors`, so `--json` output and reporter annotations include them ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[@jest/create-cache-key-function]` Include the caller support flags in the generated key, so a transformer that emits ESM or CJS based on them no longer shares one cache entry between the two ([#16331](https://github.com/jestjs/jest/pull/16331))
 - `[@jest/create-cache-key-function]` Include the stringified project config in the generated key, so editing a transformer's own settings invalidates what it cached ([#16331](https://github.com/jestjs/jest/pull/16331))

--- a/packages/jest-circus/src/__tests__/utils.test.ts
+++ b/packages/jest-circus/src/__tests__/utils.test.ts
@@ -5,9 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import type {Circus} from '@jest/types';
 import {runTest} from '../__mocks__/testUtils';
 import {ROOT_DESCRIBE_BLOCK_NAME} from '../state';
 import {
+  callAsyncCircusFn,
   makeDescribe,
   makeRunResult,
   makeSingleTestResult,
@@ -138,4 +140,38 @@ test('makeRunResult keeps the unserialized unhandled errors', () => {
 
   expect(result.unhandledErrorsDetailed[0]).toBe(error);
   expect(result.unhandledErrors[0]).toBe(error.stack);
+});
+
+test('a late done callback does not affect a later invocation', async () => {
+  const rootDescribe = makeDescribe(ROOT_DESCRIBE_BLOCK_NAME);
+  let firstDone: Circus.DoneFn = () => {};
+  const circusTest = makeTest(
+    done => {
+      firstDone = done;
+    },
+    undefined,
+    false,
+    'done callback test',
+    rootDescribe,
+    undefined,
+    new Error('async error'),
+    false,
+  );
+  const options = {isHook: false, timeout: 1000};
+
+  const firstInvocation = callAsyncCircusFn(circusTest, {}, options);
+  firstDone(new Error('first failure'));
+  await expect(firstInvocation).rejects.toThrow('first failure');
+
+  circusTest.seenDone = false;
+  let secondDone: Circus.DoneFn = () => {};
+  circusTest.fn = done => {
+    secondDone = done;
+  };
+
+  const secondInvocation = callAsyncCircusFn(circusTest, {}, options);
+  firstDone();
+  secondDone();
+
+  await expect(secondInvocation).resolves.toBeUndefined();
 });

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -230,7 +230,7 @@ export const callAsyncCircusFn = (
           }
           reject(errorAtDone);
           throw errorAtDone;
-        } else {
+        } else if (!completed) {
           testOrHook.seenDone = true;
         }
 


### PR DESCRIPTION
## Summary

A `done` callback can run after its `callAsyncCircusFn` invocation has already
settled. The completed callback currently writes to the shared `seenDone`
state, so it can make the first `done` call of a later invocation look like a
duplicate.

Only mark `seenDone` while the callback's own invocation is active. The
regression test controls the callback order without timers, while the existing
E2E test verifies that two `done` calls in the same invocation still fail.

## Test plan

- `corepack yarn jest packages/jest-circus/src/__tests__/utils.test.ts --runInBand`
- `corepack yarn jest e2e/__tests__/callDoneTwice.test.ts --runInBand`
- `corepack yarn jest packages/jest-circus --runInBand`
- `corepack yarn build`
- `corepack yarn typecheck:tests`
- `corepack yarn lint`
- `corepack yarn check-copyright-headers`
- `corepack yarn check-changelog`
- `corepack yarn constraints`
- `corepack yarn dedupe --check`
- `corepack yarn verify-pnp`
