### PR TITLE
chore: anchor the `.claude` ignore patterns to rootDir

### DIFF
--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -24,7 +24,7 @@ export default {
     '!e2e/**',
   ],
   modulePathIgnorePatterns: [
-    '\\.claude/.*',
+    '<rootDir>/\\.claude/',
     'examples/.*',
     'packages/.*/build',
     'packages/.*/tsconfig.*',
@@ -43,7 +43,7 @@ export default {
     globalsCleanup: process.env.GLOBALS_CLEANUP ?? 'on',
   },
   testPathIgnorePatterns: [
-    '/\\.claude/',
+    '<rootDir>/\\.claude/',
     '/__arbitraries__/',
     '/__benchmarks__/',
     '/__fixtures__/',
@@ -80,7 +80,7 @@ export default {
     '\\.[jt]sx?$': require.resolve('babel-jest'),
   },
   watchPathIgnorePatterns: [
-    '\\.claude',
+    '<rootDir>/\\.claude/',
     'coverage',
     '<rootDir>/packages/jest-worker/src/workers/__tests__/__temp__',
   ],


### PR DESCRIPTION
## Summary

Better version of #16350. #16350 excluded `.claude` from the Jest config's crawl. Jest matches these patterns as regexes against absolute paths, and the ones added there are unanchored, so they also match an **ancestor** `.claude` directory.

That breaks the case the exclusion exists for. Agent worktrees live under `.claude/worktrees/<name>/`, so when Jest runs from inside one, every path it crawls contains `/.claude/` and all three patterns drop the worktree's own contents. It fails silently rather than with an error — the crawl finds the files, the ignore removes them, and the run reports:

```
102 files checked across 15 projects.
testPathIgnorePatterns: /\.claude/ - 0 matches
Pattern: packages/jest-runtime - 0 matches
```

Anchoring with `<rootDir>` gives the intended meaning in both directions: a run from the repo root still skips the worktrees, and a run inside a worktree only skips a `.claude` of its own. `<rootDir>` is substituted globally in these options before matching, so this is the supported spelling (`normalizeUnmockedModulePathPatterns` in `packages/jest-config/src/normalize.ts`).

This also tightens `watchPathIgnorePatterns`, which was the loosest of the three — bare `'\\.claude'` matched that substring anywhere in a path, including inside an unrelated filename.

`eslint.config.mjs` needs no equivalent change. ESLint resolves the config per linted file, so a file inside a worktree is governed by that worktree's own config, whose basePath already makes `.claude/**` worktree-relative. Verified below.

## Test plan

Both directions, using an isolated fixture — a fake repo with a nested `.claude/worktrees/wt/`, each level having its own config and test file:

| Patterns            | Run from        | Result                                                  |
| ------------------- | --------------- | ------------------------------------------------------- |
| anchored            | repo root       | lists only the root's test — nested worktree skipped ✅ |
| anchored            | nested worktree | lists the worktree's own test ✅                        |
| unanchored (before) | nested worktree | `testPathIgnorePatterns: /\.claude/ - 0 matches` ❌     |

In a real worktree under `.claude/worktrees/`, before → after:

```
# before: yarn jest packages/jest-runtime
Pattern: packages/jest-runtime - 0 matches

# after
Test Suites: 38 passed, 38 total
Tests:       4 skipped, 405 passed, 409 total
```

The exclusion still does its job relative to its own `rootDir` — planting a test file at `<rootDir>/.claude/worktrees/fake/__tests__/n.test.js` and re-running `--listTests` yields 0 tests under `<rootDir>/.claude/`.

ESLint checks confirming no change is needed there (ESLint 10 resolves config per file):

- `.claude/lint-probe.ts` from the main checkout → ignored
- `.claude/worktrees/<wt>/lint-probe.ts` from the main checkout → linted, governed by the worktree's own config
- `.claude/worktrees/<wt>/.claude/probe.ts` → ignored, worktree-relative match

No CHANGELOG entry: `jest.config.mjs` is repo tooling, not shipped — same as #16350.
