### PR TITLE
chore: unbreak the TypeScript compatibility job after @tsconfig/node18@18.2.7

### DIFF
--- a/packages/expect/tsconfig.json
+++ b/packages/expect/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["es2023", "dom"],
+    "lib": ["es2023", "dom", "dom.iterable"],
     "rootDir": "src",
     "outDir": "build"
   },

--- a/packages/jest-runtime/src/internals/FileCache.ts
+++ b/packages/jest-runtime/src/internals/FileCache.ts
@@ -9,7 +9,7 @@ import * as fs from 'graceful-fs';
 
 export class FileCache {
   private readonly strings: Map<string, string>;
-  private readonly buffers = new Map<string, BufferSource>();
+  private readonly buffers = new Map<string, Buffer<ArrayBuffer>>();
 
   constructor(cacheFS: Map<string, string>) {
     this.strings = cacheFS;
@@ -24,7 +24,7 @@ export class FileCache {
     return source;
   }
 
-  readFileBuffer(filename: string): BufferSource {
+  readFileBuffer(filename: string): Buffer<ArrayBuffer> {
     let source = this.buffers.get(filename);
     if (!source) {
       source = fs.readFileSync(filename);

--- a/packages/pretty-format/tsconfig.json
+++ b/packages/pretty-format/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "lib": ["es2023", "dom"],
+    "lib": ["es2023", "dom", "dom.iterable"],
     "rootDir": "src",
     "outDir": "build"
   },

--- a/scripts/verifyOldTs.mjs
+++ b/scripts/verifyOldTs.mjs
@@ -23,6 +23,8 @@ const tsconfigBasePackage = Object.keys(rootPackageJson.devDependencies).find(
 );
 /* eslint-enable import-x/order */
 
+const nodeTypesPackage = `@types/node@${rootPackageJson.devDependencies['@types/node']}`;
+
 const baseTsConfig = JSON.parse(
   stripJsonComments(
     fs.readFileSync(require.resolve('../tsconfig.json'), 'utf8'),
@@ -54,18 +56,25 @@ function smoketest() {
   try {
     fs.writeFileSync(
       path.join(cwd, '.yarnrc.yml'),
-      // the CI defaults that protect a real lockfile break the throwaway one
+      // the CI defaults that protect a real lockfile break the throwaway one,
+      // and the age gate has to match ours or this project resolves versions we never would
       [
         'enableHardenedMode: false',
         'enableImmutableInstalls: false',
         'nodeLinker: node-modules',
+        'npmMinimalAgeGate: 3d',
         '',
       ].join('\n'),
     );
     execa.sync('yarn', ['init', '--yes'], {cwd, stdio: 'inherit'});
     execa.sync(
       'yarn',
-      ['add', `typescript@~${tsVersion}`, tsconfigBasePackage],
+      [
+        'add',
+        `typescript@~${tsVersion}`,
+        tsconfigBasePackage,
+        nodeTypesPackage,
+      ],
       {cwd, stdio: 'inherit'},
     );
     fs.writeFileSync(

--- a/scripts/verifyOldTs.mjs
+++ b/scripts/verifyOldTs.mjs
@@ -54,7 +54,13 @@ function smoketest() {
   try {
     fs.writeFileSync(
       path.join(cwd, '.yarnrc.yml'),
-      'nodeLinker: node-modules\n',
+      // the CI defaults that protect a real lockfile break the throwaway one
+      [
+        'enableHardenedMode: false',
+        'enableImmutableInstalls: false',
+        'nodeLinker: node-modules',
+        '',
+      ].join('\n'),
     );
     execa.sync('yarn', ['init', '--yes'], {cwd, stdio: 'inherit'});
     execa.sync(

--- a/yarn.lock
+++ b/yarn.lock
@@ -7007,9 +7007,9 @@ __metadata:
   linkType: hard
 
 "@tsconfig/node18@npm:^18.2.4":
-  version: 18.2.6
-  resolution: "@tsconfig/node18@npm:18.2.6"
-  checksum: 10/e3d907c20d04f0292288eb62af3481b11549eafdc686cd6357785083f9d00c99d49c5d9bdb10b1151d11cadbd8c39f2e0cb2644e2ba7612af7cbbcee38b01c3f
+  version: 18.2.7
+  resolution: "@tsconfig/node18@npm:18.2.7"
+  checksum: 10/625d1a390f77b03e8c8d999db76f7ddacf261156a76e906d972e89a4b7fccdafecd44c9d8ed7d51c3cd752f1d15a8deeb459ef0f870c072d7c53094817ab6373
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

The `verify-old-ts` smoketest builds a throwaway project in a temp dir and runs `yarn init` + `yarn add` in it. That project shared none of our Yarn settings, so it resolved dependencies differently than we do — and it broke the job when `@tsconfig/node18@18.2.7` was published:

```
error TS2688: Cannot find type definition file for 'node'.
```

18.2.7 adds `types: ["node"]` to the base config. The temp project never installed `@types/node`, so `tsc` had nothing to load. We did not hit this ourselves because `npmMinimalAgeGate: 3d` held us on 18.2.6 while the temp project, with no `.yarnrc.yml` of ours, took the day-old release.

Three changes make the temp project resolve the way we do:

- Install `@types/node`, at the range from our own `devDependencies`. Picking it up implicitly was always luck.
- Set `npmMinimalAgeGate: 3d` to match ours. Until 18.2.7 clears the gate the smoketest stays on 18.2.6, then the two converge.
- Turn off `enableHardenedMode` and `enableImmutableInstalls`. Both are CI defaults that protect a real repository, and both fire on a project that has no lockfile yet. The install inside `yarn init` printed the hardened-mode notice, `YN0028: The lockfile would have been modified by this install, which is explicitly forbidden`, and `Failed with errors`. `yarn init` still exited 0 and the next `yarn add` wrote the lockfile, so the step passed with a log that looked broken.

Then take 18.2.7 in the lockfile, which needs three fixes to our own type build. `types: ["node"]` stops TypeScript from loading every package under `node_modules/@types`, and `@types/jsdom` was the only one carrying `/// <reference lib="dom.iterable" />`. Every package had been getting DOM iterables through it by accident:

- `expect` and `pretty-format` declare `dom.iterable` themselves. They iterate `NamedNodeMap`, `NodeListOf`, `DOMTokenList` and `HTMLCollectionOf`.
- `FileCache` no longer returns `BufferSource`. That is a `lib.dom` global, and `Runtime` holds a `private readonly fileCache`, so the type escaped through the emitted declarations into `jest-circus`, `jest-core`, `jest-jasmine2`, `jest-resolve-dependencies` and `jest-runner` — five packages with no DOM lib and no reason to have one. `FileCache` only ever holds `readFileSync` results, so `Buffer<ArrayBuffer>` is both accurate and free of the dependency. The type argument is load-bearing: bare `Buffer` widens to `Buffer<ArrayBufferLike>` and loses the non-shared guarantee `WebAssembly.compile` asks for.

No changelog entry. Nothing here is user visible.

## Test plan

`yarn build:ts` is clean and `yarn typecheck:tests` exits 0. With 18.2.7 in the lockfile and the type fixes reverted, the same build reports four errors in three packages — CI showed only the two in `pretty-format` because `tsc -b` stops at the first failing project:

```
packages/expect/src/matchers.ts(536,27): error TS2488: Type 'ContainIterable' must have a '[Symbol.iterator]()' method that returns an iterator.
packages/jest-runtime/build/internals/FileCache.d.ts(12,39): error TS2304: Cannot find name 'BufferSource'.
packages/pretty-format/src/plugins/DOMCollection.ts(46,19): error TS2488: Type 'NamedNodeMap' must have a '[Symbol.iterator]()' method that returns an iterator.
packages/pretty-format/src/plugins/DOMElement.ts(103,15): error TS2488: Type 'NamedNodeMap' must have a '[Symbol.iterator]()' method that returns an iterator.
```

`node ./scripts/verifyOldTs.mjs` passes. I confirmed the `@types/node` fix against the exact version that broke CI by running it before the gate line went in, where the temp project still picked 18.2.7:

```
➤ YN0085: │ + @tsconfig/node18@npm:18.2.7, @types/node@npm:18.19.130, and 3 more.
 Successfully compiled Jest with TypeScript 5.4
```

With the gate in place it resolves 18.2.6 and passes the same way.

For the Yarn settings, ran the script with the CI environment simulated:

```
CI=true GITHUB_ACTIONS=true GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=main node ./scripts/verifyOldTs.mjs
```

Before, the first install printed the hardened-mode notice, `YN0028`, and `Failed with errors in 0s 15ms`. After, both installs print only `Done in …`.

`yarn jest packages/jest-runtime/src/internals/__tests__/FileCache.test.ts packages/pretty-format/src/__tests__/DOMElement.test.ts` passes, 34 tests.