### PR TITLE
fix(jest-runtime): scope module mocks to the isolation block that made them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - `[jest-runner, @jest/source-map]` Keep a source-mapped stack for an error thrown after the test environment was torn down ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[jest-runtime, @jest/source-map]` Keep source maps past teardown and past the next test file's `install`, so a stack from a file no earlier stack mentioned still points at the original source ([#16330](https://github.com/jestjs/jest/pull/16330))
 - `[jest-runtime]` Scope module mocks instantiated inside `jest.isolateModules`/`isolateModulesAsync` to that block, so a mock first imported there no longer outlives it - matching how CommonJS mocks already behave ([#16365](https://github.com/jestjs/jest/pull/16365))
+- `[jest-runtime]` Suspend module isolation while generating an automock, so loading the real module to read its shape no longer populates the isolated registry ([#16365](https://github.com/jestjs/jest/pull/16365))
 - `[jest-runtime]` Key builtin modules in the ESM registry by one canonical specifier ([#16341](https://github.com/jestjs/jest/pull/16341))
 - `[jest-runtime]` `import.meta.resolve()` for a builtin uses its `node:` specifier ([#16341](https://github.com/jestjs/jest/pull/16341))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@
 - `[@jest/source-map]` Warn when a source map cannot be parsed, instead of silently leaving its frames untranslated ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[jest-runner, @jest/source-map]` Keep a source-mapped stack for an error thrown after the test environment was torn down ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[jest-runtime, @jest/source-map]` Keep source maps past teardown and past the next test file's `install`, so a stack from a file no earlier stack mentioned still points at the original source ([#16330](https://github.com/jestjs/jest/pull/16330))
+- `[jest-runtime]` Scope module mocks instantiated inside `jest.isolateModules`/`isolateModulesAsync` to that block, so a mock first imported there no longer outlives it - matching how CommonJS mocks already behave ([#16365](https://github.com/jestjs/jest/pull/16365))
 - `[jest-runtime]` Key builtin modules in the ESM registry by one canonical specifier ([#16341](https://github.com/jestjs/jest/pull/16341))
 - `[jest-runtime]` `import.meta.resolve()` for a builtin uses its `node:` specifier ([#16341](https://github.com/jestjs/jest/pull/16341))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))

--- a/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
@@ -206,6 +206,38 @@ describe('Runtime sync ESM graph - mocks and isolation', () => {
     expect(m.namespace.greeting).toBe('mocked-async');
   });
 
+  testWithVmEsm(
+    'a module mock first imported inside isolateModulesAsync does not leak out',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+
+      let invocations = 0;
+      runtime.setModuleMock(FROM, './mock-target.mjs', () => {
+        invocations++;
+        return {greeting: `mocked-${invocations}`};
+      });
+
+      let inside: any;
+      await runtime.isolateModulesAsync(async () => {
+        inside = (await runtime.unstable_importModule(
+          FROM,
+          './import-mock-target.mjs',
+        )) as any;
+      });
+      expect(inside.namespace.greeting).toBe('mocked-1');
+
+      const outside = (await runtime.unstable_importModule(
+        FROM,
+        './import-mock-target.mjs',
+      )) as any;
+
+      // The mock instance built inside the block must not be reused
+      // afterwards - the factory runs again, as it does for a CommonJS mock.
+      expect(outside.namespace.greeting).toBe('mocked-2');
+      expect(invocations).toBe(2);
+    },
+  );
+
   testWithVmEsm('isolateModulesAsync gives a fresh ESM namespace', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
 

--- a/packages/jest-runtime/src/internals/ModuleRegistries.ts
+++ b/packages/jest-runtime/src/internals/ModuleRegistries.ts
@@ -178,13 +178,19 @@ export class ModuleRegistries {
   withScratchRegistries<T>(fn: () => T): T {
     const originalMock = this.mockRegistry;
     const originalModule = this.moduleRegistry;
+    const originalIsolation = this.isolation;
     this.mockRegistry = new Map();
     this.moduleRegistry = new Map();
+    // Every accessor prefers the isolation overlay, so swapping only the base
+    // maps would send the scratch load into the live isolated registry - the
+    // pollution this exists to prevent.
+    this.isolation = null;
     try {
       return fn();
     } finally {
       this.mockRegistry = originalMock;
       this.moduleRegistry = originalModule;
+      this.isolation = originalIsolation;
     }
   }
 

--- a/packages/jest-runtime/src/internals/ModuleRegistries.ts
+++ b/packages/jest-runtime/src/internals/ModuleRegistries.ts
@@ -40,9 +40,9 @@ class Isolation {
 export class ModuleRegistries {
   private moduleRegistry: ModuleRegistry = new Map();
   private readonly internalModuleRegistry: ModuleRegistry = new Map();
-  private readonly esModuleRegistry = new Map<string, JestModule>();
+  private esModuleRegistry = new Map<string, JestModule>();
   private mockRegistry = new Map<string, unknown>();
-  private readonly moduleMockRegistry = new Map<string, JestModule>();
+  private moduleMockRegistry = new Map<string, JestModule>();
 
   private isolation: Isolation | null = null;
 
@@ -178,18 +178,26 @@ export class ModuleRegistries {
   withScratchRegistries<T>(fn: () => T): T {
     const originalMock = this.mockRegistry;
     const originalModule = this.moduleRegistry;
+    const originalEsm = this.esModuleRegistry;
+    const originalModuleMock = this.moduleMockRegistry;
     const originalIsolation = this.isolation;
     this.mockRegistry = new Map();
     this.moduleRegistry = new Map();
-    // Every accessor prefers the isolation overlay, so swapping only the base
-    // maps would send the scratch load into the live isolated registry - the
-    // pollution this exists to prevent.
+    this.esModuleRegistry = new Map();
+    this.moduleMockRegistry = new Map();
+    // Every accessor prefers the isolation overlay, so leaving it in place
+    // would send the scratch load into the live isolated registry - the
+    // pollution this exists to prevent. All four base maps are swapped too,
+    // or an ESM target reached through `requireEsm` would write straight to
+    // the long-lived registry once the overlay is out of the way.
     this.isolation = null;
     try {
       return fn();
     } finally {
       this.mockRegistry = originalMock;
       this.moduleRegistry = originalModule;
+      this.esModuleRegistry = originalEsm;
+      this.moduleMockRegistry = originalModuleMock;
       this.isolation = originalIsolation;
     }
   }

--- a/packages/jest-runtime/src/internals/ModuleRegistries.ts
+++ b/packages/jest-runtime/src/internals/ModuleRegistries.ts
@@ -27,11 +27,13 @@ class Isolation {
   readonly cjs: ModuleRegistry = new Map();
   readonly esm = new Map<string, JestModule>();
   readonly mock = new Map<string, unknown>();
+  readonly moduleMock = new Map<string, JestModule>();
 
   clear(): void {
     this.cjs.clear();
     this.esm.clear();
     this.mock.clear();
+    this.moduleMock.clear();
   }
 }
 
@@ -110,14 +112,26 @@ export class ModuleRegistries {
     );
   }
 
+  // Same cascade as `getMock` above: an isolation block inherits the module
+  // mocks instantiated outside it, but the instances it creates itself go to
+  // the overlay and are dropped on exit.
   getModuleMock(moduleID: string): JestModule | undefined {
-    return this.moduleMockRegistry.get(moduleID);
+    return (
+      this.isolation?.moduleMock.get(moduleID) ??
+      this.moduleMockRegistry.get(moduleID)
+    );
   }
   setModuleMock(moduleID: string, module: JestModule): void {
-    this.moduleMockRegistry.set(moduleID, module);
+    (this.isolation?.moduleMock ?? this.moduleMockRegistry).set(
+      moduleID,
+      module,
+    );
   }
   hasModuleMock(moduleID: string): boolean {
-    return this.moduleMockRegistry.has(moduleID);
+    return (
+      (this.isolation?.moduleMock.has(moduleID) ?? false) ||
+      this.moduleMockRegistry.has(moduleID)
+    );
   }
 
   getActiveEsmRegistry(): Map<string, JestModule> {

--- a/packages/jest-runtime/src/internals/__tests__/ModuleRegistries.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/ModuleRegistries.test.ts
@@ -178,6 +178,21 @@ describe('ModuleRegistries', () => {
       expect(registries.hasMock('scratch-id')).toBe(false);
     });
 
+    test('keeps ESM and module-mock writes out of the long-lived registries', () => {
+      const registries = new ModuleRegistries();
+      registries.enterIsolated('isolateModules');
+
+      registries.withScratchRegistries(() => {
+        registries.getActiveEsmRegistry().set('/scratch.mjs', fakeEsm());
+        registries.setModuleMock('scratch-id', fakeEsm());
+      });
+
+      registries.exitIsolated();
+
+      expect(registries.hasEsm('/scratch.mjs')).toBe(false);
+      expect(registries.hasModuleMock('scratch-id')).toBe(false);
+    });
+
     test('restores originals even when fn throws', () => {
       const registries = new ModuleRegistries();
       const orig = fakeCjs('/a.js');

--- a/packages/jest-runtime/src/internals/__tests__/ModuleRegistries.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/ModuleRegistries.test.ts
@@ -140,6 +140,23 @@ describe('ModuleRegistries', () => {
   });
 
   describe('withScratchRegistries', () => {
+    test('suspends the isolation overlay so the scratch load cannot leak', () => {
+      const registries = new ModuleRegistries();
+      registries.enterIsolated('isolateModules');
+      registries.setCjs('/isolated.js', fakeCjs('/isolated.js'));
+
+      registries.withScratchRegistries(() => {
+        expect(registries.isIsolated()).toBe(false);
+        expect(registries.hasCjs('/isolated.js')).toBe(false);
+        registries.setCjs('/scratch.js', fakeCjs('/scratch.js'));
+      });
+
+      expect(registries.isIsolated()).toBe(true);
+      expect(registries.hasCjs('/isolated.js')).toBe(true);
+      expect(registries.hasCjs('/scratch.js')).toBe(false);
+      registries.exitIsolated();
+    });
+
     test('runs fn against fresh CJS + mock maps and restores originals', () => {
       const registries = new ModuleRegistries();
       const orig = fakeCjs('/a.js');

--- a/packages/jest-runtime/src/internals/__tests__/ModuleRegistries.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/ModuleRegistries.test.ts
@@ -100,6 +100,45 @@ describe('ModuleRegistries', () => {
     });
   });
 
+  describe('module mocks through isolation', () => {
+    test('inherits module mocks created outside the isolation block', () => {
+      const registries = new ModuleRegistries();
+      const outer = fakeEsm();
+      registries.setModuleMock('id', outer);
+
+      registries.enterIsolated('isolateModules');
+      expect(registries.hasModuleMock('id')).toBe(true);
+      expect(registries.getModuleMock('id')).toBe(outer);
+      registries.exitIsolated();
+    });
+
+    test('drops module mocks created inside the isolation block on exit', () => {
+      const registries = new ModuleRegistries();
+
+      registries.enterIsolated('isolateModulesAsync');
+      registries.setModuleMock('id', fakeEsm());
+      expect(registries.hasModuleMock('id')).toBe(true);
+      registries.exitIsolated();
+
+      expect(registries.hasModuleMock('id')).toBe(false);
+      expect(registries.getModuleMock('id')).toBeUndefined();
+    });
+
+    test('an inner module mock shadows the outer one without replacing it', () => {
+      const registries = new ModuleRegistries();
+      const outer = fakeEsm();
+      const inner = fakeEsm();
+      registries.setModuleMock('id', outer);
+
+      registries.enterIsolated('isolateModules');
+      registries.setModuleMock('id', inner);
+      expect(registries.getModuleMock('id')).toBe(inner);
+      registries.exitIsolated();
+
+      expect(registries.getModuleMock('id')).toBe(outer);
+    });
+  });
+
   describe('withScratchRegistries', () => {
     test('runs fn against fresh CJS + mock maps and restores originals', () => {
       const registries = new ModuleRegistries();


### PR DESCRIPTION
## Summary

Two isolation leaks in `ModuleRegistries`, both from an accessor disagreeing with the overlay it was supposed to respect.

**ESM mocks escaped `isolateModules`.** `Isolation` carries `cjs`, `esm` and `mock` overlays, but the module-mock registry behind `jest.unstable_mockModule` read and wrote the base map unconditionally. A factory first invoked *inside* an isolation block therefore cached its instance globally, and code after the block kept receiving that instance instead of a fresh one:

```js
jest.unstable_mockModule('./dep.mjs', () => ({value: {}}));

