### PR TITLE
chore: exclude `.claude` from the Jest config's crawl

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -24,6 +24,7 @@ export default {
     '!e2e/**',
   ],
   modulePathIgnorePatterns: [
+    '\\.claude/.*',
     'examples/.*',
     'packages/.*/build',
     'packages/.*/tsconfig.*',
@@ -42,6 +43,7 @@ export default {
     globalsCleanup: process.env.GLOBALS_CLEANUP ?? 'on',
   },
   testPathIgnorePatterns: [
+    '/\\.claude/',
     '/__arbitraries__/',
     '/__benchmarks__/',
     '/__fixtures__/',
@@ -78,6 +80,7 @@ export default {
     '\\.[jt]sx?$': require.resolve('babel-jest'),
   },
   watchPathIgnorePatterns: [
+    '\\.claude',
     'coverage',
     '<rootDir>/packages/jest-worker/src/workers/__tests__/__temp__',
   ],


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md at the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Agent tooling checks git worktrees out under `.claude/worktrees`. Each one holds a second copy of every package, so the haste map sees two providers for every package name and resolution fails with a duplicate-candidates error. The directory also carries session state that changes constantly, which restarts the run in watch mode.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->


🤷 