### PR TITLE
fix: Keep hinted snapshots with their own test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@
 - `[jest-runtime]` Support older test environments whose `moduleMocker` does not implement `clearMocksOnScope` ([#16169](https://github.com/jestjs/jest/pull/16169))
 - `[jest-reporters]` Fix coverage report table formatting in CI/GitHub Actions environments where `process.stdout.columns` is undefined by falling back to the `COLUMNS` env var or `80` columns in CI, preserving existing behaviour in other non-TTY environments ([#16227](https://github.com/jestjs/jest/pull/16227))
 - `[jest-runtime]` Support CJS-in-ESM exports via `"module.exports"` named exports ([#16277](https://github.com/jestjs/jest/pull/16277))
+- `[jest-snapshot]` Keep a skipped or failed test's hinted snapshots, instead of reporting them obsolete and dropping them under `--updateSnapshot` ([#16348](https://github.com/jestjs/jest/pull/16348))
 - `[pretty-format]` Move the `react-is` aliases into the `@jest` scope, so they cannot be shadowed by unrelated packages published under the alias names ([#16333](https://github.com/jestjs/jest/pull/16333))
 
 ### Chore & Maintenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@
 - `[jest-runtime]` Support older test environments whose `moduleMocker` does not implement `clearMocksOnScope` ([#16169](https://github.com/jestjs/jest/pull/16169))
 - `[jest-reporters]` Fix coverage report table formatting in CI/GitHub Actions environments where `process.stdout.columns` is undefined by falling back to the `COLUMNS` env var or `80` columns in CI, preserving existing behaviour in other non-TTY environments ([#16227](https://github.com/jestjs/jest/pull/16227))
 - `[jest-runtime]` Support CJS-in-ESM exports via `"module.exports"` named exports ([#16277](https://github.com/jestjs/jest/pull/16277))
-- `[jest-snapshot]` Keep a skipped or failed test's hinted snapshots, instead of reporting them obsolete and dropping them under `--updateSnapshot` ([#16348](https://github.com/jestjs/jest/pull/16348))
+- `[jest-snapshot]` Keep a skipped or failed test's hinted snapshots, instead of reporting them obsolete ([#16348](https://github.com/jestjs/jest/pull/16348))
 - `[pretty-format]` Move the `react-is` aliases into the `@jest` scope, so they cannot be shadowed by unrelated packages published under the alias names ([#16333](https://github.com/jestjs/jest/pull/16333))
 
 ### Chore & Maintenance

--- a/e2e/__tests__/toMatchSnapshot.test.ts
+++ b/e2e/__tests__/toMatchSnapshot.test.ts
@@ -6,6 +6,7 @@
  */
 
 import * as path from 'path';
+import * as fs from 'graceful-fs';
 import {cleanup, makeTemplate, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
@@ -139,6 +140,40 @@ test('does not mark snapshots as obsolete in skipped tests', () => {
     const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
     expect(stderr).not.toMatch('1 obsolete snapshot found');
     expect(exitCode).toBe(0);
+  }
+});
+
+test('does not mark hinted snapshots as obsolete in skipped tests', () => {
+  const filename = 'no-obsolete-hinted-if-skipped.test.js';
+  const template = makeTemplate(`$1('will be skipped', () => {
+      expect({a: 6}).toMatchSnapshot('hint');
+    });
+    `);
+
+  {
+    writeFiles(TESTS_DIR, {[filename]: template(['test'])});
+    const {stderr, exitCode} = runJest(DIR, ['-w=1', '--ci=false', filename]);
+    expect(stderr).toMatch('1 snapshot written from 1 test suite.');
+    expect(exitCode).toBe(0);
+  }
+
+  {
+    writeFiles(TESTS_DIR, {[filename]: template(['test.skip'])});
+    const {stderr, exitCode} = runJest(DIR, [
+      '-w=1',
+      '--ci=false',
+      '-u',
+      filename,
+    ]);
+    expect(stderr).not.toMatch('removed');
+    expect(exitCode).toBe(0);
+    // `-u` deletes whatever obsolete detection missed, so the key surviving is
+    // the proof the hint did not hide it from its own test.
+    const snapshot = fs.readFileSync(
+      path.join(TESTS_DIR, '__snapshots__', `${filename}.snap`),
+      'utf8',
+    );
+    expect(snapshot).toContain('exports[`will be skipped: hint 1`]');
   }
 });
 

--- a/e2e/__tests__/toMatchSnapshot.test.ts
+++ b/e2e/__tests__/toMatchSnapshot.test.ts
@@ -7,6 +7,7 @@
 
 import * as path from 'path';
 import * as fs from 'graceful-fs';
+import {isJestJasmineRun} from '@jest/test-utils';
 import {cleanup, makeTemplate, writeFiles} from '../Utils';
 import runJest from '../runJest';
 
@@ -176,6 +177,121 @@ test('does not mark hinted snapshots as obsolete in skipped tests', () => {
     expect(snapshot).toContain('exports[`will be skipped: hint 1`]');
   }
 });
+
+test('does not mark hinted snapshots as obsolete in deselected tests', () => {
+  const filename = 'no-obsolete-hinted-if-deselected.test.js';
+  const template = makeTemplate(`test('renders the header', () => {
+      expect('header markup').toMatchSnapshot('markup');
+      expect({a: 1}).toMatchSnapshot('props');
+    });
+
+    test('renders the footer', () => {
+      expect('footer markup').toMatchSnapshot();
+    });
+    `);
+
+  writeFiles(TESTS_DIR, {[filename]: template()});
+  expect(runJest(DIR, ['-w=1', '--ci=false', filename]).stderr).toMatch(
+    '3 snapshots written from 1 test suite.',
+  );
+
+  // A test the name pattern skips over reports as pending, same as `test.skip`,
+  // so its snapshots have to survive the update the matching test triggers.
+  const {stderr, exitCode} = runJest(DIR, [
+    '-w=1',
+    '--ci=false',
+    '-t',
+    'footer',
+    '-u',
+    filename,
+  ]);
+
+  expect(stderr).not.toMatch('removed');
+  expect(exitCode).toBe(0);
+  const snapshot = fs.readFileSync(
+    path.join(TESTS_DIR, '__snapshots__', `${filename}.snap`),
+    'utf8',
+  );
+  expect(snapshot).toContain('exports[`renders the header: markup 1`]');
+  expect(snapshot).toContain('exports[`renders the header: props 1`]');
+});
+
+test('does not mark hinted snapshots as obsolete in failing tests', () => {
+  const filename = 'no-obsolete-hinted-if-failed.test.js';
+  // The failure comes first, so the snapshot below is never reached on the
+  // second run — an unreached snapshot is the only kind obsolete detection
+  // has to decide about.
+  const template = makeTemplate(`test('breaks early', () => {
+      expect(true).toBe($1);
+      expect({a: 6}).toMatchSnapshot('hint');
+    });
+    `);
+
+  writeFiles(TESTS_DIR, {[filename]: template(['true'])});
+  expect(runJest(DIR, ['-w=1', '--ci=false', filename]).stderr).toMatch(
+    '1 snapshot written from 1 test suite.',
+  );
+
+  // Updating snapshots is the usual response to a failure, so the failing
+  // test's own snapshots must not be swept up by the same run.
+  writeFiles(TESTS_DIR, {[filename]: template(['false'])});
+  const {stderr, exitCode} = runJest(DIR, [
+    '-w=1',
+    '--ci=false',
+    '-u',
+    filename,
+  ]);
+
+  expect(stderr).not.toMatch('removed');
+  expect(exitCode).toBe(1);
+  const snapshot = fs.readFileSync(
+    path.join(TESTS_DIR, '__snapshots__', `${filename}.snap`),
+    'utf8',
+  );
+  expect(snapshot).toContain('exports[`breaks early: hint 1`]');
+});
+
+// jasmine2 has no `test.failing` clause in its obsolete guard at all.
+const testOnCircus = isJestJasmineRun() ? test.skip : test;
+
+testOnCircus(
+  'does not mark hinted snapshots as obsolete in passing `test.failing`',
+  () => {
+    const filename = 'no-obsolete-hinted-if-test-failing.test.js';
+    const template = makeTemplate(`$1('throws as expected', () => {
+      $2;
+      expect({a: 6}).toMatchSnapshot('hint');
+    });
+    `);
+
+    writeFiles(TESTS_DIR, {
+      [filename]: template(['test', 'expect(true).toBe(true)']),
+    });
+    expect(runJest(DIR, ['-w=1', '--ci=false', filename]).stderr).toMatch(
+      '1 snapshot written from 1 test suite.',
+    );
+
+    // A `test.failing` that throws reports as passed, and the snapshots it never
+    // reached past the throw are kept on purpose.
+    writeFiles(TESTS_DIR, {
+      [filename]: template(['test.failing', "throw new Error('boom')"]),
+    });
+    const {stderr, exitCode} = runJest(DIR, [
+      '-w=1',
+      '--ci=false',
+      '-u',
+      filename,
+    ]);
+
+    expect(stderr).not.toMatch('removed');
+    expect(exitCode).toBe(0);
+    const snapshot = fs.readFileSync(
+      path.join(TESTS_DIR, '__snapshots__', `${filename}.snap`),
+      'utf8',
+    );
+    expect(snapshot).toContain('exports[`throws as expected: hint 1`]');
+  },
+);
 
 test('accepts custom snapshot name', () => {
   const filename = 'accept-custom-snapshot-name.test.js';

--- a/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
+++ b/packages/jest-circus/src/legacy-code-todo-rewrite/jestAdapterInit.ts
@@ -30,15 +30,10 @@ import {
 } from 'jest-snapshot';
 import globals from '..';
 import run from '../run';
-import {
-  ROOT_DESCRIBE_BLOCK_NAME,
-  addEventHandler,
-  dispatch,
-  getState as getRunnerState,
-} from '../state';
+import {addEventHandler, dispatch, getState as getRunnerState} from '../state';
 import testCaseReportHandler from '../testCaseReportHandler';
 import {unhandledRejectionHandler} from '../unhandledRejectionHandler';
-import {getTestID} from '../utils';
+import {getTestID, parseSingleTestResult} from '../utils';
 
 interface RuntimeGlobals extends Global.TestFrameworkGlobals {
   expect: JestExpect;
@@ -270,44 +265,24 @@ export const runAndTransformResultsToJestFormat = async ({
 
   const assertionResults: Array<AssertionResult> = runResult.testResults.map(
     testResult => {
-      let status: Status;
-      if (testResult.status === 'skip') {
-        status = 'pending';
+      // `TestCaseResult` names the same instant `startedAt`, so the field has
+      // to be renamed rather than spread through.
+      const {startedAt, ...assertionResult} = parseSingleTestResult(
+        testResult,
+        formatRetryError,
+      );
+
+      if (assertionResult.status === 'pending') {
         numPendingTests += 1;
-      } else if (testResult.status === 'todo') {
-        status = 'todo';
+      } else if (assertionResult.status === 'todo') {
         numTodoTests += 1;
-      } else if (testResult.errors.length > 0) {
-        status = 'failed';
+      } else if (assertionResult.status === 'failed') {
         numFailingTests += 1;
       } else {
-        status = 'passed';
         numPassingTests += 1;
       }
 
-      const ancestorTitles = testResult.testPath.filter(
-        name => name !== ROOT_DESCRIBE_BLOCK_NAME,
-      );
-      const title = ancestorTitles.pop();
-
-      return {
-        ancestorTitles,
-        duration: testResult.duration,
-        failing: testResult.failing,
-        failureDetails: testResult.errorsDetailed,
-        failureMessages: testResult.errors,
-        fullName: title
-          ? [...ancestorTitles, title].join(' ')
-          : ancestorTitles.join(' '),
-        invocations: testResult.invocations,
-        location: testResult.location,
-        numPassingAsserts: testResult.numPassingAsserts,
-        retryMessages: testResult.retryReasonsDetailed.map(formatRetryError),
-        retryReasons: testResult.retryReasons,
-        startAt: testResult.startedAt,
-        status,
-        title: testResult.testPath.at(-1)!,
-      };
+      return {...assertionResult, startAt: startedAt};
     },
   );
 

--- a/packages/jest-snapshot/src/State.ts
+++ b/packages/jest-snapshot/src/State.ts
@@ -129,7 +129,11 @@ export default class SnapshotState {
 
   markSnapshotsAsCheckedForTest(testName: string): void {
     for (const uncheckedKey of this._uncheckedKeys) {
-      if (keyToTestName(uncheckedKey) === testName) {
+      const keyTestName = keyToTestName(uncheckedKey);
+      // A hint is joined onto the test name with ': ' before the key is built,
+      // so the recovered name of a hinted snapshot is longer than the name the
+      // runner reports for the test that took it.
+      if (keyTestName === testName || keyTestName.startsWith(`${testName}: `)) {
         this._uncheckedKeys.delete(uncheckedKey);
       }
     }

--- a/packages/jest-snapshot/src/__tests__/State.test.ts
+++ b/packages/jest-snapshot/src/__tests__/State.test.ts
@@ -210,3 +210,69 @@ test('clear without a test identity removes all pending inline snapshots', () =>
     'expect(1).toMatchInlineSnapshot();\n',
   );
 });
+
+describe('markSnapshotsAsCheckedForTest', () => {
+  // Only a key the test never reached is still unchecked by the time the
+  // runner asks — `match` claims the rest as it goes.
+  const stateWithKeys = (keys: Array<string>) => {
+    const snapshotPath = path.join(rootDir, 'example.test.js.snap');
+    fs.writeFileSync(
+      snapshotPath,
+      `// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing\n\n${keys
+        .map(key => `exports[\`${key}\`] = \`"value"\`;\n`)
+        .join('\n')}`,
+    );
+    return new SnapshotState(snapshotPath, {
+      rootDir,
+      snapshotFormat: {},
+      updateSnapshot: 'none',
+    });
+  };
+
+  test('claims the keys the test took under its own name', () => {
+    const snapshotState = stateWithKeys(['a test 1', 'a test 2']);
+
+    snapshotState.markSnapshotsAsCheckedForTest('a test');
+
+    expect(snapshotState.getUncheckedKeys()).toEqual([]);
+  });
+
+  test('claims the keys the test took under a hint', () => {
+    const snapshotState = stateWithKeys(['a test: hint 1', 'a test: other 1']);
+
+    snapshotState.markSnapshotsAsCheckedForTest('a test');
+
+    expect(snapshotState.getUncheckedKeys()).toEqual([]);
+  });
+
+  test('leaves the keys of every other test alone', () => {
+    const snapshotState = stateWithKeys([
+      'a test 1',
+      'a test: hint 1',
+      'a test extra 1',
+      'another test 1',
+      'a tes 1',
+    ]);
+
+    snapshotState.markSnapshotsAsCheckedForTest('a test');
+
+    // `a test extra` is a separate test whose name merely starts the same way:
+    // only a ': ' after the full name marks a hint.
+    expect(snapshotState.getUncheckedKeys()).toEqual([
+      'a test extra 1',
+      'another test 1',
+      'a tes 1',
+    ]);
+  });
+
+  test('cannot tell a hint from a test whose name contains the separator', () => {
+    const snapshotState = stateWithKeys(['a: b 1']);
+
+    snapshotState.markSnapshotsAsCheckedForTest('a');
+
+    // A key left by a removed `test('a: b')` is indistinguishable from a hinted
+    // snapshot of `test('a')`, so it is claimed and never reported obsolete.
+    // Telling them apart needs ownership the key format does not record.
+    expect(snapshotState.getUncheckedKeys()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Two independent fixes.

### Keep a hinted snapshot with the test that took it

`markSnapshotsAsCheckedForTest` compares the name recovered from a key against the full name the runner reports for the test. A hint is joined onto that name with `': '` before the key is built, so a hinted key never matches its own test.

A test that does not reach a snapshot therefore fails to claim it, and it is reported obsolete — which exits 1 — and deleted on the next `--updateSnapshot`. That covers more than `test.skip`: a name pattern reports every unselected test as pending, so `jest -t 'footer' -u` deletes the hinted snapshots of every test that did not match:

```
› 2 snapshots removed from 1 test suite.
```

The same goes for a test that fails before its snapshot while you run `-u` to fix the failure. Unhinted snapshots were always kept — only hinted ones were lost, so using the documented hint argument is what exposes you to it.

The fix treats a key as belonging to the test when the recovered name equals the test name or starts with `` `${testName}: ` ``.

**This trades a rarer bug in the other direction, and it cannot be fixed inside the current key format.** `keyToTestName('a: b 1')` yields `a: b`, and nothing records whether that `': '` separates a hint or is part of the test's own name. So a key left behind by a removed `test('a: b')` is now claimed by a skipped or failing `test('a')` and can no longer be removed by `-u`. Reaching it needs a colon in a test title, that test removed or renamed, and another test named exactly its prefix, skipped or failing in the same run. The result is a stale line in a `.snap` file rather than lost data, which is why this is still worth landing: the direction of harm goes from deleting snapshots people wanted to keeping one they did not. Unambiguous hint ownership needs the key format to record it, and belongs with a format change.

### Build the run's assertion results in one place

`Circus.TestResult` became an `AssertionResult` in two hand-maintained mappings: `parseSingleTestResult`, and an inline copy in `runAndTransformResultsToJestFormat`. Adding a field meant remembering both, and they had drifted:

- the inline copy popped `title` off the filtered array and then returned `testPath.at(-1)` anyway;
- `fullName` was computed by a different route (pop-then-rejoin vs join-before-pop);
- `parseSingleTestResult` copies `failureMessages` and `retryReasons`, the inline version passed the originals through.

All three were equivalent in practice. The one real difference stays: `TestCaseResult` names the same instant `startedAt` where `AssertionResult` calls it `startAt`, so the transform renames that field explicitly rather than spreading it through.

No behaviour change: the `--json` assertion results parse identically across every status — passed, failed, pending, todo and `.failing` — with no stray `startedAt` in the output and the same status bucketing.

The one raw difference is key order. Spreading the parsed result puts `startAt` after `status` and `title`, where the old mapping emitted it before both, so `JSON.stringify` writes the same keys and values in a different sequence. Nothing reads `--json` positionally and object key order carries no meaning, so this is left as is rather than destructured back into place.

## Test plan

Unit tests in `State.test.ts` pin what `markSnapshotsAsCheckedForTest` matches, including the ambiguous case it cannot get right. E2E tests cover the routes into the obsolete guard, since which status reaches it is the runner's decision: `test.skip`, `--testNamePattern` deselection, a failing test, and a passing `test.failing` (circus only — jasmine2 has no `test.failing`). Each fails without the fix.

Both new failure cases take their snapshot *after* failing, because a snapshot the test already reached is claimed by `match` and never reaches the guard.

- `yarn jest packages/jest-snapshot e2e/__tests__/toMatchSnapshot.test.ts`
- `yarn jest-jasmine-ci e2e/__tests__/toMatchSnapshot.test.ts`
- `yarn jest e2e/__tests__/snapshot.test.ts e2e/__tests__/jsonReporter.test.ts e2e/__tests__/testResultsProcessor.test.ts e2e/__tests__/collectTests.test.ts e2e/__tests__/testRetries.test.ts e2e/__tests__/failures.test.ts --ci`
- `yarn lint`, `yarn typecheck:tests`, `yarn check-changelog`