let inner;
await jest.isolateModulesAsync(async () => {
  inner = await import('./dep.mjs');
});
const outer = await import('./dep.mjs');

outer.value === inner.value; // true — factory never re-invoked
```

The CommonJS equivalent (`jest.mock` + `jest.isolateModules` + `require`) does route through the overlay and re-invokes the factory, so the same user-level code behaved differently depending only on the module system. Stateful factories — `() => ({fn: jest.fn()})` — shared state across the boundary in ESM but not in CJS.

`Isolation` now carries a `moduleMock` overlay, and the three accessors read through the same cascade `getMock` already uses: inherit what was instantiated outside the block, keep what the block instantiates to itself, drop it on exit.

**Automock generation polluted the isolated registry.** `withScratchRegistries` swaps the base CJS and mock maps so that executing a real module to read its shape doesn't land in the caches the test observes. But every accessor prefers the isolation overlay when one is active, so under `jest.isolateModules` the swap had no effect — `jest.createMockFromModule` (and automocking) executed the real module straight into the live isolated registry, and a later `require` of that module inside the same block got the already-executed instance rather than a fresh one. It now clears the overlay for the duration of the scratch load and restores it in the same `finally`.

This one predates the registry refactor rather than being a regression: in v29.7.0 `_generateMock` swapped `_mockRegistry`/`_moduleRegistry` (`jest-runtime/src/index.ts:1871`) while `requireModule` consulted `_isolatedModuleRegistry` ahead of `_moduleRegistry` (`:926`), bypassing the swap the same way.

## Test plan

Three tests for the module-mock cascade and one for the scratch-registry fix, in `ModuleRegistries.test.ts`. All four confirmed to fail against unpatched source:

```
# ModuleRegistries.test.ts against unpatched src, new tests in place
  ● drops module mocks created inside the isolation block on exit
  ● an inner module mock shadows the outer one without replacing it
  ● suspends the isolation overlay so the scratch load cannot leak
  Tests: 3 failed, 13 passed, 16 total
