### PR TITLE
perf(jest-haste-map): reuse cached metadata for duplicated haste names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,7 +67,7 @@
 - `[babel-jest, @jest/transform]` Update `babel-plugin-istanbul` to v8 ([#16049](https://github.com/jestjs/jest/pull/16049))
 - `[jest-haste-map]` Refactor massive class into multiple files ([#16180](https://github.com/jestjs/jest/pull/16180))
 - `[jest-haste-map]` Drop `walker` dependency; replace hand-rolled directory recursion in the JS crawler and watcher startup with `fdir` ([#16187](https://github.com/jestjs/jest/pull/16187))
-- `[jest-haste-map]` Reuse cached metadata for files whose haste name is a known duplicate, instead of re-reading and re-parsing them on every startup ([#16349](https://github.com/jestjs/jest/pull/16349))
+- `[jest-haste-map]` Reuse cached metadata for files whose haste name is a known duplicate, instead of re-reading and re-parsing them on every startup ([#16351](https://github.com/jestjs/jest/pull/16351))
 - `[jest-runner, @jest/source-map]` Replace `source-map-support` with an implementation in `@jest/source-map` ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[@jest/source-map]` Deprecate `getCallsite` in favour of `SourceMapSupport#getCallsite` ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[jest-runtime]` Avoid magical `null` value in ESM loader ([#16160](https://github.com/jestjs/jest/pull/16160))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - `[babel-jest, @jest/transform]` Update `babel-plugin-istanbul` to v8 ([#16049](https://github.com/jestjs/jest/pull/16049))
 - `[jest-haste-map]` Refactor massive class into multiple files ([#16180](https://github.com/jestjs/jest/pull/16180))
 - `[jest-haste-map]` Drop `walker` dependency; replace hand-rolled directory recursion in the JS crawler and watcher startup with `fdir` ([#16187](https://github.com/jestjs/jest/pull/16187))
+- `[jest-haste-map]` Reuse cached metadata for files whose haste name is a known duplicate, instead of re-reading and re-parsing them on every startup ([#16349](https://github.com/jestjs/jest/pull/16349))
 - `[jest-runner, @jest/source-map]` Replace `source-map-support` with an implementation in `@jest/source-map` ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[@jest/source-map]` Deprecate `getCallsite` in favour of `SourceMapSupport#getCallsite` ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[jest-runtime]` Avoid magical `null` value in ESM loader ([#16160](https://github.com/jestjs/jest/pull/16160))

--- a/packages/jest-haste-map/src/lib/FileProcessor.ts
+++ b/packages/jest-haste-map/src/lib/FileProcessor.ts
@@ -244,18 +244,18 @@ export class FileProcessor {
         return null;
       }
 
-      if (moduleMetadata != null) {
-        const platform =
-          getPlatformExtension(filePath, this._options.platforms) ||
-          H.GENERIC_PLATFORM;
+      const moduleId = fileMetadata[H.ID];
+      const platform =
+        getPlatformExtension(filePath, this._options.platforms) ||
+        H.GENERIC_PLATFORM;
 
+      if (moduleMetadata != null) {
         const module = moduleMetadata[platform];
 
         if (module == null) {
           return null;
         }
 
-        const moduleId = fileMetadata[H.ID];
         let modulesByPlatform = map.get(moduleId);
         if (!modulesByPlatform) {
           modulesByPlatform = Object.create(null) as ModuleMapItem;
@@ -263,6 +263,16 @@ export class FileProcessor {
         }
         modulesByPlatform[platform] = module;
 
+        return null;
+      }
+
+      // A haste name involved in a collision has no `map` entry — it was
+      // deleted when the collision was recorded — but `duplicates` survives a
+      // rebuild and already lists this file, so its metadata is up to date and
+      // re-extracting it would change nothing.
+      if (
+        hasteMap.duplicates.get(moduleId)?.get(platform)?.has(relativeFilePath)
+      ) {
         return null;
       }
     }

--- a/packages/jest-haste-map/src/lib/__tests__/FileProcessor.test.ts
+++ b/packages/jest-haste-map/src/lib/__tests__/FileProcessor.test.ts
@@ -278,6 +278,76 @@ describe('FileProcessor', () => {
       );
       expect(result).toBeNull();
     });
+
+    it('does not re-run the worker for a visited file whose ID is a known duplicate', () => {
+      const relativeFilePath = path.join('src', 'Dup.js');
+      const hasteMap = createEmptyMap();
+      hasteMap.files.set(relativeFilePath, ['Dup', 1000, 42, 1, '', null]);
+      // A collided name is removed from `map` and recorded in `duplicates`.
+      hasteMap.duplicates.set(
+        'Dup',
+        new Map([
+          [
+            'g',
+            new Map([
+              [relativeFilePath, 0],
+              [path.join('other', 'Dup.js'), 0],
+            ]),
+          ],
+        ]),
+      );
+
+      const pool = new MockWorkerPool({
+        maxWorkers: 1,
+        workerPath: FAKE_WORKER_PATH,
+      });
+      const workerInstance = makeWorker();
+      jest.mocked(pool.get).mockReturnValue(workerInstance);
+
+      const fp = new FileProcessor(makeOptions(), console, pool);
+      const result = fp.processFile(
+        hasteMap,
+        new Map(),
+        hasteMap.mocks,
+        path.join(ROOT, relativeFilePath),
+      );
+
+      expect(result).toBeNull();
+      expect(workerInstance.worker).not.toHaveBeenCalled();
+    });
+
+    it('still runs the worker for a visited file absent from the duplicates set', () => {
+      const hasteMap = createEmptyMap();
+      hasteMap.files.set(path.join('src', 'Dup.js'), [
+        'Dup',
+        1000,
+        42,
+        1,
+        '',
+        null,
+      ]);
+      hasteMap.duplicates.set(
+        'Dup',
+        new Map([['g', new Map([[path.join('other', 'Dup.js'), 0]])]]),
+      );
+
+      const pool = new MockWorkerPool({
+        maxWorkers: 1,
+        workerPath: FAKE_WORKER_PATH,
+      });
+      const workerInstance = makeWorker();
+      jest.mocked(pool.get).mockReturnValue(workerInstance);
+
+      const fp = new FileProcessor(makeOptions(), console, pool);
+      fp.processFile(
+        hasteMap,
+        new Map(),
+        hasteMap.mocks,
+        path.join(ROOT, 'src', 'Dup.js'),
+      );
+
+      expect(workerInstance.worker).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('buildHasteMap', () => {


### PR DESCRIPTION
## Summary

When two files claim the same haste name, `setModule` deletes the name from `map` and records both paths under `duplicates`, so consumers cannot resolve an ambiguous module.

`processFile` has a shortcut that skips the worker for files the cache already has metadata for. It takes that shortcut only when the file's haste name is still present in `map`:

```js
const moduleMetadata = hasteMap.map.get(fileMetadata[H.ID]);
// …
if (fileMetadata[H.VISITED]) {
  if (!fileMetadata[H.ID]) {
    return null;
  }
  if (moduleMetadata != null) {
    // reuse the cached entry
  }
}
```

For a duplicated name that lookup always misses, because the collision removed the entry. Every file in a duplicate group therefore falls through to the worker and is read off disk and run through dependency extraction again, on every single startup, for as long as the collision exists — even though its cached metadata is complete and nothing about it has changed.

`duplicates` is not rebuilt the way `map` is: `buildHasteMap` replaces `map` and `mocks` with fresh maps but carries `duplicates` over. So a file already listed there is in its final state, and the worker round-trip produces the same result it produced last time. This checks `duplicates` before falling through, and returns early when the file is already listed for its platform.

No change in what ends up in the haste map. A file whose name collides is still absent from `map` and still listed in `duplicates`; the only difference is that reaching that state no longer costs a file read and a parse per file per run. `moduleId` and `platform` move up a few lines so both branches can use them.

The win scales with how long a collision goes unfixed and how many files share the name. It is nothing for a clean repo, and monorepos that live with a known duplicate — vendored copies of a package, a checked-in build output next to its source — pay it on every run.

## Test plan

Two tests in `packages/jest-haste-map/src/lib/__tests__/FileProcessor.test.ts`, covering both directions of the new branch:

- a visited file listed in `duplicates` for its platform returns `null` without the worker being called
- a visited file whose name is in `duplicates` but which is not itself in the set still goes to the worker, so the early return cannot swallow a file that genuinely needs processing

```
yarn jest packages/jest-haste-map

Test Suites: 22 passed, 22 total
Tests:       200 passed, 200 total
Snapshots:   5 passed, 5 total
```

Also green: `yarn lint`, `yarn typecheck:tests`, `yarn check-changelog`, `yarn check-copyright-headers`.