### PR TITLE
[jest-circus, jest-snapshot] Preserve unrelated inline snapshots across test retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - `[jest-circus]` Clear `currentlyRunningTest` after skipped and todo tests ([#16342](https://github.com/jestjs/jest/pull/16342))
 - `[jest-circus]` Prevent late `done()` callbacks from affecting later test or hook invocations ([#16343](https://github.com/jestjs/jest/pull/16343))
 - `[jest-circus, jest-jasmine2, jest-message-util]` Serialize the inner errors of an `AggregateError` into `failureMessages`, `retryReasons` and `unhandledErrors`, so `--json` output and reporter annotations include them ([#16316](https://github.com/jestjs/jest/pull/16316))
-- `[jest-circus, jest-snapshot]` Preserve inline snapshots from other tests when retrying a failed test ([#16344](https://github.com/jestjs/jest/pull/16344))
+- `[jest-circus, jest-snapshot]` Keep snapshot state and counts correct when a test retries ([#16344](https://github.com/jestjs/jest/pull/16344))
 - `[@jest/create-cache-key-function]` Include the caller support flags in the generated key, so a transformer that emits ESM or CJS based on them no longer shares one cache entry between the two ([#16331](https://github.com/jestjs/jest/pull/16331))
 - `[@jest/create-cache-key-function]` Include the stringified project config in the generated key, so editing a transformer's own settings invalidates what it cached ([#16331](https://github.com/jestjs/jest/pull/16331))
 - `[@jest/transform]` Include the caller support flags in a transform's cache key, so a file transformed both as ESM and as CJS no longer serves one shape's output for the other ([#16331](https://github.com/jestjs/jest/pull/16331))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))
 - `[jest-circus, jest-jasmine2, jest-message-util]` Serialize the inner errors of an `AggregateError` into `failureMessages`, `retryReasons` and `unhandledErrors`, so `--json` output and reporter annotations include them ([#16316](https://github.com/jestjs/jest/pull/16316))
+- `[jest-circus, jest-snapshot]` Preserve inline snapshots from other tests when retrying a failed test ([#16344](https://github.com/jestjs/jest/pull/16344))
 - `[@jest/create-cache-key-function]` Include the caller support flags in the generated key, so a transformer that emits ESM or CJS based on them no longer shares one cache entry between the two ([#16331](https://github.com/jestjs/jest/pull/16331))
 - `[@jest/create-cache-key-function]` Include the stringified project config in the generated key, so editing a transformer's own settings invalidates what it cached ([#16331](https://github.com/jestjs/jest/pull/16331))
 - `[@jest/transform]` Include the caller support flags in a transform's cache key, so a file transformed both as ESM and as CJS no longer serves one shape's output for the other ([#16331](https://github.com/jestjs/jest/pull/16331))

--- a/e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts
+++ b/e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts
@@ -119,7 +119,7 @@ test('works when multiple tests have snapshots but only one of them failed multi
       [filename]: template(['index', '4' /* retries */]),
     });
     const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
-    expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
+    expect(stderr).toMatch('Snapshots:   2 passed, 2 total');
     expect(exitCode).toBe(0);
   }
 });

--- a/e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts
+++ b/e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts
@@ -6,6 +6,7 @@
  */
 
 import * as path from 'path';
+import * as fs from 'graceful-fs';
 import {skipSuiteOnJasmine} from '@jest/test-utils';
 import {cleanup, makeTemplate, writeFiles} from '../Utils';
 import runJest from '../runJest';
@@ -121,4 +122,49 @@ test('works when multiple tests have snapshots but only one of them failed multi
     expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
     expect(exitCode).toBe(0);
   }
+});
+
+test('preserves added and updated snapshots from colliding full names', () => {
+  const filename = 'preserve-unrelated-inline-snapshots.test.js';
+  const template = makeTemplate(`
+    let attempt = 0;
+    jest.retryTimes(2);
+
+    describe('a', () => {
+      test('b c', () => {
+        expect('before retry').toMatchInlineSnapshot(\`"outdated"\`);
+        expect('new snapshot').toMatchInlineSnapshot();
+      });
+    });
+
+    describe('a b', () => {
+      test('c', () => {
+        attempt += 1;
+        expect('retry ' + attempt).toMatchInlineSnapshot();
+        expect(attempt).toBe(3);
+      });
+    });
+  `);
+
+  writeFiles(TESTS_DIR, {[filename]: template([])});
+  const {stderr, exitCode} = runJest(DIR, [
+    '-w=1',
+    '--ci=false',
+    '-u',
+    filename,
+  ]);
+  const testContents = fs.readFileSync(path.join(TESTS_DIR, filename), 'utf8');
+
+  expect(stderr).not.toContain(
+    'Multiple inline snapshots for the same call are not supported.',
+  );
+  expect(stderr).toMatch('2 snapshots written from 1 test suite.');
+  expect(stderr).toMatch('1 snapshot updated from 1 test suite.');
+  expect(testContents).toContain('toMatchInlineSnapshot(`"before retry"`)');
+  expect(testContents).toContain('toMatchInlineSnapshot(`"new snapshot"`)');
+  expect(testContents).toContain('toMatchInlineSnapshot(`"retry 3"`)');
+  expect(testContents).not.toContain('`"retry 1"`');
+  expect(testContents).not.toContain('`"retry 2"`');
+  expect(testContents.match(/toMatchInlineSnapshot\(`/g)).toHaveLength(3);
+  expect(exitCode).toBe(0);
 });

--- a/e2e/__tests__/toMatchSnapshotWithRetries.test.ts
+++ b/e2e/__tests__/toMatchSnapshotWithRetries.test.ts
@@ -6,6 +6,7 @@
  */
 
 import * as path from 'path';
+import * as fs from 'graceful-fs';
 import {skipSuiteOnJasmine} from '@jest/test-utils';
 import {cleanup, makeTemplate, writeFiles} from '../Utils';
 import runJest from '../runJest';
@@ -149,6 +150,46 @@ exports[\`varies 2\`] = \`"b"\`;
   // the run, even though every test passed.
   expect(exitCode).toBe(1);
   expect(stderr).toMatch('Snapshots:   1 obsolete, 1 passed, 1 total');
+});
+
+test('keeps counters for colliding full names across an immediate retry', () => {
+  const filename = 'counters-across-immediate-retries.test.js';
+  const template = makeTemplate(`
+    let attempt = 0;
+    jest.retryTimes(1, {retryImmediately: true});
+
+    describe('a', () => {
+      test('b c', () => {
+        expect('first').toMatchSnapshot();
+      });
+    });
+
+    test('flaky', () => {
+      attempt += 1;
+      expect(attempt).toBe(2);
+    });
+
+    describe('a b', () => {
+      test('c', () => {
+        expect('second').toMatchSnapshot();
+      });
+    });
+  `);
+
+  writeFiles(TESTS_DIR, {[filename]: template([])});
+
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+  const snapshot = fs.readFileSync(
+    path.join(TESTS_DIR, '__snapshots__', `${filename}.snap`),
+    'utf8',
+  );
+
+  // The two full names collide, so the second test's key must keep counting
+  // from the first test's, even though the flaky test was cleared in between.
+  expect(exitCode).toBe(0);
+  expect(stderr).toMatch('Snapshots:   2 written, 2 total');
+  expect(snapshot).toContain('exports[`a b c 1`] = `"first"`;');
+  expect(snapshot).toContain('exports[`a b c 2`] = `"second"`;');
 });
 
 test('scopes retry cleanup to the test, not its enclosing hooks', () => {

--- a/e2e/__tests__/toMatchSnapshotWithRetries.test.ts
+++ b/e2e/__tests__/toMatchSnapshotWithRetries.test.ts
@@ -88,6 +88,132 @@ exports[\`with retries flaky snapshot 1\`] = \`3\`;
   expect(stderr).toMatch('Snapshots:   1 written, 1 passed, 2 total');
 });
 
+test('reports a snapshot added on a discarded attempt as written', () => {
+  const filename = 'written-on-retry.test.js';
+  const template = makeTemplate(`
+    let index = 0;
+    afterEach(() => {
+      index += 1;
+    });
+    jest.retryTimes(1);
+    test('existing', () => expect('old').toMatchSnapshot());
+    test('adds a new snapshot then fails once', () => {
+      expect('brand new').toMatchSnapshot();
+      expect(index).toBe(2);
+    });
+  `);
+
+  writeFiles(TESTS_DIR, {
+    [filename]: template([]),
+    [`__snapshots__/${filename}.snap`]: `// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[\`existing 1\`] = \`"old"\`;
+`,
+  });
+
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+
+  expect(exitCode).toBe(0);
+  expect(stderr).toMatch('1 snapshot written from 1 test suite.');
+  expect(stderr).toMatch('Snapshots:   1 written, 1 passed, 2 total');
+});
+
+test('still reports a snapshot only reached on a discarded attempt as obsolete', () => {
+  const filename = 'obsolete-across-retries.test.js';
+  const template = makeTemplate(`
+    let attempt = 0;
+    jest.retryTimes(1);
+    test('varies', () => {
+      attempt += 1;
+      expect('a').toMatchSnapshot();
+      if (attempt === 1) {
+        expect('b').toMatchSnapshot();
+        throw new Error('fail once');
+      }
+    });
+  `);
+
+  writeFiles(TESTS_DIR, {
+    [filename]: template([]),
+    [`__snapshots__/${filename}.snap`]: `// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[\`varies 1\`] = \`"a"\`;
+
+exports[\`varies 2\`] = \`"b"\`;
+`,
+  });
+
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+
+  // Matches a run without retries: an obsolete snapshot is reported and fails
+  // the run, even though every test passed.
+  expect(exitCode).toBe(1);
+  expect(stderr).toMatch('Snapshots:   1 obsolete, 1 passed, 1 total');
+});
+
+test('scopes retry cleanup to the test, not its enclosing hooks', () => {
+  const filename = 'hook-snapshots-on-retry.test.js';
+  const template = makeTemplate(`
+    let attempt = 0;
+    jest.retryTimes(1);
+
+    describe('suite', () => {
+      beforeAll(() => {
+        expect('from beforeAll').toMatchSnapshot();
+      });
+      beforeEach(() => {
+        expect('from beforeEach').toMatchSnapshot();
+      });
+      test('flaky', () => {
+        attempt += 1;
+        expect('from test').toMatchSnapshot();
+        expect(attempt).toBe(2);
+      });
+    });
+  `);
+
+  writeFiles(TESTS_DIR, {[filename]: template([])});
+
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+
+  // `beforeAll` runs outside the test, so its snapshot is written once and
+  // survives the retry. The `beforeEach` and test snapshots belong to the test,
+  // so the discarded attempt's copies are rolled back and written once each.
+  expect(exitCode).toBe(0);
+  expect(stderr).toMatch('3 snapshots written from 1 test suite.');
+  expect(stderr).toMatch('Snapshots:   3 written, 3 total');
+});
+
+test('keeps concurrent tests independent when one of them retries', () => {
+  const filename = 'concurrent-snapshots-on-retry.test.js';
+  const template = makeTemplate(`
+    let attempt = 0;
+    jest.retryTimes(1);
+
+    test.concurrent('steady', async () => {
+      expect('steady value').toMatchSnapshot();
+    });
+    test.concurrent('flaky', async () => {
+      attempt += 1;
+      expect('flaky value').toMatchSnapshot();
+      expect(attempt).toBe(2);
+    });
+  `);
+
+  writeFiles(TESTS_DIR, {[filename]: template([])});
+
+  const {stderr, exitCode} = runJest(DIR, [
+    '-w=1',
+    '--maxConcurrency=1',
+    '--ci=false',
+    filename,
+  ]);
+
+  expect(exitCode).toBe(0);
+  expect(stderr).toMatch('2 snapshots written from 1 test suite.');
+  expect(stderr).toMatch('Snapshots:   2 written, 2 total');
+});
+
 test('works when multiple tests have snapshots but only one of them failed multiple times', () => {
   const filename = 'basic-support.test.js';
   const template = makeTemplate(`

--- a/e2e/__tests__/toMatchSnapshotWithRetries.test.ts
+++ b/e2e/__tests__/toMatchSnapshotWithRetries.test.ts
@@ -58,6 +58,36 @@ test('works with a single snapshot', () => {
   }
 });
 
+test('keeps snapshot counts from other tests when a test retries', () => {
+  const filename = 'counts-across-retries.test.js';
+  const template = makeTemplate(`
+    test('passing snapshot', () => expect('foo').toMatchSnapshot());
+
+    describe('with retries', () => {
+      let index = 0;
+      afterEach(() => {
+        index += 1;
+      });
+      jest.retryTimes(4);
+      test('flaky snapshot', () => expect(index).toMatchSnapshot());
+    });
+  `);
+
+  writeFiles(TESTS_DIR, {
+    [filename]: template([]),
+    [`__snapshots__/${filename}.snap`]: `// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[\`with retries flaky snapshot 1\`] = \`3\`;
+`,
+  });
+
+  const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+
+  expect(exitCode).toBe(0);
+  expect(stderr).toMatch('1 snapshot written from 1 test suite.');
+  expect(stderr).toMatch('Snapshots:   1 written, 1 passed, 2 total');
+});
+
 test('works when multiple tests have snapshots but only one of them failed multiple times', () => {
   const filename = 'basic-support.test.js';
   const template = makeTemplate(`
@@ -96,7 +126,7 @@ test('works when multiple tests have snapshots but only one of them failed multi
       [filename]: template(['index', '4' /* retries */]),
     });
     const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
-    expect(stderr).toMatch('Snapshots:   1 passed, 1 total');
+    expect(stderr).toMatch('Snapshots:   2 passed, 2 total');
     expect(exitCode).toBe(0);
   }
 });

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -65,8 +65,13 @@ export interface MatcherUtils {
 export interface MatcherState {
   assertionCalls: number;
   currentConcurrentTestName?: () => string | undefined;
+  /**
+   * Stable identity of the currently running test: the same object across the
+   * retries of one test, a different object for every other test, even when
+   * full test names collide. `undefined` outside a test.
+   */
+  currentTestIdentity?: () => object | undefined;
   currentTestName?: string;
-  currentTestRetryOwner?: () => object | undefined;
   error?: Error;
   expand?: boolean;
   expectedAssertionsNumber: number | null;

--- a/packages/expect/src/types.ts
+++ b/packages/expect/src/types.ts
@@ -66,6 +66,7 @@ export interface MatcherState {
   assertionCalls: number;
   currentConcurrentTestName?: () => string | undefined;
   currentTestName?: string;
+  currentTestRetryOwner?: () => object | undefined;
   error?: Error;
   expand?: boolean;
   expectedAssertionsNumber: number | null;

--- a/packages/jest-circus/src/__tests__/run.test.ts
+++ b/packages/jest-circus/src/__tests__/run.test.ts
@@ -31,14 +31,14 @@ afterEach(() => {
 
 test('expect state exposes the same test entry across retries', async () => {
   const observedNames: Array<string | undefined> = [];
-  const observedOwners: Array<object | undefined> = [];
+  const observedIdentities: Array<object | undefined> = [];
   let attempts = 0;
 
   circusTest('retried test', () => {
     attempts++;
     const expectState = jestExpect.getState();
     observedNames.push(expectState.currentConcurrentTestName?.());
-    observedOwners.push(expectState.currentTestRetryOwner?.());
+    observedIdentities.push(expectState.currentTestIdentity?.());
     if (attempts === 1) {
       throw new Error('retry');
     }
@@ -52,7 +52,7 @@ test('expect state exposes the same test entry across retries', async () => {
   expect(result.testResults[0].status).toBe('done');
   expect(attempts).toBe(2);
   expect(observedNames).toEqual(['retried test', 'retried test']);
-  expect(observedOwners).toEqual([testEntry, testEntry]);
+  expect(observedIdentities).toEqual([testEntry, testEntry]);
   expect(jestExpect.getState().currentConcurrentTestName?.()).toBeUndefined();
-  expect(jestExpect.getState().currentTestRetryOwner?.()).toBeUndefined();
+  expect(jestExpect.getState().currentTestIdentity?.()).toBeUndefined();
 });

--- a/packages/jest-circus/src/__tests__/run.test.ts
+++ b/packages/jest-circus/src/__tests__/run.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {afterEach, beforeEach, expect, test} from '@jest/globals';
+import {jestExpect} from '@jest/expect';
+import type {Circus, Global} from '@jest/types';
+import {test as circusTest} from '../index';
+import run from '../run';
+import {getState, resetState} from '../state';
+import {RETRY_TIMES} from '../types';
+
+let originalRetryTimes: unknown;
+
+beforeEach(() => {
+  resetState();
+  originalRetryTimes = (globalThis as Global.Global)[RETRY_TIMES];
+  (globalThis as Global.Global)[RETRY_TIMES] = '1';
+});
+
+afterEach(() => {
+  if (originalRetryTimes === undefined) {
+    Reflect.deleteProperty(globalThis, RETRY_TIMES);
+  } else {
+    (globalThis as Global.Global)[RETRY_TIMES] = originalRetryTimes;
+  }
+});
+
+test('expect state exposes the same test entry across retries', async () => {
+  const observedNames: Array<string | undefined> = [];
+  const observedOwners: Array<object | undefined> = [];
+  let attempts = 0;
+
+  circusTest('retried test', () => {
+    attempts++;
+    const expectState = jestExpect.getState();
+    observedNames.push(expectState.currentConcurrentTestName?.());
+    observedOwners.push(expectState.currentTestRetryOwner?.());
+    if (attempts === 1) {
+      throw new Error('retry');
+    }
+  });
+
+  const testEntry = getState().rootDescribeBlock
+    .children[0] as Circus.TestEntry;
+  const result = await run();
+
+  expect(result.testResults).toHaveLength(1);
+  expect(result.testResults[0].status).toBe('done');
+  expect(attempts).toBe(2);
+  expect(observedNames).toEqual(['retried test', 'retried test']);
+  expect(observedOwners).toEqual([testEntry, testEntry]);
+  expect(jestExpect.getState().currentConcurrentTestName?.()).toBeUndefined();
+  expect(jestExpect.getState().currentTestRetryOwner?.()).toBeUndefined();
+});

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -357,7 +357,7 @@ const handleSnapshotStateAfterRetry =
     switch (event.name) {
       case 'test_retry': {
         // Clear any snapshot data that occurred in previous test run
-        snapshotState.clear();
+        snapshotState.clear(event.test);
       }
     }
   };

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -28,16 +28,23 @@ import {
 // the original values in the variables before we require any files.
 const {setTimeout} = globalThis;
 
-const testEntryStorage = new AsyncLocalStorage<Circus.TestEntry>();
+type RunningTest = {
+  id: string;
+  test: Circus.TestEntry;
+};
+
+const testEntryStorage = new AsyncLocalStorage<RunningTest>();
+
+const runningTest = (test: Circus.TestEntry): RunningTest => ({
+  id: getTestID(test),
+  test,
+});
 
 const run = async (): Promise<Circus.RunResult> => {
   const {rootDescribeBlock, seed, randomize} = getState();
   jestExpect.setState({
-    currentConcurrentTestName: () => {
-      const test = testEntryStorage.getStore();
-      return test === undefined ? undefined : getTestID(test);
-    },
-    currentTestRetryOwner: () => testEntryStorage.getStore(),
+    currentConcurrentTestName: () => testEntryStorage.getStore()?.id,
+    currentTestRetryOwner: () => testEntryStorage.getStore()?.test,
   });
   const rng = randomize ? rngBuilder(seed) : undefined;
   await dispatch({name: 'run_start'});
@@ -122,7 +129,9 @@ const _runTestsForDescribeBlock = async (
         await new Promise(resolve => setTimeout(resolve, waitBeforeRetry));
       }
 
-      await testEntryStorage.run(test, () => _runTest(test, isSkipped));
+      await testEntryStorage.run(runningTest(test), () =>
+        _runTest(test, isSkipped),
+      );
       numRetriesAvailable--;
     }
   };
@@ -147,7 +156,7 @@ const _runTestsForDescribeBlock = async (
   };
   const runTestWithContext = async (child: Circus.TestEntry) => {
     const hasErrorsBeforeTestRun = child.errors.length > 0;
-    return testEntryStorage.run(child, async () => {
+    return testEntryStorage.run(runningTest(child), async () => {
       await _runTest(child, isSkipped);
       await handleRetry(child, hasErrorsBeforeTestRun, hasRetryTimes);
     });

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -44,7 +44,7 @@ const run = async (): Promise<Circus.RunResult> => {
   const {rootDescribeBlock, seed, randomize} = getState();
   jestExpect.setState({
     currentConcurrentTestName: () => testEntryStorage.getStore()?.id,
-    currentTestRetryOwner: () => testEntryStorage.getStore()?.test,
+    currentTestIdentity: () => testEntryStorage.getStore()?.test,
   });
   const rng = randomize ? rngBuilder(seed) : undefined;
   await dispatch({name: 'run_start'});

--- a/packages/jest-circus/src/run.ts
+++ b/packages/jest-circus/src/run.ts
@@ -28,12 +28,16 @@ import {
 // the original values in the variables before we require any files.
 const {setTimeout} = globalThis;
 
-const testNameStorage = new AsyncLocalStorage<string>();
+const testEntryStorage = new AsyncLocalStorage<Circus.TestEntry>();
 
 const run = async (): Promise<Circus.RunResult> => {
   const {rootDescribeBlock, seed, randomize} = getState();
   jestExpect.setState({
-    currentConcurrentTestName: () => testNameStorage.getStore(),
+    currentConcurrentTestName: () => {
+      const test = testEntryStorage.getStore();
+      return test === undefined ? undefined : getTestID(test);
+    },
+    currentTestRetryOwner: () => testEntryStorage.getStore(),
   });
   const rng = randomize ? rngBuilder(seed) : undefined;
   await dispatch({name: 'run_start'});
@@ -118,7 +122,7 @@ const _runTestsForDescribeBlock = async (
         await new Promise(resolve => setTimeout(resolve, waitBeforeRetry));
       }
 
-      await _runTest(test, isSkipped);
+      await testEntryStorage.run(test, () => _runTest(test, isSkipped));
       numRetriesAvailable--;
     }
   };
@@ -143,7 +147,7 @@ const _runTestsForDescribeBlock = async (
   };
   const runTestWithContext = async (child: Circus.TestEntry) => {
     const hasErrorsBeforeTestRun = child.errors.length > 0;
-    return testNameStorage.run(getTestID(child), async () => {
+    return testEntryStorage.run(child, async () => {
       await _runTest(child, isSkipped);
       await handleRetry(child, hasErrorsBeforeTestRun, hasRetryTimes);
     });

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -66,6 +66,7 @@ type SnapshotCounts = {
 // retry can undo exactly that much and leave the other tests' work alone.
 type AttemptRecord = {
   checkedKeys: Set<string>;
+  counters: Map<string, number | undefined>;
   counts: SnapshotCounts;
   fileSnapshots: Map<string, string | undefined>;
   inlineSnapshots: Set<InlineSnapshot>;
@@ -75,7 +76,7 @@ export default class SnapshotState {
   private _counters: Map<string, number>;
   private _dirty: boolean;
   private readonly _updateSnapshot: Config.SnapshotUpdateState;
-  private _snapshotData: SnapshotData;
+  private readonly _snapshotData: SnapshotData;
   private readonly _snapshotPath: string;
   private _inlineSnapshots: Array<InlineSnapshot>;
   private _attemptRecordsByTest: WeakMap<object, AttemptRecord>;
@@ -173,6 +174,7 @@ export default class SnapshotState {
     if (record === undefined) {
       record = {
         checkedKeys: new Set(),
+        counters: new Map(),
         counts: {added: 0, matched: 0, unmatched: 0, updated: 0},
         fileSnapshots: new Map(),
         inlineSnapshots: new Set(),
@@ -190,10 +192,22 @@ export default class SnapshotState {
     }
   }
 
-  clear(testRetryOwner?: object): void {
-    this._counters = new Map();
+  // Counters number keys per full test name, and full names can collide
+  // across tests. Undoing an increment could double-undo a collision, so the
+  // record keeps each counter's value from before the test first touched it.
+  private _bumpCounter(testName: string, testRetryOwner?: object): number {
+    const record = this._recordFor(testRetryOwner);
+    if (record !== undefined && !record.counters.has(testName)) {
+      record.counters.set(testName, this._counters.get(testName));
+    }
+    const count = (this._counters.get(testName) ?? 0) + 1;
+    this._counters.set(testName, count);
+    return count;
+  }
 
+  clear(testRetryOwner?: object): void {
     if (testRetryOwner === undefined) {
+      this._counters = new Map();
       // TODO(jest next major): require `testRetryOwner` and drop this branch.
       // Unlike the per-owner path below it rolls back neither file snapshot
       // data nor unchecked keys, so a snapshot added before the reset is
@@ -229,6 +243,13 @@ export default class SnapshotState {
     }
     for (const key of record.checkedKeys) {
       this._uncheckedKeys.add(key);
+    }
+    for (const [testName, previous] of record.counters) {
+      if (previous === undefined) {
+        this._counters.delete(testName);
+      } else {
+        this._counters.set(testName, previous);
+      }
     }
   }
 
@@ -301,8 +322,7 @@ export default class SnapshotState {
     error,
     testFailing = false,
   }: SnapshotMatchOptions): SnapshotReturnOptions {
-    this._counters.set(testName, (this._counters.get(testName) || 0) + 1);
-    const count = Number(this._counters.get(testName));
+    const count = this._bumpCounter(testName, testRetryOwner);
 
     if (!key) {
       key = testNameToKey(testName, count);
@@ -425,8 +445,7 @@ export default class SnapshotState {
     key?: string,
     testRetryOwner?: object,
   ): string {
-    this._counters.set(testName, (this._counters.get(testName) || 0) + 1);
-    const count = Number(this._counters.get(testName));
+    const count = this._bumpCounter(testName, testRetryOwner);
 
     if (!key) {
       key = testNameToKey(testName, count);

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -62,18 +62,23 @@ type SnapshotCounts = {
   updated: number;
 };
 
+// Everything a single test contributed since its current attempt began, so a
+// retry can undo exactly that much and leave the other tests' work alone.
+type AttemptRecord = {
+  checkedKeys: Set<string>;
+  counts: SnapshotCounts;
+  fileSnapshots: Map<string, string | undefined>;
+  inlineSnapshots: Set<InlineSnapshot>;
+};
+
 export default class SnapshotState {
   private _counters: Map<string, number>;
   private _dirty: boolean;
-  // @ts-expect-error - seemingly unused?
-  private _index: number;
   private readonly _updateSnapshot: Config.SnapshotUpdateState;
   private _snapshotData: SnapshotData;
-  private readonly _initialData: SnapshotData;
   private readonly _snapshotPath: string;
   private _inlineSnapshots: Array<InlineSnapshot>;
-  private readonly _inlineSnapshotOwners: WeakMap<InlineSnapshot, object>;
-  private _snapshotCountsByTest: WeakMap<object, SnapshotCounts>;
+  private _attemptRecordsByTest: WeakMap<object, AttemptRecord>;
   private readonly _uncheckedKeys: Set<string>;
   private readonly _prettierPath: string | null;
   private readonly _rootDir: string;
@@ -92,16 +97,13 @@ export default class SnapshotState {
       this._snapshotPath,
       options.updateSnapshot,
     );
-    this._initialData = data;
     this._snapshotData = data;
     this._dirty = dirty;
     this._prettierPath = options.prettierPath ?? null;
     this._inlineSnapshots = [];
-    this._inlineSnapshotOwners = new WeakMap();
-    this._snapshotCountsByTest = new WeakMap();
+    this._attemptRecordsByTest = new WeakMap();
     this._uncheckedKeys = new Set(Object.keys(this._snapshotData));
     this._counters = new Map();
-    this._index = 0;
     this.expand = options.expand || false;
     this.added = 0;
     this.matched = 0;
@@ -147,22 +149,57 @@ export default class SnapshotState {
         snapshot: receivedSerialized,
       };
       this._inlineSnapshots.push(inlineSnapshot);
-      if (options.testRetryOwner !== undefined) {
-        this._inlineSnapshotOwners.set(inlineSnapshot, options.testRetryOwner);
-      }
+      this._recordFor(options.testRetryOwner)?.inlineSnapshots.add(
+        inlineSnapshot,
+      );
     } else {
+      // A retried attempt must not leave its writes behind, or the next attempt
+      // sees the key as pre-existing and reports it as matched, not written.
+      const fileSnapshots = this._recordFor(
+        options.testRetryOwner,
+      )?.fileSnapshots;
+      if (fileSnapshots !== undefined && !fileSnapshots.has(key)) {
+        fileSnapshots.set(key, this._snapshotData[key]);
+      }
       this._snapshotData[key] = receivedSerialized;
     }
   }
 
+  private _recordFor(testRetryOwner?: object): AttemptRecord | undefined {
+    if (testRetryOwner === undefined) {
+      return undefined;
+    }
+    let record = this._attemptRecordsByTest.get(testRetryOwner);
+    if (record === undefined) {
+      record = {
+        checkedKeys: new Set(),
+        counts: {added: 0, matched: 0, unmatched: 0, updated: 0},
+        fileSnapshots: new Map(),
+        inlineSnapshots: new Set(),
+      };
+      this._attemptRecordsByTest.set(testRetryOwner, record);
+    }
+    return record;
+  }
+
+  // `match` marks a key as checked so it is not reported obsolete. A key only
+  // reached on a discarded attempt has to go back to being unchecked.
+  private _markKeyChecked(key: string, testRetryOwner?: object): void {
+    if (this._uncheckedKeys.delete(key)) {
+      this._recordFor(testRetryOwner)?.checkedKeys.add(key);
+    }
+  }
+
   clear(testRetryOwner?: object): void {
-    this._snapshotData = this._initialData;
     this._counters = new Map();
-    this._index = 0;
 
     if (testRetryOwner === undefined) {
+      // TODO(jest next major): require `testRetryOwner` and drop this branch.
+      // Unlike the per-owner path below it rolls back neither file snapshot
+      // data nor unchecked keys, so a snapshot added before the reset is
+      // reported as matched and one it checked is never reported obsolete.
       this._inlineSnapshots = [];
-      this._snapshotCountsByTest = new WeakMap();
+      this._attemptRecordsByTest = new WeakMap();
       this.added = 0;
       this.matched = 0;
       this.unmatched = 0;
@@ -170,33 +207,39 @@ export default class SnapshotState {
       return;
     }
 
+    const record = this._attemptRecordsByTest.get(testRetryOwner);
+    if (record === undefined) {
+      return;
+    }
+    this._attemptRecordsByTest.delete(testRetryOwner);
+
     this._inlineSnapshots = this._inlineSnapshots.filter(
-      snapshot => this._inlineSnapshotOwners.get(snapshot) !== testRetryOwner,
+      snapshot => !record.inlineSnapshots.has(snapshot),
     );
-    const counts = this._snapshotCountsByTest.get(testRetryOwner);
-    if (counts !== undefined) {
-      this.added -= counts.added;
-      this.matched -= counts.matched;
-      this.unmatched -= counts.unmatched;
-      this.updated -= counts.updated;
-      this._snapshotCountsByTest.delete(testRetryOwner);
+    this.added -= record.counts.added;
+    this.matched -= record.counts.matched;
+    this.unmatched -= record.counts.unmatched;
+    this.updated -= record.counts.updated;
+    for (const [key, previous] of record.fileSnapshots) {
+      if (previous === undefined) {
+        delete this._snapshotData[key];
+      } else {
+        this._snapshotData[key] = previous;
+      }
+    }
+    for (const key of record.checkedKeys) {
+      this._uncheckedKeys.add(key);
     }
   }
 
   private _incrementSnapshotCount(
-    count: keyof SnapshotCounts,
+    status: keyof SnapshotCounts,
     testRetryOwner?: object,
   ): void {
-    this[count]++;
-    if (testRetryOwner !== undefined) {
-      const counts = this._snapshotCountsByTest.get(testRetryOwner) ?? {
-        added: 0,
-        matched: 0,
-        unmatched: 0,
-        updated: 0,
-      };
-      counts[count]++;
-      this._snapshotCountsByTest.set(testRetryOwner, counts);
+    this[status]++;
+    const record = this._recordFor(testRetryOwner);
+    if (record !== undefined) {
+      record.counts[status]++;
     }
   }
 
@@ -269,7 +312,7 @@ export default class SnapshotState {
     // there's an external snapshot. This way the external snapshot can be
     // removed with `--updateSnapshot`.
     if (!(isInline && this._snapshotData[key] !== undefined)) {
-      this._uncheckedKeys.delete(key);
+      this._markKeyChecked(key, testRetryOwner);
     }
 
     const receivedSerialized = addExtraLineBreaks(
@@ -389,7 +432,7 @@ export default class SnapshotState {
       key = testNameToKey(testName, count);
     }
 
-    this._uncheckedKeys.delete(key);
+    this._markKeyChecked(key, testRetryOwner);
     this._incrementSnapshotCount('unmatched', testRetryOwner);
     return key;
   }

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -62,6 +62,15 @@ type SnapshotCounts = {
   updated: number;
 };
 
+// The dirty flag is monotonic, so undoing it per test needs proof that no
+// other test wrote in between: the value it had before this test's first
+// write, and how many of the writes since then were this test's own.
+type AttemptWrites = {
+  dirtyBefore: boolean;
+  ownWrites: number;
+  writeCountBefore: number;
+};
+
 // Everything a single test contributed since its current attempt began, so a
 // retry can undo exactly that much and leave the other tests' work alone.
 type AttemptRecord = {
@@ -70,6 +79,7 @@ type AttemptRecord = {
   counts: SnapshotCounts;
   fileSnapshots: Map<string, string | undefined>;
   inlineSnapshots: Set<InlineSnapshot>;
+  writes: AttemptWrites | undefined;
 };
 
 export default class SnapshotState {
@@ -80,6 +90,7 @@ export default class SnapshotState {
   private readonly _snapshotPath: string;
   private _inlineSnapshots: Array<InlineSnapshot>;
   private _attemptRecordsByTest: WeakMap<object, AttemptRecord>;
+  private _writeCount: number;
   private readonly _uncheckedKeys: Set<string>;
   private readonly _prettierPath: string | null;
   private readonly _rootDir: string;
@@ -103,6 +114,7 @@ export default class SnapshotState {
     this._prettierPath = options.prettierPath ?? null;
     this._inlineSnapshots = [];
     this._attemptRecordsByTest = new WeakMap();
+    this._writeCount = 0;
     this._uncheckedKeys = new Set(Object.keys(this._snapshotData));
     this._counters = new Map();
     this.expand = options.expand || false;
@@ -132,6 +144,16 @@ export default class SnapshotState {
       testIdentity?: object;
     },
   ): void {
+    const record = this._recordFor(options.testIdentity);
+    if (record !== undefined) {
+      record.writes ??= {
+        dirtyBefore: this._dirty,
+        ownWrites: 0,
+        writeCountBefore: this._writeCount,
+      };
+      record.writes.ownWrites++;
+    }
+    this._writeCount++;
     this._dirty = true;
     if (options.isInline) {
       // eslint-disable-next-line unicorn/error-message
@@ -150,17 +172,12 @@ export default class SnapshotState {
         snapshot: receivedSerialized,
       };
       this._inlineSnapshots.push(inlineSnapshot);
-      this._recordFor(options.testIdentity)?.inlineSnapshots.add(
-        inlineSnapshot,
-      );
+      record?.inlineSnapshots.add(inlineSnapshot);
     } else {
       // A retried attempt must not leave its writes behind, or the next attempt
       // sees the key as pre-existing and reports it as matched, not written.
-      const fileSnapshots = this._recordFor(
-        options.testIdentity,
-      )?.fileSnapshots;
-      if (fileSnapshots !== undefined && !fileSnapshots.has(key)) {
-        fileSnapshots.set(key, this._snapshotData[key]);
+      if (record !== undefined && !record.fileSnapshots.has(key)) {
+        record.fileSnapshots.set(key, this._snapshotData[key]);
       }
       this._snapshotData[key] = receivedSerialized;
     }
@@ -178,6 +195,7 @@ export default class SnapshotState {
         counts: {added: 0, matched: 0, unmatched: 0, updated: 0},
         fileSnapshots: new Map(),
         inlineSnapshots: new Set(),
+        writes: undefined,
       };
       this._attemptRecordsByTest.set(testIdentity, record);
     }
@@ -250,6 +268,16 @@ export default class SnapshotState {
       } else {
         this._counters.set(testName, previous);
       }
+    }
+    // The dirty flag can only be undone when every write since this test's
+    // first was its own; a foreign write in between keeps the flag earned.
+    const writes = record.writes;
+    if (
+      writes !== undefined &&
+      this._writeCount - writes.writeCountBefore === writes.ownWrites
+    ) {
+      this._dirty = writes.dirtyBefore;
+      this._writeCount = writes.writeCountBefore;
     }
   }
 

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -358,7 +358,7 @@ export default class SnapshotState {
     if (testFailing) {
       if (hasSnapshot && !isInline) {
         // Retain current snapshot values.
-        this._addSnapshot(key, expected, {error, isInline});
+        this._addSnapshot(key, expected, {error, isInline, testIdentity});
       }
       return {
         actual: removeExtraLineBreaks(receivedSerialized),

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -279,11 +279,7 @@ export default class SnapshotState {
     if (testFailing) {
       if (hasSnapshot && !isInline) {
         // Retain current snapshot values.
-        this._addSnapshot(key, expected, {
-          error,
-          isInline,
-          testRetryOwner,
-        });
+        this._addSnapshot(key, expected, {error, isInline});
       }
       return {
         actual: removeExtraLineBreaks(receivedSerialized),

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -33,7 +33,7 @@ export type SnapshotStateOptions = {
 
 export type SnapshotMatchOptions = {
   readonly testName: string;
-  readonly testRetryOwner?: object;
+  readonly testIdentity?: object;
   readonly received: unknown;
   readonly key?: string;
   readonly inlineSnapshot?: string;
@@ -129,7 +129,7 @@ export default class SnapshotState {
     options: {
       error?: Error;
       isInline: boolean;
-      testRetryOwner?: object;
+      testIdentity?: object;
     },
   ): void {
     this._dirty = true;
@@ -150,14 +150,14 @@ export default class SnapshotState {
         snapshot: receivedSerialized,
       };
       this._inlineSnapshots.push(inlineSnapshot);
-      this._recordFor(options.testRetryOwner)?.inlineSnapshots.add(
+      this._recordFor(options.testIdentity)?.inlineSnapshots.add(
         inlineSnapshot,
       );
     } else {
       // A retried attempt must not leave its writes behind, or the next attempt
       // sees the key as pre-existing and reports it as matched, not written.
       const fileSnapshots = this._recordFor(
-        options.testRetryOwner,
+        options.testIdentity,
       )?.fileSnapshots;
       if (fileSnapshots !== undefined && !fileSnapshots.has(key)) {
         fileSnapshots.set(key, this._snapshotData[key]);
@@ -166,11 +166,11 @@ export default class SnapshotState {
     }
   }
 
-  private _recordFor(testRetryOwner?: object): AttemptRecord | undefined {
-    if (testRetryOwner === undefined) {
+  private _recordFor(testIdentity?: object): AttemptRecord | undefined {
+    if (testIdentity === undefined) {
       return undefined;
     }
-    let record = this._attemptRecordsByTest.get(testRetryOwner);
+    let record = this._attemptRecordsByTest.get(testIdentity);
     if (record === undefined) {
       record = {
         checkedKeys: new Set(),
@@ -179,24 +179,24 @@ export default class SnapshotState {
         fileSnapshots: new Map(),
         inlineSnapshots: new Set(),
       };
-      this._attemptRecordsByTest.set(testRetryOwner, record);
+      this._attemptRecordsByTest.set(testIdentity, record);
     }
     return record;
   }
 
   // `match` marks a key as checked so it is not reported obsolete. A key only
   // reached on a discarded attempt has to go back to being unchecked.
-  private _markKeyChecked(key: string, testRetryOwner?: object): void {
+  private _markKeyChecked(key: string, testIdentity?: object): void {
     if (this._uncheckedKeys.delete(key)) {
-      this._recordFor(testRetryOwner)?.checkedKeys.add(key);
+      this._recordFor(testIdentity)?.checkedKeys.add(key);
     }
   }
 
   // Counters number keys per full test name, and full names can collide
   // across tests. Undoing an increment could double-undo a collision, so the
   // record keeps each counter's value from before the test first touched it.
-  private _bumpCounter(testName: string, testRetryOwner?: object): number {
-    const record = this._recordFor(testRetryOwner);
+  private _bumpCounter(testName: string, testIdentity?: object): number {
+    const record = this._recordFor(testIdentity);
     if (record !== undefined && !record.counters.has(testName)) {
       record.counters.set(testName, this._counters.get(testName));
     }
@@ -205,11 +205,11 @@ export default class SnapshotState {
     return count;
   }
 
-  clear(testRetryOwner?: object): void {
-    if (testRetryOwner === undefined) {
+  clear(testIdentity?: object): void {
+    if (testIdentity === undefined) {
       this._counters = new Map();
-      // TODO(jest next major): require `testRetryOwner` and drop this branch.
-      // Unlike the per-owner path below it rolls back neither file snapshot
+      // TODO(jest next major): require `testIdentity` and drop this branch.
+      // Unlike the per-test path below it rolls back neither file snapshot
       // data nor unchecked keys, so a snapshot added before the reset is
       // reported as matched and one it checked is never reported obsolete.
       this._inlineSnapshots = [];
@@ -221,11 +221,11 @@ export default class SnapshotState {
       return;
     }
 
-    const record = this._attemptRecordsByTest.get(testRetryOwner);
+    const record = this._attemptRecordsByTest.get(testIdentity);
     if (record === undefined) {
       return;
     }
-    this._attemptRecordsByTest.delete(testRetryOwner);
+    this._attemptRecordsByTest.delete(testIdentity);
 
     this._inlineSnapshots = this._inlineSnapshots.filter(
       snapshot => !record.inlineSnapshots.has(snapshot),
@@ -255,10 +255,10 @@ export default class SnapshotState {
 
   private _incrementSnapshotCount(
     status: keyof SnapshotCounts,
-    testRetryOwner?: object,
+    testIdentity?: object,
   ): void {
     this[status]++;
-    const record = this._recordFor(testRetryOwner);
+    const record = this._recordFor(testIdentity);
     if (record !== undefined) {
       record.counts[status]++;
     }
@@ -314,7 +314,7 @@ export default class SnapshotState {
 
   match({
     testName,
-    testRetryOwner,
+    testIdentity,
     received,
     key,
     inlineSnapshot,
@@ -322,7 +322,7 @@ export default class SnapshotState {
     error,
     testFailing = false,
   }: SnapshotMatchOptions): SnapshotReturnOptions {
-    const count = this._bumpCounter(testName, testRetryOwner);
+    const count = this._bumpCounter(testName, testIdentity);
 
     if (!key) {
       key = testNameToKey(testName, count);
@@ -332,7 +332,7 @@ export default class SnapshotState {
     // there's an external snapshot. This way the external snapshot can be
     // removed with `--updateSnapshot`.
     if (!(isInline && this._snapshotData[key] !== undefined)) {
-      this._markKeyChecked(key, testRetryOwner);
+      this._markKeyChecked(key, testIdentity);
     }
 
     const receivedSerialized = addExtraLineBreaks(
@@ -384,26 +384,26 @@ export default class SnapshotState {
     ) {
       if (this._updateSnapshot === 'all') {
         if (pass) {
-          this._incrementSnapshotCount('matched', testRetryOwner);
+          this._incrementSnapshotCount('matched', testIdentity);
         } else {
           if (hasSnapshot) {
-            this._incrementSnapshotCount('updated', testRetryOwner);
+            this._incrementSnapshotCount('updated', testIdentity);
           } else {
-            this._incrementSnapshotCount('added', testRetryOwner);
+            this._incrementSnapshotCount('added', testIdentity);
           }
           this._addSnapshot(key, receivedSerialized, {
             error,
             isInline,
-            testRetryOwner,
+            testIdentity,
           });
         }
       } else {
         this._addSnapshot(key, receivedSerialized, {
           error,
           isInline,
-          testRetryOwner,
+          testIdentity,
         });
-        this._incrementSnapshotCount('added', testRetryOwner);
+        this._incrementSnapshotCount('added', testIdentity);
       }
 
       return {
@@ -415,7 +415,7 @@ export default class SnapshotState {
       };
     } else {
       if (pass) {
-        this._incrementSnapshotCount('matched', testRetryOwner);
+        this._incrementSnapshotCount('matched', testIdentity);
         return {
           actual: '',
           count,
@@ -424,7 +424,7 @@ export default class SnapshotState {
           pass: true,
         };
       } else {
-        this._incrementSnapshotCount('unmatched', testRetryOwner);
+        this._incrementSnapshotCount('unmatched', testIdentity);
         return {
           actual: removeExtraLineBreaks(receivedSerialized),
           count,
@@ -443,16 +443,16 @@ export default class SnapshotState {
     testName: string,
     _received: unknown,
     key?: string,
-    testRetryOwner?: object,
+    testIdentity?: object,
   ): string {
-    const count = this._bumpCounter(testName, testRetryOwner);
+    const count = this._bumpCounter(testName, testIdentity);
 
     if (!key) {
       key = testNameToKey(testName, count);
     }
 
-    this._markKeyChecked(key, testRetryOwner);
-    this._incrementSnapshotCount('unmatched', testRetryOwner);
+    this._markKeyChecked(key, testIdentity);
+    this._incrementSnapshotCount('unmatched', testIdentity);
     return key;
   }
 }

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -33,6 +33,7 @@ export type SnapshotStateOptions = {
 
 export type SnapshotMatchOptions = {
   readonly testName: string;
+  readonly testRetryOwner?: object;
   readonly received: unknown;
   readonly key?: string;
   readonly inlineSnapshot?: string;
@@ -54,6 +55,11 @@ type SaveStatus = {
   saved: boolean;
 };
 
+type InlineSnapshotMetadata = {
+  readonly snapshotStatus: 'added' | 'updated';
+  readonly testRetryOwner?: object;
+};
+
 export default class SnapshotState {
   private _counters: Map<string, number>;
   private _dirty: boolean;
@@ -64,6 +70,10 @@ export default class SnapshotState {
   private readonly _initialData: SnapshotData;
   private readonly _snapshotPath: string;
   private _inlineSnapshots: Array<InlineSnapshot>;
+  private readonly _inlineSnapshotMetadata: WeakMap<
+    InlineSnapshot,
+    InlineSnapshotMetadata
+  >;
   private readonly _uncheckedKeys: Set<string>;
   private readonly _prettierPath: string | null;
   private readonly _rootDir: string;
@@ -87,6 +97,7 @@ export default class SnapshotState {
     this._dirty = dirty;
     this._prettierPath = options.prettierPath ?? null;
     this._inlineSnapshots = [];
+    this._inlineSnapshotMetadata = new WeakMap();
     this._uncheckedKeys = new Set(Object.keys(this._snapshotData));
     this._counters = new Map();
     this._index = 0;
@@ -111,7 +122,12 @@ export default class SnapshotState {
   private _addSnapshot(
     key: string,
     receivedSerialized: string,
-    options: {isInline: boolean; error?: Error},
+    options: {
+      error?: Error;
+      isInline: boolean;
+      snapshotStatus?: InlineSnapshotMetadata['snapshotStatus'];
+      testRetryOwner?: object;
+    },
   ): void {
     this._dirty = true;
     if (options.isInline) {
@@ -126,24 +142,46 @@ export default class SnapshotState {
           "Jest: Couldn't infer stack frame for inline snapshot.",
         );
       }
-      this._inlineSnapshots.push({
+      const inlineSnapshot = {
         frame,
         snapshot: receivedSerialized,
+      };
+      this._inlineSnapshots.push(inlineSnapshot);
+      this._inlineSnapshotMetadata.set(inlineSnapshot, {
+        snapshotStatus: options.snapshotStatus ?? 'added',
+        testRetryOwner: options.testRetryOwner,
       });
     } else {
       this._snapshotData[key] = receivedSerialized;
     }
   }
 
-  clear(): void {
+  clear(testRetryOwner?: object): void {
     this._snapshotData = this._initialData;
-    this._inlineSnapshots = [];
+    this._inlineSnapshots =
+      testRetryOwner === undefined
+        ? []
+        : this._inlineSnapshots.filter(
+            snapshot =>
+              this._inlineSnapshotMetadata.get(snapshot)?.testRetryOwner !==
+              testRetryOwner,
+          );
+    let retainedAdded = 0;
+    let retainedUpdated = 0;
+    for (const snapshot of this._inlineSnapshots) {
+      const metadata = this._inlineSnapshotMetadata.get(snapshot);
+      if (metadata?.snapshotStatus === 'added') {
+        retainedAdded++;
+      } else if (metadata?.snapshotStatus === 'updated') {
+        retainedUpdated++;
+      }
+    }
     this._counters = new Map();
     this._index = 0;
-    this.added = 0;
+    this.added = retainedAdded;
     this.matched = 0;
     this.unmatched = 0;
-    this.updated = 0;
+    this.updated = retainedUpdated;
   }
 
   save(): SaveStatus {
@@ -196,6 +234,7 @@ export default class SnapshotState {
 
   match({
     testName,
+    testRetryOwner,
     received,
     key,
     inlineSnapshot,
@@ -240,7 +279,11 @@ export default class SnapshotState {
     if (testFailing) {
       if (hasSnapshot && !isInline) {
         // Retain current snapshot values.
-        this._addSnapshot(key, expected, {error, isInline});
+        this._addSnapshot(key, expected, {
+          error,
+          isInline,
+          testRetryOwner,
+        });
       }
       return {
         actual: removeExtraLineBreaks(receivedSerialized),
@@ -273,10 +316,20 @@ export default class SnapshotState {
           } else {
             this.added++;
           }
-          this._addSnapshot(key, receivedSerialized, {error, isInline});
+          this._addSnapshot(key, receivedSerialized, {
+            error,
+            isInline,
+            snapshotStatus: hasSnapshot ? 'updated' : 'added',
+            testRetryOwner,
+          });
         }
       } else {
-        this._addSnapshot(key, receivedSerialized, {error, isInline});
+        this._addSnapshot(key, receivedSerialized, {
+          error,
+          isInline,
+          snapshotStatus: 'added',
+          testRetryOwner,
+        });
         this.added++;
       }
 

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -55,9 +55,11 @@ type SaveStatus = {
   saved: boolean;
 };
 
-type InlineSnapshotMetadata = {
-  readonly snapshotStatus: 'added' | 'updated';
-  readonly testRetryOwner?: object;
+type SnapshotCounts = {
+  added: number;
+  matched: number;
+  unmatched: number;
+  updated: number;
 };
 
 export default class SnapshotState {
@@ -70,10 +72,8 @@ export default class SnapshotState {
   private readonly _initialData: SnapshotData;
   private readonly _snapshotPath: string;
   private _inlineSnapshots: Array<InlineSnapshot>;
-  private readonly _inlineSnapshotMetadata: WeakMap<
-    InlineSnapshot,
-    InlineSnapshotMetadata
-  >;
+  private readonly _inlineSnapshotOwners: WeakMap<InlineSnapshot, object>;
+  private _snapshotCountsByTest: WeakMap<object, SnapshotCounts>;
   private readonly _uncheckedKeys: Set<string>;
   private readonly _prettierPath: string | null;
   private readonly _rootDir: string;
@@ -97,7 +97,8 @@ export default class SnapshotState {
     this._dirty = dirty;
     this._prettierPath = options.prettierPath ?? null;
     this._inlineSnapshots = [];
-    this._inlineSnapshotMetadata = new WeakMap();
+    this._inlineSnapshotOwners = new WeakMap();
+    this._snapshotCountsByTest = new WeakMap();
     this._uncheckedKeys = new Set(Object.keys(this._snapshotData));
     this._counters = new Map();
     this._index = 0;
@@ -125,7 +126,6 @@ export default class SnapshotState {
     options: {
       error?: Error;
       isInline: boolean;
-      snapshotStatus?: InlineSnapshotMetadata['snapshotStatus'];
       testRetryOwner?: object;
     },
   ): void {
@@ -147,10 +147,9 @@ export default class SnapshotState {
         snapshot: receivedSerialized,
       };
       this._inlineSnapshots.push(inlineSnapshot);
-      this._inlineSnapshotMetadata.set(inlineSnapshot, {
-        snapshotStatus: options.snapshotStatus ?? 'added',
-        testRetryOwner: options.testRetryOwner,
-      });
+      if (options.testRetryOwner !== undefined) {
+        this._inlineSnapshotOwners.set(inlineSnapshot, options.testRetryOwner);
+      }
     } else {
       this._snapshotData[key] = receivedSerialized;
     }
@@ -158,30 +157,47 @@ export default class SnapshotState {
 
   clear(testRetryOwner?: object): void {
     this._snapshotData = this._initialData;
-    this._inlineSnapshots =
-      testRetryOwner === undefined
-        ? []
-        : this._inlineSnapshots.filter(
-            snapshot =>
-              this._inlineSnapshotMetadata.get(snapshot)?.testRetryOwner !==
-              testRetryOwner,
-          );
-    let retainedAdded = 0;
-    let retainedUpdated = 0;
-    for (const snapshot of this._inlineSnapshots) {
-      const metadata = this._inlineSnapshotMetadata.get(snapshot);
-      if (metadata?.snapshotStatus === 'added') {
-        retainedAdded++;
-      } else if (metadata?.snapshotStatus === 'updated') {
-        retainedUpdated++;
-      }
-    }
     this._counters = new Map();
     this._index = 0;
-    this.added = retainedAdded;
-    this.matched = 0;
-    this.unmatched = 0;
-    this.updated = retainedUpdated;
+
+    if (testRetryOwner === undefined) {
+      this._inlineSnapshots = [];
+      this._snapshotCountsByTest = new WeakMap();
+      this.added = 0;
+      this.matched = 0;
+      this.unmatched = 0;
+      this.updated = 0;
+      return;
+    }
+
+    this._inlineSnapshots = this._inlineSnapshots.filter(
+      snapshot => this._inlineSnapshotOwners.get(snapshot) !== testRetryOwner,
+    );
+    const counts = this._snapshotCountsByTest.get(testRetryOwner);
+    if (counts !== undefined) {
+      this.added -= counts.added;
+      this.matched -= counts.matched;
+      this.unmatched -= counts.unmatched;
+      this.updated -= counts.updated;
+      this._snapshotCountsByTest.delete(testRetryOwner);
+    }
+  }
+
+  private _incrementSnapshotCount(
+    count: keyof SnapshotCounts,
+    testRetryOwner?: object,
+  ): void {
+    this[count]++;
+    if (testRetryOwner !== undefined) {
+      const counts = this._snapshotCountsByTest.get(testRetryOwner) ?? {
+        added: 0,
+        matched: 0,
+        unmatched: 0,
+        updated: 0,
+      };
+      counts[count]++;
+      this._snapshotCountsByTest.set(testRetryOwner, counts);
+    }
   }
 
   save(): SaveStatus {
@@ -305,17 +321,16 @@ export default class SnapshotState {
     ) {
       if (this._updateSnapshot === 'all') {
         if (pass) {
-          this.matched++;
+          this._incrementSnapshotCount('matched', testRetryOwner);
         } else {
           if (hasSnapshot) {
-            this.updated++;
+            this._incrementSnapshotCount('updated', testRetryOwner);
           } else {
-            this.added++;
+            this._incrementSnapshotCount('added', testRetryOwner);
           }
           this._addSnapshot(key, receivedSerialized, {
             error,
             isInline,
-            snapshotStatus: hasSnapshot ? 'updated' : 'added',
             testRetryOwner,
           });
         }
@@ -323,10 +338,9 @@ export default class SnapshotState {
         this._addSnapshot(key, receivedSerialized, {
           error,
           isInline,
-          snapshotStatus: 'added',
           testRetryOwner,
         });
-        this.added++;
+        this._incrementSnapshotCount('added', testRetryOwner);
       }
 
       return {
@@ -338,7 +352,7 @@ export default class SnapshotState {
       };
     } else {
       if (pass) {
-        this.matched++;
+        this._incrementSnapshotCount('matched', testRetryOwner);
         return {
           actual: '',
           count,
@@ -347,7 +361,7 @@ export default class SnapshotState {
           pass: true,
         };
       } else {
-        this.unmatched++;
+        this._incrementSnapshotCount('unmatched', testRetryOwner);
         return {
           actual: removeExtraLineBreaks(receivedSerialized),
           count,
@@ -362,7 +376,12 @@ export default class SnapshotState {
     }
   }
 
-  fail(testName: string, _received: unknown, key?: string): string {
+  fail(
+    testName: string,
+    _received: unknown,
+    key?: string,
+    testRetryOwner?: object,
+  ): string {
     this._counters.set(testName, (this._counters.get(testName) || 0) + 1);
     const count = Number(this._counters.get(testName));
 
@@ -371,7 +390,7 @@ export default class SnapshotState {
     }
 
     this._uncheckedKeys.delete(key);
-    this.unmatched++;
+    this._incrementSnapshotCount('unmatched', testRetryOwner);
     return key;
   }
 }

--- a/packages/jest-snapshot/src/__tests__/State.test.ts
+++ b/packages/jest-snapshot/src/__tests__/State.test.ts
@@ -42,6 +42,7 @@ test('clear preserves inline snapshots owned by other tests', () => {
     filename,
     `expect(1).toMatchInlineSnapshot(\`"outdated"\`);
 expect(1).toMatchInlineSnapshot();
+expect(1).toMatchInlineSnapshot(\`"outdated"\`);
 expect(1).toMatchInlineSnapshot();
 `,
   );
@@ -66,23 +67,52 @@ expect(1).toMatchInlineSnapshot();
   });
   snapshotState.match({
     error: makeErrorAt(filename, 3),
+    inlineSnapshot: '"outdated"',
+    isInline: true,
+    received: 'updated on retry',
+    testName: 'updated snapshot on retry',
+    testRetryOwner: retriedOwner,
+  });
+  snapshotState.match({
+    error: makeErrorAt(filename, 4),
     isInline: true,
     received: 'retry',
     testName: 'retried snapshot',
     testRetryOwner: retriedOwner,
   });
+  snapshotState.match({
+    inlineSnapshot: '"matched"',
+    isInline: true,
+    received: 'matched',
+    testName: 'retained match',
+    testRetryOwner: retainedOwner,
+  });
+  snapshotState.match({
+    inlineSnapshot: '"matched"',
+    isInline: true,
+    received: 'matched',
+    testName: 'retried match',
+    testRetryOwner: retriedOwner,
+  });
+  snapshotState.fail('retained failure', undefined, undefined, retainedOwner);
+  snapshotState.fail('retried failure', undefined, undefined, retriedOwner);
 
   expect(snapshotState.added).toBe(2);
-  expect(snapshotState.updated).toBe(1);
+  expect(snapshotState.matched).toBe(2);
+  expect(snapshotState.unmatched).toBe(2);
+  expect(snapshotState.updated).toBe(2);
 
   snapshotState.clear(retriedOwner);
 
   expect(snapshotState.added).toBe(1);
+  expect(snapshotState.matched).toBe(1);
+  expect(snapshotState.unmatched).toBe(1);
   expect(snapshotState.updated).toBe(1);
   expect(snapshotState.save()).toEqual({deleted: false, saved: true});
   expect(fs.readFileSync(filename, 'utf8')).toBe(
     `expect(1).toMatchInlineSnapshot(\`"updated"\`);
 expect(1).toMatchInlineSnapshot(\`"added"\`);
+expect(1).toMatchInlineSnapshot(\`"outdated"\`);
 expect(1).toMatchInlineSnapshot();
 `,
   );

--- a/packages/jest-snapshot/src/__tests__/State.test.ts
+++ b/packages/jest-snapshot/src/__tests__/State.test.ts
@@ -47,8 +47,8 @@ expect(1).toMatchInlineSnapshot();
 `,
   );
   const snapshotState = makeSnapshotState(rootDir, 'all');
-  const retainedOwner = {};
-  const retriedOwner = {};
+  const retainedTest = {};
+  const retriedTest = {};
 
   snapshotState.match({
     error: makeErrorAt(filename, 1),
@@ -56,14 +56,14 @@ expect(1).toMatchInlineSnapshot();
     isInline: true,
     received: 'updated',
     testName: 'updated snapshot',
-    testRetryOwner: retainedOwner,
+    testIdentity: retainedTest,
   });
   snapshotState.match({
     error: makeErrorAt(filename, 2),
     isInline: true,
     received: 'added',
     testName: 'added snapshot',
-    testRetryOwner: retainedOwner,
+    testIdentity: retainedTest,
   });
   snapshotState.match({
     error: makeErrorAt(filename, 3),
@@ -71,38 +71,38 @@ expect(1).toMatchInlineSnapshot();
     isInline: true,
     received: 'updated on retry',
     testName: 'updated snapshot on retry',
-    testRetryOwner: retriedOwner,
+    testIdentity: retriedTest,
   });
   snapshotState.match({
     error: makeErrorAt(filename, 4),
     isInline: true,
     received: 'retry',
     testName: 'retried snapshot',
-    testRetryOwner: retriedOwner,
+    testIdentity: retriedTest,
   });
   snapshotState.match({
     inlineSnapshot: '"matched"',
     isInline: true,
     received: 'matched',
     testName: 'retained match',
-    testRetryOwner: retainedOwner,
+    testIdentity: retainedTest,
   });
   snapshotState.match({
     inlineSnapshot: '"matched"',
     isInline: true,
     received: 'matched',
     testName: 'retried match',
-    testRetryOwner: retriedOwner,
+    testIdentity: retriedTest,
   });
-  snapshotState.fail('retained failure', undefined, undefined, retainedOwner);
-  snapshotState.fail('retried failure', undefined, undefined, retriedOwner);
+  snapshotState.fail('retained failure', undefined, undefined, retainedTest);
+  snapshotState.fail('retried failure', undefined, undefined, retriedTest);
 
   expect(snapshotState.added).toBe(2);
   expect(snapshotState.matched).toBe(2);
   expect(snapshotState.unmatched).toBe(2);
   expect(snapshotState.updated).toBe(2);
 
-  snapshotState.clear(retriedOwner);
+  snapshotState.clear(retriedTest);
 
   expect(snapshotState.added).toBe(1);
   expect(snapshotState.matched).toBe(1);
@@ -118,7 +118,7 @@ expect(1).toMatchInlineSnapshot();
   );
 });
 
-test('clear without an owner removes all pending inline snapshots', () => {
+test('clear without a test identity removes all pending inline snapshots', () => {
   const filename = path.join(rootDir, 'example.test.js');
   fs.writeFileSync(filename, 'expect(1).toMatchInlineSnapshot();\n');
   const snapshotState = makeSnapshotState(rootDir, 'new');
@@ -128,7 +128,7 @@ test('clear without an owner removes all pending inline snapshots', () => {
     isInline: true,
     received: 'added',
     testName: 'added snapshot',
-    testRetryOwner: {},
+    testIdentity: {},
   });
   expect(snapshotState.added).toBe(1);
 

--- a/packages/jest-snapshot/src/__tests__/State.test.ts
+++ b/packages/jest-snapshot/src/__tests__/State.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {tmpdir} from 'os';
+import * as path from 'path';
+import * as fs from 'graceful-fs';
+import SnapshotState from '../State';
+
+const makeErrorAt = (filename: string, line: number): Error => {
+  const error = new Error();
+  error.stack = `Error\n    at Object.<anonymous> (${filename}:${line}:11)`;
+  return error;
+};
+
+const makeSnapshotState = (
+  rootDir: string,
+  updateSnapshot: 'all' | 'new',
+): SnapshotState =>
+  new SnapshotState(path.join(rootDir, 'unused.snap'), {
+    rootDir,
+    snapshotFormat: {},
+    updateSnapshot,
+  });
+
+let rootDir: string;
+
+beforeEach(() => {
+  rootDir = fs.mkdtempSync(path.join(tmpdir(), 'jest-snapshot-state-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(rootDir, {recursive: true});
+});
+
+test('clear preserves inline snapshots owned by other tests', () => {
+  const filename = path.join(rootDir, 'example.test.js');
+  fs.writeFileSync(
+    filename,
+    `expect(1).toMatchInlineSnapshot(\`"outdated"\`);
+expect(1).toMatchInlineSnapshot();
+expect(1).toMatchInlineSnapshot();
+`,
+  );
+  const snapshotState = makeSnapshotState(rootDir, 'all');
+  const retainedOwner = {};
+  const retriedOwner = {};
+
+  snapshotState.match({
+    error: makeErrorAt(filename, 1),
+    inlineSnapshot: '"outdated"',
+    isInline: true,
+    received: 'updated',
+    testName: 'updated snapshot',
+    testRetryOwner: retainedOwner,
+  });
+  snapshotState.match({
+    error: makeErrorAt(filename, 2),
+    isInline: true,
+    received: 'added',
+    testName: 'added snapshot',
+    testRetryOwner: retainedOwner,
+  });
+  snapshotState.match({
+    error: makeErrorAt(filename, 3),
+    isInline: true,
+    received: 'retry',
+    testName: 'retried snapshot',
+    testRetryOwner: retriedOwner,
+  });
+
+  expect(snapshotState.added).toBe(2);
+  expect(snapshotState.updated).toBe(1);
+
+  snapshotState.clear(retriedOwner);
+
+  expect(snapshotState.added).toBe(1);
+  expect(snapshotState.updated).toBe(1);
+  expect(snapshotState.save()).toEqual({deleted: false, saved: true});
+  expect(fs.readFileSync(filename, 'utf8')).toBe(
+    `expect(1).toMatchInlineSnapshot(\`"updated"\`);
+expect(1).toMatchInlineSnapshot(\`"added"\`);
+expect(1).toMatchInlineSnapshot();
+`,
+  );
+});
+
+test('clear without an owner removes all pending inline snapshots', () => {
+  const filename = path.join(rootDir, 'example.test.js');
+  fs.writeFileSync(filename, 'expect(1).toMatchInlineSnapshot();\n');
+  const snapshotState = makeSnapshotState(rootDir, 'new');
+
+  snapshotState.match({
+    error: makeErrorAt(filename, 1),
+    isInline: true,
+    received: 'added',
+    testName: 'added snapshot',
+    testRetryOwner: {},
+  });
+  expect(snapshotState.added).toBe(1);
+
+  snapshotState.clear();
+
+  expect(snapshotState.added).toBe(0);
+  expect(snapshotState.updated).toBe(0);
+  expect(snapshotState.save()).toEqual({deleted: false, saved: false});
+  expect(fs.readFileSync(filename, 'utf8')).toBe(
+    'expect(1).toMatchInlineSnapshot();\n',
+  );
+});

--- a/packages/jest-snapshot/src/__tests__/State.test.ts
+++ b/packages/jest-snapshot/src/__tests__/State.test.ts
@@ -118,6 +118,75 @@ expect(1).toMatchInlineSnapshot();
   );
 });
 
+test('does not save when the only writes were rolled back', () => {
+  const snapshotPath = path.join(rootDir, 'example.test.js.snap');
+  fs.writeFileSync(
+    snapshotPath,
+    '// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing\n\nexports[`existing 1`] = `"kept"`;\n',
+  );
+  const snapshotState = new SnapshotState(snapshotPath, {
+    rootDir,
+    snapshotFormat: {},
+    updateSnapshot: 'new',
+  });
+  const retriedTest = {};
+
+  snapshotState.match({
+    isInline: false,
+    received: 'kept',
+    testName: 'existing',
+  });
+  snapshotState.match({
+    isInline: false,
+    received: 'discarded',
+    testIdentity: retriedTest,
+    testName: 'written on retry',
+  });
+  snapshotState.clear(retriedTest);
+
+  const modifiedBefore = fs.statSync(snapshotPath).mtimeMs;
+  expect(snapshotState.save()).toEqual({deleted: false, saved: false});
+  expect(fs.statSync(snapshotPath).mtimeMs).toBe(modifiedBefore);
+});
+
+test('still saves when another test wrote between the rolled-back writes', () => {
+  const snapshotPath = path.join(rootDir, 'example.test.js.snap');
+  fs.writeFileSync(
+    snapshotPath,
+    '// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing\n\nexports[`existing 1`] = `"kept"`;\n',
+  );
+  const snapshotState = new SnapshotState(snapshotPath, {
+    rootDir,
+    snapshotFormat: {},
+    updateSnapshot: 'new',
+  });
+  const retriedTest = {};
+
+  snapshotState.match({
+    isInline: false,
+    received: 'kept',
+    testName: 'existing',
+  });
+  snapshotState.match({
+    isInline: false,
+    received: 'discarded',
+    testIdentity: retriedTest,
+    testName: 'written on retry',
+  });
+  snapshotState.match({
+    isInline: false,
+    received: 'other',
+    testIdentity: {},
+    testName: 'written by another test',
+  });
+  snapshotState.clear(retriedTest);
+
+  expect(snapshotState.save()).toEqual({deleted: false, saved: true});
+  const snapshotFile = fs.readFileSync(snapshotPath, 'utf8');
+  expect(snapshotFile).toContain('exports[`written by another test 1`]');
+  expect(snapshotFile).not.toContain('written on retry');
+});
+
 test('clear without a test identity removes all pending inline snapshots', () => {
   const filename = path.join(rootDir, 'example.test.js');
   fs.writeFileSync(filename, 'expect(1).toMatchInlineSnapshot();\n');

--- a/packages/jest-snapshot/src/__tests__/State.test.ts
+++ b/packages/jest-snapshot/src/__tests__/State.test.ts
@@ -55,44 +55,44 @@ expect(1).toMatchInlineSnapshot();
     inlineSnapshot: '"outdated"',
     isInline: true,
     received: 'updated',
-    testName: 'updated snapshot',
     testIdentity: retainedTest,
+    testName: 'updated snapshot',
   });
   snapshotState.match({
     error: makeErrorAt(filename, 2),
     isInline: true,
     received: 'added',
-    testName: 'added snapshot',
     testIdentity: retainedTest,
+    testName: 'added snapshot',
   });
   snapshotState.match({
     error: makeErrorAt(filename, 3),
     inlineSnapshot: '"outdated"',
     isInline: true,
     received: 'updated on retry',
-    testName: 'updated snapshot on retry',
     testIdentity: retriedTest,
+    testName: 'updated snapshot on retry',
   });
   snapshotState.match({
     error: makeErrorAt(filename, 4),
     isInline: true,
     received: 'retry',
+    testIdentity: retriedTest,
     testName: 'retried snapshot',
-    testIdentity: retriedTest,
   });
   snapshotState.match({
     inlineSnapshot: '"matched"',
     isInline: true,
     received: 'matched',
-    testName: 'retained match',
     testIdentity: retainedTest,
+    testName: 'retained match',
   });
   snapshotState.match({
     inlineSnapshot: '"matched"',
     isInline: true,
     received: 'matched',
-    testName: 'retried match',
     testIdentity: retriedTest,
+    testName: 'retried match',
   });
   snapshotState.fail('retained failure', undefined, undefined, retainedTest);
   snapshotState.fail('retried failure', undefined, undefined, retriedTest);
@@ -127,8 +127,8 @@ test('clear without a test identity removes all pending inline snapshots', () =>
     error: makeErrorAt(filename, 1),
     isInline: true,
     received: 'added',
-    testName: 'added snapshot',
     testIdentity: {},
+    testName: 'added snapshot',
   });
   expect(snapshotState.added).toBe(1);
 

--- a/packages/jest-snapshot/src/__tests__/matcher.test.ts
+++ b/packages/jest-snapshot/src/__tests__/matcher.test.ts
@@ -8,9 +8,12 @@
 import {type Context, toMatchSnapshot} from '../';
 
 test('returns matcher name, expected and actual values', () => {
+  const testRetryOwner = {};
+  const match = jest.fn((_options: unknown) => ({actual: 'a', expected: 'b'}));
   const mockedContext = {
+    currentTestRetryOwner: () => testRetryOwner,
     snapshotState: {
-      match: () => ({actual: 'a', expected: 'b'}),
+      match,
     },
   } as unknown as Context;
 
@@ -25,4 +28,5 @@ test('returns matcher name, expected and actual values', () => {
       name: 'toMatchSnapshot',
     }),
   );
+  expect(match).toHaveBeenCalledWith(expect.objectContaining({testRetryOwner}));
 });

--- a/packages/jest-snapshot/src/__tests__/matcher.test.ts
+++ b/packages/jest-snapshot/src/__tests__/matcher.test.ts
@@ -42,8 +42,8 @@ test('passes the test identity to failed property snapshots', () => {
     ) => 'test name 1',
   );
   const mockedContext = {
-    currentTestName: 'test name',
     currentTestIdentity: () => testIdentity,
+    currentTestName: 'test name',
     equals: () => false,
     snapshotState: {expand: false, fail},
     utils: {iterableEquality: jest.fn(), subsetEquality: jest.fn()},

--- a/packages/jest-snapshot/src/__tests__/matcher.test.ts
+++ b/packages/jest-snapshot/src/__tests__/matcher.test.ts
@@ -30,3 +30,32 @@ test('returns matcher name, expected and actual values', () => {
   );
   expect(match).toHaveBeenCalledWith(expect.objectContaining({testRetryOwner}));
 });
+
+test('passes the retry owner to failed property snapshots', () => {
+  const testRetryOwner = {};
+  const fail = jest.fn(
+    (
+      _testName: string,
+      _received: unknown,
+      _key?: string,
+      _testRetryOwner?: object,
+    ) => 'test name 1',
+  );
+  const mockedContext = {
+    currentTestName: 'test name',
+    currentTestRetryOwner: () => testRetryOwner,
+    equals: () => false,
+    snapshotState: {expand: false, fail},
+    utils: {iterableEquality: jest.fn(), subsetEquality: jest.fn()},
+  } as unknown as Context;
+  const received = {value: 1};
+
+  toMatchSnapshot.call(mockedContext, received, {value: 2});
+
+  expect(fail).toHaveBeenCalledWith(
+    'test name',
+    received,
+    undefined,
+    testRetryOwner,
+  );
+});

--- a/packages/jest-snapshot/src/__tests__/matcher.test.ts
+++ b/packages/jest-snapshot/src/__tests__/matcher.test.ts
@@ -8,10 +8,10 @@
 import {type Context, toMatchSnapshot} from '../';
 
 test('returns matcher name, expected and actual values', () => {
-  const testRetryOwner = {};
+  const testIdentity = {};
   const match = jest.fn((_options: unknown) => ({actual: 'a', expected: 'b'}));
   const mockedContext = {
-    currentTestRetryOwner: () => testRetryOwner,
+    currentTestIdentity: () => testIdentity,
     snapshotState: {
       match,
     },
@@ -28,22 +28,22 @@ test('returns matcher name, expected and actual values', () => {
       name: 'toMatchSnapshot',
     }),
   );
-  expect(match).toHaveBeenCalledWith(expect.objectContaining({testRetryOwner}));
+  expect(match).toHaveBeenCalledWith(expect.objectContaining({testIdentity}));
 });
 
-test('passes the retry owner to failed property snapshots', () => {
-  const testRetryOwner = {};
+test('passes the test identity to failed property snapshots', () => {
+  const testIdentity = {};
   const fail = jest.fn(
     (
       _testName: string,
       _received: unknown,
       _key?: string,
-      _testRetryOwner?: object,
+      _testIdentity?: object,
     ) => 'test name 1',
   );
   const mockedContext = {
     currentTestName: 'test name',
-    currentTestRetryOwner: () => testRetryOwner,
+    currentTestIdentity: () => testIdentity,
     equals: () => false,
     snapshotState: {expand: false, fail},
     utils: {iterableEquality: jest.fn(), subsetEquality: jest.fn()},
@@ -56,6 +56,6 @@ test('passes the retry owner to failed property snapshots', () => {
     'test name',
     received,
     undefined,
-    testRetryOwner,
+    testIdentity,
   );
 });

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -287,9 +287,15 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
     context.dontThrow();
   }
 
-  const {currentConcurrentTestName, isNot, snapshotState} = context;
+  const {
+    currentConcurrentTestName,
+    currentTestRetryOwner,
+    isNot,
+    snapshotState,
+  } = context;
   const currentTestName =
     currentConcurrentTestName?.() ?? context.currentTestName;
+  const testRetryOwner = currentTestRetryOwner?.();
 
   if (isNot) {
     throw new Error(
@@ -369,6 +375,7 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
     received,
     testFailing,
     testName: fullTestName,
+    testRetryOwner,
   });
   const {actual, count, expected, pass} = result;
 

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -345,7 +345,12 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
     if (propertyPass) {
       received = deepMerge(received, properties);
     } else {
-      const key = snapshotState.fail(fullTestName, received);
+      const key = snapshotState.fail(
+        fullTestName,
+        received,
+        undefined,
+        testRetryOwner,
+      );
       const matched = /(\d+)$/.exec(key);
       const count = matched === null ? 1 : Number(matched[1]);
 

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -287,15 +287,11 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
     context.dontThrow();
   }
 
-  const {
-    currentConcurrentTestName,
-    currentTestRetryOwner,
-    isNot,
-    snapshotState,
-  } = context;
+  const {currentConcurrentTestName, currentTestIdentity, isNot, snapshotState} =
+    context;
   const currentTestName =
     currentConcurrentTestName?.() ?? context.currentTestName;
-  const testRetryOwner = currentTestRetryOwner?.();
+  const testIdentity = currentTestIdentity?.();
 
   if (isNot) {
     throw new Error(
@@ -349,7 +345,7 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
         fullTestName,
         received,
         undefined,
-        testRetryOwner,
+        testIdentity,
       );
       const matched = /(\d+)$/.exec(key);
       const count = matched === null ? 1 : Number(matched[1]);
@@ -379,8 +375,8 @@ const _toMatchSnapshot = (config: MatchSnapshotConfig) => {
     isInline,
     received,
     testFailing,
+    testIdentity,
     testName: fullTestName,
-    testRetryOwner,
   });
   const {actual, count, expected, pass} = result;
 


### PR DESCRIPTION
## Summary

`SnapshotState.clear()` currently drops every pending inline snapshot when a
test retries, including snapshots written by other tests in the same file.

Associate pending inline snapshots with the unique test entry supplied by
`jest-circus` and clear only snapshots owned by the retried test. Preserve the
added and updated counts for snapshots retained from other tests.

This extends the existing `clear` method with an optional retry owner. Calls
without an owner retain the existing full-clear behavior.

Add an E2E regression test with two distinct tests whose full names collide. It
adds and updates snapshots in the first test, retries the second test twice, and
verifies the final source and snapshot summary.

## Test plan

- `corepack yarn jest e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts --runInBand`
- `corepack yarn jest packages/expect packages/jest-circus packages/jest-snapshot e2e/__tests__/testRetries.test.ts e2e/__tests__/toMatchInlineSnapshotWithRetries.test.ts e2e/__tests__/toMatchSnapshotWithRetries.test.ts --runInBand`
- `corepack yarn build`
- `corepack yarn typecheck:tests`
- `corepack yarn lint`
- `corepack yarn check-copyright-headers`
- `corepack yarn check-changelog`
- `corepack yarn constraints`
- `corepack yarn dedupe --check`
- `corepack yarn verify-pnp`