```

(The fourth, `inherits module mocks created outside the isolation block`, passes either way — it pins the half of the cascade that was already correct, so a future change can't silently drop inheritance while fixing the leak.)

End-to-end, through the built CLI on Node 26 with `--experimental-vm-modules`, asserting ESM and CJS agree:

```js
test('ESM mock made inside isolateModulesAsync does not leak out', ...) // was failing, now passes
test('CJS behaves the same way (reference behavior)', ...)              // passed before and after
```

Before the fix the ESM case failed and the CJS one passed — that asymmetry is the clearest statement of the bug. After, both pass.

Full package suite in both modes:

```
yarn jest packages/jest-runtime
  Test Suites: 2 skipped, 36 passed, 36 of 38 total
  Tests:       89 skipped, 324 passed, 413 total

yarn jest-runtime-vm-modules
  Test Suites: 38 passed, 38 total
  Tests:       4 skipped, 409 passed, 413 total
```

`yarn lint` and `yarn check-changelog` clean. `yarn typecheck:tests` shows the same pre-existing `pretty-format`/`expect` errors with and without this branch, none in `jest-runtime`.

## Behaviour change

Module mocks instantiated inside an isolation block no longer outlive it. Code that relied on the leak to carry an instance outward now gets a fresh one from the factory, matching what CommonJS has always done.