### PR TITLE
fix(jest-haste-map): restore the nested duplicates index in `ModuleMap.fromJSON`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@
 - `[jest-environment-node, jest-util]` Only warn about a conflicting `globalsCleanup` mode when one was explicitly configured, and follow the mode that is actually in effect ([#16323](https://github.com/jestjs/jest/pull/16323))
 - `[jest-environment-node, jest-util]` Stop resolving lazy globals when setting up an environment, so Node 26's builtin module globals are no longer loaded (and no longer emit their deprecation warnings) for every test file ([#16324](https://github.com/jestjs/jest/pull/16324))
 - `[jest-haste-map]` Keep watch mode alive when an outside process briefly makes a file unreadable on Windows, instead of tearing the watcher down on `EPERM` ([#16295](https://github.com/jestjs/jest/pull/16295))
-- `[jest-haste-map]` Restore the nested `duplicates` index correctly in `ModuleMap.fromJSON`, so a haste collision reported inside a test worker raises `DuplicateHasteCandidatesError` instead of a `TypeError` ([#16349](https://github.com/jestjs/jest/pull/16349))
+- `[jest-haste-map]` Restore the nested `duplicates` index correctly in `ModuleMap.fromJSON`, so a haste collision reported inside a test worker raises `DuplicateHasteCandidatesError` instead of a `TypeError` ([#16353](https://github.com/jestjs/jest/pull/16353))
 - `[jest-message-util]` Print the inner errors of an `AggregateError` thrown inside a test ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[jest-message-util]` Indent nested `cause` and `AggregateError` sections of a test failure by one level per depth, so the nesting is legible instead of rendering flat ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[jest-message-util]` Color stack traces line by line so blank lines stay blank ([#16316](https://github.com/jestjs/jest/pull/16316))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@
 - `[jest-environment-node, jest-util]` Only warn about a conflicting `globalsCleanup` mode when one was explicitly configured, and follow the mode that is actually in effect ([#16323](https://github.com/jestjs/jest/pull/16323))
 - `[jest-environment-node, jest-util]` Stop resolving lazy globals when setting up an environment, so Node 26's builtin module globals are no longer loaded (and no longer emit their deprecation warnings) for every test file ([#16324](https://github.com/jestjs/jest/pull/16324))
 - `[jest-haste-map]` Keep watch mode alive when an outside process briefly makes a file unreadable on Windows, instead of tearing the watcher down on `EPERM` ([#16295](https://github.com/jestjs/jest/pull/16295))
+- `[jest-haste-map]` Restore the nested `duplicates` index correctly in `ModuleMap.fromJSON`, so a haste collision reported inside a test worker raises `DuplicateHasteCandidatesError` instead of a `TypeError` ([#16349](https://github.com/jestjs/jest/pull/16349))
 - `[jest-message-util]` Print the inner errors of an `AggregateError` thrown inside a test ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[jest-message-util]` Indent nested `cause` and `AggregateError` sections of a test failure by one level per depth, so the nesting is legible instead of rendering flat ([#16316](https://github.com/jestjs/jest/pull/16316))
 - `[jest-message-util]` Color stack traces line by line so blank lines stay blank ([#16316](https://github.com/jestjs/jest/pull/16316))

--- a/packages/jest-haste-map/src/ModuleMap.ts
+++ b/packages/jest-haste-map/src/ModuleMap.ts
@@ -39,7 +39,7 @@ export default class ModuleMap implements IModuleMap {
   private static mapFromArrayRecursive(
     arr: ReadonlyArray<[string, unknown]>,
   ): Map<string, unknown> {
-    if (arr[0] && Array.isArray(arr[1])) {
+    if (arr[0] && Array.isArray(arr[0][1])) {
       arr = arr.map(el => [
         el[0],
         this.mapFromArrayRecursive(el[1] as Array<[string, unknown]>),

--- a/packages/jest-haste-map/src/__tests__/ModuleMap.test.ts
+++ b/packages/jest-haste-map/src/__tests__/ModuleMap.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import H from '../constants';
+import ModuleMap from '../ModuleMap';
+import type {DuplicatesIndex, RawModuleMap} from '../types';
+
+const rootDir = '/root';
+
+function buildModuleMap(duplicates: DuplicatesIndex): ModuleMap {
+  const raw: RawModuleMap = {
+    duplicates,
+    map: new Map(),
+    mocks: new Map(),
+    rootDir,
+  };
+  return new ModuleMap(raw);
+}
+
+function duplicatesFor(
+  entries: Array<[name: string, platforms: Array<string>]>,
+): DuplicatesIndex {
+  return new Map(
+    entries.map(([name, platforms]) => [
+      name,
+      new Map(
+        platforms.map(platform => [
+          platform,
+          new Map([
+            [`a/${name}.js`, H.MODULE],
+            [`b/${name}.js`, H.MODULE],
+          ]),
+        ]),
+      ),
+    ]),
+  );
+}
+
+describe('ModuleMap serialization', () => {
+  it.each([
+    ['one name, one platform', [['Foo', ['g']]]],
+    [
+      'several names, one platform each',
+      [
+        ['Foo', ['g']],
+        ['Bar', ['g']],
+      ],
+    ],
+    ['one name, several platforms', [['Foo', ['g', 'ios']]]],
+    [
+      'several names, several platforms',
+      [
+        ['Foo', ['g', 'ios']],
+        ['Bar', ['g']],
+      ],
+    ],
+  ] as Array<[string, Array<[string, Array<string>]>]>)(
+    'round-trips duplicates through toJSON/fromJSON: %s',
+    (_label, entries) => {
+      const duplicates = duplicatesFor(entries);
+      const restored = ModuleMap.fromJSON(buildModuleMap(duplicates).toJSON());
+
+      expect(restored.getRawModuleMap().duplicates).toEqual(duplicates);
+    },
+  );
+
+  it('reports duplicates as DuplicateHasteCandidatesError after a round-trip', () => {
+    const original = buildModuleMap(duplicatesFor([['Foo', ['g']]]));
+    const restored = ModuleMap.fromJSON(original.toJSON());
+
+    expect(() => restored.getModule('Foo', 'g')).toThrow(
+      ModuleMap.DuplicateHasteCandidatesError,
+    );
+  });
+
+  it('round-trips an empty duplicates index', () => {
+    const restored = ModuleMap.fromJSON(buildModuleMap(new Map()).toJSON());
+
+    expect(restored.getRawModuleMap().duplicates).toEqual(new Map());
+  });
+});


### PR DESCRIPTION
## Summary

`ModuleMap.toJSON`/`fromJSON` convert the `duplicates` index — `Map<name, Map<platform, Map<path, type>>>` — to nested arrays and back. The two halves disagree about how they detect nesting:

```js
// toJSON — checks the first entry's VALUE
if (arr[0] && arr[0][1] instanceof Map) {

// fromJSON — checks the array's SECOND ENTRY
if (arr[0] && Array.isArray(arr[1])) {
```

So on the way back in, the condition asks "does this level have two or more entries" instead of "are the values nested". Whether the index is rebuilt correctly then depends on how many haste collisions a run happens to have, and at which level:

- **one duplicated name** — the outer array has a single entry, `arr[1]` is `undefined`, no recursion. `duplicates.get(name)` comes back as a raw array instead of a `Map`, and `getModule` throws `TypeError: dupMap.get is not a function` in place of the intended `DuplicateHasteCandidatesError`.
- **two or more names, one of which spans two platforms** — recursion runs a level too deep and reaches the numeric type leaves, so `fromJSON` itself throws `TypeError: number 0 is not iterable`.
- **two or more names, one platform each** — the two bugs cancel out and the result is correct, which is why this has gone unnoticed.

This is not a cold path. `jest-runner` serialises the module map for every test worker (`test.context.moduleMap.toJSON()`), and `testWorker` restores it with `getModuleMapFromJSON`, so any parallel run over a project with a haste collision hits it. Instead of the actionable "you must delete or exclude files until there remains only one of these" error listing the conflicting paths, the user gets a `TypeError` from inside `jest-haste-map`.

The fix is to test `arr[0][1]`, mirroring the serializer.

Worth noting the fix restores the _intended_ error rather than making duplicates resolvable — a project that currently sees a `TypeError` will now see `DuplicateHasteCandidatesError` naming the files, which is the diagnosis it should have had.

## Test plan

Added `packages/jest-haste-map/src/__tests__/ModuleMap.test.ts`, which round-trips `duplicates` through `toJSON`/`fromJSON` across all four shapes above (one name/one platform, several names/one platform each, one name/several platforms, several names/several platforms) plus the empty index, and asserts a round-tripped collision surfaces as `DuplicateHasteCandidatesError`.

Five of the six new tests fail on `main` and pass with the fix; the sixth is the empty-index case, which was never broken.

```
yarn jest packages/jest-haste-map

Test Suites: 23 passed, 23 total
Tests:       204 passed, 204 total
Snapshots:   5 passed, 5 total
```

Also green: `yarn lint`, `yarn typecheck:tests`, `yarn check-changelog`, `yarn check-copyright-headers`.