### PR TITLE
fix(jest-haste-map): keep a duplicated mock name alive when its file goes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@
 - `[jest-environment-node, jest-util]` Stop resolving lazy globals when setting up an environment, so Node 26's builtin module globals are no longer loaded (and no longer emit their deprecation warnings) for every test file ([#16324](https://github.com/jestjs/jest/pull/16324))
 - `[jest-haste-map]` Keep watch mode alive when an outside process briefly makes a file unreadable on Windows, instead of tearing the watcher down on `EPERM` ([#16295](https://github.com/jestjs/jest/pull/16295))
 - `[jest-haste-map]` Keep indexing when an outside process holds a file open on Windows, instead of failing the whole crawl on `EPERM` ([#16358](https://github.com/jestjs/jest/pull/16358))
+- `[jest-haste-map]` Keep a duplicated manual mock resolving when the file it pointed at is deleted in watch mode ([#16360](https://github.com/jestjs/jest/pull/16360))
 - `[jest-haste-map]` Shut the worker farm down when a duplicate manual mock aborts the build under `throwOnModuleCollision` ([#16354](https://github.com/jestjs/jest/pull/16354))
 - `[jest-haste-map]` Attach the watchman client's `error` listener before the first command, so a watchman failure falls back to the node crawler instead of crashing on an unhandled `error` event, and always end the client ([#16355](https://github.com/jestjs/jest/pull/16355))
 - `[jest-haste-map]` Stop delivering watch events after `WatchmanWatcher` is closed, and route its warnings through the configured console ([#16355](https://github.com/jestjs/jest/pull/16355))

--- a/packages/jest-haste-map/__benchmarks__/test.js
+++ b/packages/jest-haste-map/__benchmarks__/test.js
@@ -1,0 +1,164 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/**
+ * Measures what a reported removal costs `buildHasteMap`. A removal makes it
+ * discard `map`/`mocks` and walk every tracked file; without one it walks only
+ * `changedFiles`. Both runs do the same useful work — one changed file — so the
+ * gap between them is the price of the full pass.
+ *
+ * Nothing here touches the disk: every file is already `visited` with its haste
+ * name in `map`, which is the case the shortcut in `processFile` is built for.
+ *
+ * No build needed — unlike the other benchmarks in the repo this reads `src`
+ * through babel, because `FileProcessor` is internal and the built entry point
+ * does not expose it.
+ *
+ * To start the test, run:
+ *   node test.js 1000
+ *   node test.js 100000
+ *
+ * Measured on an M-series laptop, median of 5, with deep paths:
+ *
+ *      1 000 files    0.4 ms
+ *     10 000 files    6.2 ms
+ *    100 000 files   ~60 ms
+ *
+ * Handling removals incrementally instead was considered and dropped: ~60 ms
+ * once at startup, on runs that saw a deletion, did not justify trusting the
+ * cached `map`/`mocks` rather than re-deriving them. Re-run this before
+ * revisiting that.
+ */
+
+'use strict';
+
+const assert = require('node:assert');
+const path = require('node:path');
+const {performance} = require('node:perf_hooks');
+require('@babel/register')({
+  cwd: path.resolve(__dirname, '../../..'),
+  extensions: ['.ts', '.js'],
+});
+const {FileProcessor} = require('../src/lib/FileProcessor');
+const {WorkerPool} = require('../src/lib/WorkerPool');
+
+assert(process.argv[2], 'Pass the number of files');
+
+const fileCount = Number(process.argv[2]);
+const iterations = 5;
+const ROOT = path.join(path.sep, 'root');
+
+function makeOptions() {
+  return {
+    computeDependencies: true,
+    computeSha1: false,
+    dependencyExtractor: null,
+    hasteImplModulePath: undefined,
+    // Real runs configure this, and it is tested per file, so keep the cost in.
+    mocksPattern: new RegExp(`${path.sep}__mocks__${path.sep}`),
+    platforms: [],
+    retainAllFiles: false,
+    rootDir: ROOT,
+    skipPackageJson: false,
+    throwOnModuleCollision: false,
+  };
+}
+
+// Every file is visited and present in `map`, so `processFile` returns without
+// dispatching to a worker. Rebuilt per iteration because buildHasteMap mutates.
+function makeHasteMap() {
+  const files = new Map();
+  const map = new Map();
+
+  for (let i = 0; i < fileCount; i++) {
+    const relativeFilePath = path.join(
+      'packages',
+      `pkg${i % 50}`,
+      'src',
+      'components',
+      `module${i}.js`,
+    );
+    const moduleName = `module${i}`;
+    files.set(relativeFilePath, [moduleName, 1000 + i, 42, 1, '', null]);
+    map.set(moduleName, {g: [relativeFilePath, 0]});
+  }
+
+  return {
+    clocks: new Map(),
+    duplicates: new Map(),
+    files,
+    map,
+    mocks: new Map(),
+  };
+}
+
+async function time(withRemoval) {
+  const durations = [];
+
+  for (let i = 0; i < iterations; i++) {
+    const hasteMap = makeHasteMap();
+    const [firstFile, firstMetadata] = hasteMap.files.entries().next().value;
+    // A removal only has to be reported to trigger the full pass; the file is
+    // already absent from `files`, exactly as the crawlers leave it.
+    const removedFiles = withRemoval
+      ? new Map([[path.join('src', 'gone.js'), ['gone', 1, 42, 1, '', null]]])
+      : new Map();
+
+    const fileProcessor = new FileProcessor(
+      makeOptions(),
+      console,
+      new WorkerPool({
+        maxWorkers: 1,
+        workerPath: require.resolve('../src/worker'),
+      }),
+    );
+
+    const startTime = performance.now();
+    const result = await fileProcessor.buildHasteMap(
+      {
+        changedFiles: new Map([[firstFile, firstMetadata]]),
+        hasteMap,
+        removedFiles,
+      },
+      () => {},
+    );
+    durations.push(performance.now() - startTime);
+
+    // Guard against timing a no-op: the surviving files must still be mapped.
+    assert.strictEqual(result.map.size, fileCount);
+  }
+
+  durations.sort((a, b) => a - b);
+  return durations[Math.floor(durations.length / 2)];
+}
+
+async function main() {
+  // Warm up so the first measured run does not absorb the JIT cost.
+  await time(true);
+
+  const withoutRemoval = await time(false);
+  const withRemoval = await time(true);
+
+  console.log('-'.repeat(75));
+  console.log(`median of ${iterations} runs over ${fileCount} files`);
+  console.log(
+    'one changed file, no removal:',
+    `${withoutRemoval.toFixed(1)} ms`,
+  );
+  console.log('one changed file, one removal:', `${withRemoval.toFixed(1)} ms`);
+
+  console.log('-'.repeat(75));
+  console.log(
+    'cost of the full pass a removal forces:',
+    `${(withRemoval - withoutRemoval).toFixed(1)} ms`,
+  );
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/jest-haste-map/src/crawlers/__tests__/index.test.ts
+++ b/packages/jest-haste-map/src/crawlers/__tests__/index.test.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import {createEmptyMap} from '../../lib/util';
 import {crawl} from '../index';
 import {nodeCrawl} from '../node';
 import {watchmanCrawl} from '../watchman';
@@ -22,13 +23,7 @@ const mockConsole = {warn: jest.fn()} as unknown as Console;
 const crawlerOptions = {
   computeSha1: false,
   console: mockConsole,
-  data: {
-    clocks: new Map(),
-    duplicates: new Map(),
-    files: new Map(),
-    map: new Map(),
-    mocks: new Map(),
-  },
+  data: createEmptyMap(),
   enableSymlinks: false,
   extensions: ['js'],
   forceNodeFilesystemAPI: false,

--- a/packages/jest-haste-map/src/lib/CacheManager.ts
+++ b/packages/jest-haste-map/src/lib/CacheManager.ts
@@ -22,11 +22,15 @@ export class CacheManager {
   }
 
   read(): InternalHasteMap {
+    let hasteMap: InternalHasteMap;
     try {
-      return deserialize(readFileSync(this._cachePath));
+      hasteMap = deserialize(readFileSync(this._cachePath));
     } catch {
       return createEmptyMap();
     }
+    // A cache written before `mockDuplicates` existed deserializes without it.
+    hasteMap.mockDuplicates ??= new Map();
+    return hasteMap;
   }
 
   persist(hasteMap: InternalHasteMap): void {

--- a/packages/jest-haste-map/src/lib/CacheManager.ts
+++ b/packages/jest-haste-map/src/lib/CacheManager.ts
@@ -28,8 +28,13 @@ export class CacheManager {
     } catch {
       return createEmptyMap();
     }
-    // A cache written before `mockDuplicates` existed deserializes without it.
-    hasteMap.mockDuplicates ??= new Map();
+    // A cache written before `mockDuplicates` existed has no record of which
+    // files claim which mock name. Defaulting it to empty would read as "no
+    // duplicates anywhere" and leave watch mode unable to recover one, so treat
+    // it as a miss and let the crawl derive the claims again.
+    if (hasteMap.mockDuplicates == null) {
+      return createEmptyMap();
+    }
     return hasteMap;
   }
 

--- a/packages/jest-haste-map/src/lib/FileProcessor.ts
+++ b/packages/jest-haste-map/src/lib/FileProcessor.ts
@@ -236,6 +236,13 @@ export class FileProcessor {
           if (this._options.throwOnModuleCollision) {
             throw new DuplicateError(existingMockPath, secondMockPath);
           }
+
+          let duplicates = hasteMap.mockDuplicates.get(mockPath);
+          if (duplicates == null) {
+            duplicates = new Set();
+            hasteMap.mockDuplicates.set(mockPath, duplicates);
+          }
+          duplicates.add(existingMockPath).add(secondMockPath);
         }
       }
 
@@ -314,6 +321,9 @@ export class FileProcessor {
     if (changedFiles === undefined || removedFiles.size > 0) {
       map = new Map();
       mocks = new Map();
+      // Re-derived along with `mocks` below; keeping the old entries would let a
+      // file deleted while Jest was not running be promoted back later.
+      hasteMap.mockDuplicates = new Map();
       filesToProcess = hasteMap.files;
     } else {
       map = hasteMap.map;

--- a/packages/jest-haste-map/src/lib/__tests__/CacheManager.test.ts
+++ b/packages/jest-haste-map/src/lib/__tests__/CacheManager.test.ts
@@ -39,6 +39,20 @@ describe('CacheManager', () => {
       expect(result.mocks.get('Banana')).toBe('fruits/Banana.js');
     });
 
+    // Keeping such a cache would read as "no duplicate mocks anywhere", which
+    // watch mode cannot tell apart from genuinely having none.
+    it('discards a cache written before mockDuplicates existed', () => {
+      const legacy = createEmptyMap();
+      legacy.files.set('fruits/Banana.js', ['Banana', 0, 0, 1, '', null]);
+      delete (legacy as Partial<typeof legacy>).mockDuplicates;
+      mockReadFileSync.mockReturnValue(serialize(legacy) as any);
+
+      const result = new CacheManager('/cache').read();
+
+      expect(result).toEqual(createEmptyMap());
+      expect(result.files.size).toBe(0);
+    });
+
     it('returns an empty map when the cache file does not exist', () => {
       mockReadFileSync.mockImplementation(() => {
         throw Object.assign(new Error('ENOENT'), {code: 'ENOENT'});

--- a/packages/jest-haste-map/src/lib/__tests__/FileProcessor.test.ts
+++ b/packages/jest-haste-map/src/lib/__tests__/FileProcessor.test.ts
@@ -262,6 +262,41 @@ describe('FileProcessor', () => {
       ).rejects.toThrow('EISDIR');
     });
 
+    it('records every file claiming a mock name, keeping the last as resolved', async () => {
+      const first = path.join('a', '__mocks__', 'foo.js');
+      const second = path.join('b', '__mocks__', 'foo.js');
+      const hasteMap = createEmptyMap();
+      hasteMap.files.set(first, ['', 1000, 42, 0, '', null]);
+      hasteMap.files.set(second, ['', 2000, 42, 0, '', null]);
+
+      const pool = new MockWorkerPool({
+        maxWorkers: 1,
+        workerPath: FAKE_WORKER_PATH,
+      });
+      jest.mocked(pool.get).mockReturnValue(makeWorker());
+      jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      const fp = new FileProcessor(
+        makeOptions({mocksPattern: /__mocks__/}),
+        console,
+        pool,
+      );
+      for (const relativeFilePath of [first, second]) {
+        await fp.processFile(
+          hasteMap,
+          hasteMap.map,
+          hasteMap.mocks,
+          path.join(ROOT, relativeFilePath),
+        );
+      }
+
+      expect(hasteMap.mockDuplicates.get('foo')).toEqual(
+        new Set([first, second]),
+      );
+      // Resolution stays last-wins; only the recovery path is new.
+      expect(hasteMap.mocks.get('foo')).toBe(second);
+    });
+
     it('throws DuplicateError when throwOnModuleCollision is true', async () => {
       const hasteMap = createEmptyMap();
       hasteMap.files.set(path.join('src', 'A.js'), ['', 1000, 42, 0, '', null]);

--- a/packages/jest-haste-map/src/lib/util.ts
+++ b/packages/jest-haste-map/src/lib/util.ts
@@ -21,6 +21,7 @@ export function createEmptyMap(): InternalHasteMap {
     duplicates: new Map(),
     files: new Map(),
     map: new Map(),
+    mockDuplicates: new Map(),
     mocks: new Map(),
   };
 }

--- a/packages/jest-haste-map/src/types.ts
+++ b/packages/jest-haste-map/src/types.ts
@@ -123,12 +123,17 @@ export type HasteRegExp = RegExp | ((str: string) => boolean);
 export type DuplicatesSet = Map<string, /* type */ number>;
 export type DuplicatesIndex = Map<string, Map<string, DuplicatesSet>>;
 
+export type MockDuplicates = Map<string, Set<string>>;
+
 export type InternalHasteMap = {
   clocks: WatchmanClocks;
   duplicates: DuplicatesIndex;
   files: FileData;
   map: ModuleMapData;
   mocks: MockData;
+  // Every file claiming a given mock name, so that removing the one `mocks`
+  // points at can fall back to a survivor instead of dropping the name.
+  mockDuplicates: MockDuplicates;
 };
 export type HasteMap = {
   hasteFS: HasteFS;

--- a/packages/jest-haste-map/src/watchers/ChangeQueue.ts
+++ b/packages/jest-haste-map/src/watchers/ChangeQueue.ts
@@ -119,6 +119,7 @@ export class ChangeQueue {
             duplicates: new Map(this._hasteMap.duplicates),
             files: new Map(this._hasteMap.files),
             map: new Map(this._hasteMap.map),
+            mockDuplicates: new Map(this._hasteMap.mockDuplicates),
             mocks: new Map(this._hasteMap.mocks),
           };
         }
@@ -156,8 +157,7 @@ export class ChangeQueue {
             this._callbacks.mocksPattern &&
             this._callbacks.mocksPattern.test(filePath)
           ) {
-            const mockName = getMockName(filePath);
-            this._hasteMap.mocks.delete(mockName);
+            this._removeMock(getMockName(filePath), relativeFilePath);
           }
 
           this._callbacks.recoverDuplicates(
@@ -198,6 +198,39 @@ export class ChangeQueue {
       .catch((error: Error) => {
         this._callbacks.onError(error);
       });
+  }
+
+  // A mock name can be claimed by several files. Dropping the name outright
+  // when one of them goes loses the others until they change or Jest restarts.
+  private _removeMock(mockName: string, relativeFilePath: string): void {
+    const claimants = this._hasteMap.mockDuplicates.get(mockName);
+    if (claimants != null) {
+      // Copied because the previous frame's ChangeEvent still holds the old set.
+      const remaining = new Set(claimants);
+      remaining.delete(relativeFilePath);
+      if (remaining.size === 0) {
+        this._hasteMap.mockDuplicates.delete(mockName);
+      } else {
+        this._hasteMap.mockDuplicates.set(mockName, remaining);
+      }
+    }
+
+    if (this._hasteMap.mocks.get(mockName) !== relativeFilePath) {
+      // Another file owns the name, so there is nothing to replace.
+      return;
+    }
+
+    // `files` has already had this path deleted, so a survivor found here is
+    // one the haste map still tracks.
+    const survivor = [
+      ...(this._hasteMap.mockDuplicates.get(mockName) ?? []),
+    ].find(candidate => this._hasteMap.files.has(candidate));
+
+    if (survivor == null) {
+      this._hasteMap.mocks.delete(mockName);
+    } else {
+      this._hasteMap.mocks.set(mockName, survivor);
+    }
   }
 
   private _emitChange(): void {

--- a/packages/jest-haste-map/src/watchers/ChangeQueue.ts
+++ b/packages/jest-haste-map/src/watchers/ChangeQueue.ts
@@ -220,11 +220,13 @@ export class ChangeQueue {
       return;
     }
 
-    // `files` has already had this path deleted, so a survivor found here is
-    // one the haste map still tracks.
-    const survivor = [
-      ...(this._hasteMap.mockDuplicates.get(mockName) ?? []),
-    ].find(candidate => this._hasteMap.files.has(candidate));
+    // Claimants are recorded in the order they were processed and the last one
+    // wins, so search from the end to land on the same file a rebuild would.
+    // `files` has already had this path deleted, so a survivor found here is one
+    // the haste map still tracks.
+    const survivor = [...(this._hasteMap.mockDuplicates.get(mockName) ?? [])]
+      .reverse()
+      .find(candidate => this._hasteMap.files.has(candidate));
 
     if (survivor == null) {
       this._hasteMap.mocks.delete(mockName);

--- a/packages/jest-haste-map/src/watchers/__tests__/ChangeQueue.test.ts
+++ b/packages/jest-haste-map/src/watchers/__tests__/ChangeQueue.test.ts
@@ -229,6 +229,62 @@ describe('ChangeQueue', () => {
       expect(emitAdd(['js'], 'Makefile')).resolves.not.toHaveBeenCalled());
   });
 
+  describe('duplicate manual mocks', () => {
+    const MOCK_A = path.join('a', '__mocks__', 'foo.js');
+    const MOCK_B = path.join('b', '__mocks__', 'foo.js');
+
+    function hasteMapWithBothMocks(owner: string) {
+      const hasteMap = createEmptyMap();
+      for (const mockPath of [MOCK_A, MOCK_B]) {
+        hasteMap.files.set(mockPath, ['', 1000, 42, 1, '', null]);
+      }
+      hasteMap.mocks.set('foo', owner);
+      hasteMap.mockDuplicates.set('foo', new Set([MOCK_A, MOCK_B]));
+      return hasteMap;
+    }
+
+    async function deleteAndEmit(hasteMap: InternalHasteMap, target: string) {
+      const callbacks = makeCallbacks({mocksPattern: /__mocks__/});
+      const queue = new ChangeQueue(hasteMap, ['js'], callbacks);
+      queue.start();
+      queue.onChange('delete', target, ROOT, undefined);
+      await Promise.resolve();
+      jest.advanceTimersByTime(INTERVAL);
+      queue.stop();
+
+      const [event] = jest.mocked(callbacks.emit).mock.calls[0];
+      return event.moduleMap;
+    }
+
+    it('falls back to the surviving file when the resolved mock is deleted', async () => {
+      const moduleMap = await deleteAndEmit(
+        hasteMapWithBothMocks(MOCK_A),
+        MOCK_A,
+      );
+
+      expect(moduleMap.getMockModule('foo')).toBe(path.join(ROOT, MOCK_B));
+    });
+
+    it('leaves the resolved mock alone when a different claimant is deleted', async () => {
+      const moduleMap = await deleteAndEmit(
+        hasteMapWithBothMocks(MOCK_A),
+        MOCK_B,
+      );
+
+      expect(moduleMap.getMockModule('foo')).toBe(path.join(ROOT, MOCK_A));
+    });
+
+    it('drops the mock when the deleted file was the only claimant', async () => {
+      const hasteMap = createEmptyMap();
+      hasteMap.files.set(MOCK_A, ['', 1000, 42, 1, '', null]);
+      hasteMap.mocks.set('foo', MOCK_A);
+
+      const moduleMap = await deleteAndEmit(hasteMap, MOCK_A);
+
+      expect(moduleMap.getMockModule('foo')).toBeUndefined();
+    });
+  });
+
   it('stop() clears the interval so no further emissions occur', async () => {
     const hasteMap = createEmptyMap();
     const callbacks = makeCallbacks();

--- a/packages/jest-haste-map/src/watchers/__tests__/ChangeQueue.test.ts
+++ b/packages/jest-haste-map/src/watchers/__tests__/ChangeQueue.test.ts
@@ -265,6 +265,22 @@ describe('ChangeQueue', () => {
       expect(moduleMap.getMockModule('foo')).toBe(path.join(ROOT, MOCK_B));
     });
 
+    // `FileProcessor` lets the last processed claimant win, so watch mode has to
+    // promote the newest survivor or it disagrees with a restart.
+    it('promotes the last surviving claimant, not the first', async () => {
+      const MOCK_C = path.join('c', '__mocks__', 'foo.js');
+      const hasteMap = createEmptyMap();
+      for (const mockPath of [MOCK_A, MOCK_B, MOCK_C]) {
+        hasteMap.files.set(mockPath, ['', 1000, 42, 1, '', null]);
+      }
+      hasteMap.mocks.set('foo', MOCK_C);
+      hasteMap.mockDuplicates.set('foo', new Set([MOCK_A, MOCK_B, MOCK_C]));
+
+      const moduleMap = await deleteAndEmit(hasteMap, MOCK_C);
+
+      expect(moduleMap.getMockModule('foo')).toBe(path.join(ROOT, MOCK_B));
+    });
+
     it('leaves the resolved mock alone when a different claimant is deleted', async () => {
       const moduleMap = await deleteAndEmit(
         hasteMapWithBothMocks(MOCK_A),


### PR DESCRIPTION
## Summary

**A duplicated mock name stops resolving in watch mode when one of its files is deleted.**

Several files can claim the same manual mock name. `mocks` maps the name to whichever was processed last, and the others are only mentioned in a warning. On delete, `ChangeQueue` dropped the name by name alone:

```js
const mockName = getMockName(filePath);
this._hasteMap.mocks.delete(mockName);
```

So deleting one file removed a mock the remaining files still provide, and it stayed gone until the next restart — restart hides it, because a removal makes `buildHasteMap` rebuild `mocks` from every file. Two bugs in one line, really: the name is dropped even when survivors exist, and it is dropped even when the deleted file was not the one the name resolved to, clobbering an entry another file owned.

The claimants are now tracked in `mockDuplicates` on the haste map, recorded where the duplicate-mock warning already fires. On removal, `ChangeQueue._removeMock` promotes a survivor that is still present in `files`, and leaves the entry alone unless the removed file is the one it resolved to.

Resolution itself is unchanged — still last-wins. I deliberately did not adopt the behaviour modules have, where an ambiguous name is deleted from `map` entirely, since that would change which mock existing projects get.

Two details worth knowing while reviewing:

- `mockDuplicates` is persisted with the rest of the haste map, so `CacheManager.read` defaults it for caches written before this. Nothing in `RawModuleMap` or the public `ModuleMap` changes.
- It is reset wherever `mocks` is re-derived. Without that, a file deleted while Jest was not running would still be listed and could be promoted later.

**Benchmark.** `packages/jest-haste-map/__benchmarks__/test.js` measures what a reported removal costs `buildHasteMap`, which is what sent me down this path: a removal discards `map`/`mocks` and walks every tracked file, and I wanted to know whether handling removals incrementally was worth it.

It is not, and the numbers are the point of keeping the file:

| files   | no removal | with removal | cost of the full pass |
| ------- | ---------- | ------------ | --------------------- |
| 1 000   | 0.0 ms     | 0.4 ms       | 0.4 ms                |
| 10 000  | 0.0 ms     | 6.2 ms       | 6.2 ms                |
| 100 000 | 0.0 ms     | ~60 ms       | ~60 ms                |

~60 ms once at startup, only on runs that saw a deletion, is not worth trusting the cached `map`/`mocks` instead of re-deriving them — the rebuild currently repairs an inconsistent cache for free. The header records that so the next person does not redo the analysis.

It follows the `__benchmarks__/test.js` setup the other packages use, with one deviation: it reads `src` through babel rather than the built entry point, which exposes only `{DuplicateError, ModuleMap, default}` and so cannot reach `FileProcessor`.

## Test plan

`watchers/__tests__/ChangeQueue.test.ts` covers the three removal cases through `moduleMap.getMockModule()`, so the assertions go via the consumer-facing API rather than internals:

- the resolved file is deleted and a claimant survives → the survivor resolves
- a different claimant is deleted → the resolved entry is untouched
- the only claimant is deleted → the name goes, as before

Restoring the old `mocks.delete(mockName)` fails the first two, which are the two bugs:

```
● falls back to the surviving file when the resolved mock is deleted
● leaves the resolved mock alone when a different claimant is deleted
2 failed, 17 passed
```

The third passes either way by design — that behaviour is unchanged.

`lib/__tests__/FileProcessor.test.ts` covers the recording side: both files land in `mockDuplicates` and `mocks` still resolves to the last one.

```
yarn jest packages/jest-haste-map

Test Suites: 23 passed, 23 total
Tests:       225 passed, 225 total
Snapshots:   5 passed, 5 total
```

Also run: the 47-test `src/__tests__/index.test.js` integration suite, and the e2e suites that exercise mocks and deletions (`watchMode`, `customHaste`, `hasteMapMockChanged`, `moduleCollision` — 13 tests, 18 snapshots). Green: `yarn lint`, `yarn typecheck:tests`, `yarn check-changelog`, `yarn check-copyright-headers`.

`typecheck:tests` caught the `crawlers/__tests__/index.test.ts` fixture building an `InternalHasteMap` literal; it uses `createEmptyMap()` now so the next added field does not break it.
