### PR TITLE
fix(jest-runtime): throw ERR_REQUIRE_CYCLE_MODULE on require(esm) re-entry

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ yarn install        # ~45 s. Python is required (node-gyp).
 yarn build:js       # ~5 s. Run this before tests — they import from build/, not src/.
 ```
 
-Tests transform on the fly via `babel-jest`, but their `import {x} from '../'` resolves to each package's `build/`. `yarn build:js` is required after every checkout. Full `yarn build` (`build:js && build:ts && bundle:ts`) is 3–5 min and only needed when working on type declarations or API Extractor output.
+Tests transform on the fly via `babel-jest`, but their `import {x} from '../'` resolves to each package's `build/`. `yarn build:js` is required after every checkout. Full `yarn build` (`build:js && build:ts && bundle:ts`) is 3–5 min and needed when working on type declarations or API Extractor output — and before `yarn typecheck:tests`, which resolves cross-package types from `build/*.d.ts` and reports phantom errors (e.g. missing custom matchers) in a fresh checkout without them.
 
 Iterative: `yarn watch` (webpack), `yarn watch:ts` (declarations). Clean: `yarn build-clean`; full reset: `yarn clean-all`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - `[jest-runtime]` Check a cached ES module's status before `require()` returns it, so a module whose evaluation threw rethrows that error and one left linked by a failed sibling is evaluated instead of returning uninitialized bindings ([#16364](https://github.com/jestjs/jest/pull/16364))
 - `[jest-runtime]` Report the original `ERR_REQUIRE_ASYNC_MODULE` when a `require()` of a top-level-await graph is retried, instead of a spurious "concurrent `import()`" error ([#16364](https://github.com/jestjs/jest/pull/16364))
 - `[jest-runtime]` Throw the evaluation error when another caller's `import()` of the same module failed while we awaited it, instead of resolving with the errored module ([#16364](https://github.com/jestjs/jest/pull/16364))
+- `[jest-runtime]` Throw `ERR_REQUIRE_CYCLE_MODULE` like Node when a CommonJS module `require()`s an ES module that is still being loaded, instead of evaluating the module a second time ([#16366](https://github.com/jestjs/jest/pull/16366))
 - `[jest-runtime]` Key builtin modules in the ESM registry by one canonical specifier ([#16341](https://github.com/jestjs/jest/pull/16341))
 - `[jest-runtime]` `import.meta.resolve()` for a builtin uses its `node:` specifier ([#16341](https://github.com/jestjs/jest/pull/16341))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))

--- a/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
@@ -388,6 +388,27 @@ describe('Runtime sync ESM graph - require(esm)', () => {
   );
 
   testWithSyncEsm(
+    'throws ERR_REQUIRE_CYCLE_MODULE for a self-require during evaluation',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const ns = runtime.requireModule(FROM, './eval-time-cycle.mjs');
+      expect(ns.observed).toBe('ERR_REQUIRE_CYCLE_MODULE');
+    },
+  );
+
+  testWithSyncEsm(
+    'scopes cycle detection to the registry the walk runs against',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const ns = runtime.requireModule(FROM, './isolation-reentry-root.mjs');
+      expect(ns.outerValue).toBe('outer');
+      const probe = runtime.requireModule(FROM, './isolates-same-root.cjs');
+      expect(probe.isolated.outerValue).toBe('outer');
+      expect(probe.isolated).not.toBe(ns);
+    },
+  );
+
+  testWithSyncEsm(
     'allows a CJS dep to require an unrelated ESM root mid-walk',
     async () => {
       const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});

--- a/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
@@ -373,6 +373,44 @@ describe('Runtime sync ESM graph - require(esm)', () => {
   );
 
   testWithSyncEsm(
+    'throws ERR_REQUIRE_CYCLE_MODULE when a CJS dep requires back into the graph',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      expect(() => runtime.requireModule(FROM, './cycle-root.mjs')).toThrow(
+        expect.objectContaining({
+          code: 'ERR_REQUIRE_CYCLE_MODULE',
+          message: expect.stringMatching(
+            /Cannot require\(\) ES Module .*cycle-root\.mjs in a cycle\. \(from .*requires-cycle-root\.cjs\)/,
+          ),
+        }),
+      );
+    },
+  );
+
+  testWithSyncEsm(
+    'allows a CJS dep to require an unrelated ESM root mid-walk',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const ns = runtime.requireModule(FROM, './nested-walk-root.mjs');
+      expect(ns.rootValue).toBe('root');
+      const unrelated = runtime.requireModule(FROM, './requires-unrelated.cjs');
+      expect(unrelated.otherValue).toBe('sibling');
+    },
+  );
+
+  testWithSyncEsm(
+    'serves an already-evaluated module to a CJS dep mid-walk',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const first = runtime.requireModule(FROM, './a.mjs');
+      const ns = runtime.requireModule(FROM, './reuse-evaluated-root.mjs');
+      expect(ns.reuseValue).toBe('reuse-root');
+      const probe = runtime.requireModule(FROM, './requires-evaluated.cjs');
+      expect(probe.aValue).toBe(first.valueA);
+    },
+  );
+
+  testWithSyncEsm(
     'throws ERR_REQUIRE_ASYNC_MODULE for an async mock factory',
     async () => {
       const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});

--- a/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
@@ -397,6 +397,17 @@ describe('Runtime sync ESM graph - require(esm)', () => {
   );
 
   testWithSyncEsm(
+    'throws ERR_REQUIRE_CYCLE_MODULE across nested walks',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const ns = runtime.requireModule(FROM, './deep-cycle-root.mjs');
+      expect(ns.rootOneValue).toBe(1);
+      const probe = runtime.requireModule(FROM, './requires-first-root.cjs');
+      expect(probe.observed).toBe('ERR_REQUIRE_CYCLE_MODULE');
+    },
+  );
+
+  testWithSyncEsm(
     'scopes cycle detection to the registry the walk runs against',
     async () => {
       const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/cycle-root.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/cycle-root.mjs
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './requires-cycle-root.cjs';
+export const cycleValue = 'never-reached';

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/deep-cycle-root.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/deep-cycle-root.mjs
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './requires-second-root.cjs';
+export const rootOneValue = 1;

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/eval-time-cycle.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/eval-time-cycle.mjs
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import {createRequire} from 'module';
 
 const require = createRequire(import.meta.url);

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/eval-time-cycle.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/eval-time-cycle.mjs
@@ -1,0 +1,10 @@
+import {createRequire} from 'module';
+
+const require = createRequire(import.meta.url);
+let observedCode;
+try {
+  require('./eval-time-cycle.mjs');
+} catch (error) {
+  observedCode = error.code;
+}
+export const observed = observedCode;

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/isolates-same-root.cjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/isolates-same-root.cjs
@@ -1,0 +1,6 @@
+if (!globalThis.__cycleIsolationRan) {
+  globalThis.__cycleIsolationRan = true;
+  jest.isolateModules(() => {
+    exports.isolated = require('./isolation-reentry-root.mjs');
+  });
+}

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/isolates-same-root.cjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/isolates-same-root.cjs
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 if (!globalThis.__cycleIsolationRan) {
   globalThis.__cycleIsolationRan = true;
   jest.isolateModules(() => {

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/isolation-reentry-root.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/isolation-reentry-root.mjs
@@ -1,2 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import './isolates-same-root.cjs';
 export const outerValue = 'outer';

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/isolation-reentry-root.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/isolation-reentry-root.mjs
@@ -1,0 +1,2 @@
+import './isolates-same-root.cjs';
+export const outerValue = 'outer';

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/nested-walk-root.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/nested-walk-root.mjs
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './requires-unrelated.cjs';
+export const rootValue = 'root';

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/requires-cycle-root.cjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/requires-cycle-root.cjs
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const root = require('./cycle-root.mjs');
+exports.fromRoot = root;

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/requires-evaluated.cjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/requires-evaluated.cjs
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const a = require('./a.mjs');
+exports.aValue = a.valueA;

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/requires-first-root.cjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/requires-first-root.cjs
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+let observedCode;
+try {
+  require('./deep-cycle-root.mjs');
+} catch (error) {
+  observedCode = error.code;
+}
+exports.observed = observedCode;

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/requires-second-root.cjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/requires-second-root.cjs
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+exports.secondRoot = require('./second-root.mjs');

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/requires-unrelated.cjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/requires-unrelated.cjs
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const other = require('./linked-sibling.mjs');
+exports.otherValue = other.value;

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/reuse-evaluated-root.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/reuse-evaluated-root.mjs
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './requires-evaluated.cjs';
+export const reuseValue = 'reuse-root';

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/second-root.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/second-root.mjs
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import './requires-first-root.cjs';
+export const rootTwoValue = 2;

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -248,8 +248,8 @@ export default class Runtime {
       logFormattedReferenceError: msg => this._logFormattedReferenceError(msg),
       mockState: this.mockState,
       registries: this.registries,
-      requireEsm: <T>(modulePath: string) =>
-        this.esmLoader.requireEsmModule<T>(modulePath),
+      requireEsm: <T>(modulePath: string, requiredFrom: string) =>
+        this.esmLoader.requireEsmModule<T>(modulePath, requiredFrom),
       resolution: this._resolution,
       testState: this.testState,
       transformCache: this.transformCache,

--- a/packages/jest-runtime/src/internals/CjsLoader.ts
+++ b/packages/jest-runtime/src/internals/CjsLoader.ts
@@ -30,7 +30,7 @@ export interface CjsLoaderOptions {
   environment: JestEnvironment;
   coreModule: CoreModuleProvider;
   executor: ModuleExecutor;
-  requireEsm: <T>(modulePath: string) => T;
+  requireEsm: <T>(modulePath: string, requiredFrom: string) => T;
   testState: TestState;
   logFormattedReferenceError: (msg: string) => void;
 }
@@ -43,7 +43,10 @@ export class CjsLoader {
   private readonly environment: JestEnvironment;
   private readonly coreModule: CoreModuleProvider;
   private readonly executor: ModuleExecutor;
-  private readonly requireEsm: <T>(modulePath: string) => T;
+  private readonly requireEsm: <T>(
+    modulePath: string,
+    requiredFrom: string,
+  ) => T;
   private readonly testState: TestState;
   private readonly logFormattedReferenceError: (msg: string) => void;
 
@@ -97,7 +100,7 @@ export class CjsLoader {
     // On Node 24.9+ we can require() ESM natively. On older Node, fall
     // through to the CJS path so a configured transform can convert it.
     if (supportsSyncEvaluate && this.resolution.shouldLoadAsEsm(modulePath)) {
-      return this.requireEsm<T>(modulePath);
+      return this.requireEsm<T>(modulePath, from);
     }
 
     const moduleRegistry = isInternal
@@ -135,7 +138,7 @@ export class CjsLoader {
     } catch (error) {
       moduleRegistry.delete(modulePath);
       if (error instanceof CjsParseError) {
-        return this.handleCjsParseError(modulePath, error);
+        return this.handleCjsParseError(modulePath, from, error);
       }
       // Without --experimental-vm-modules, CjsParseError is never thrown.
       // Detect untransformed ESM syntax and surface an actionable error.
@@ -161,11 +164,12 @@ export class CjsLoader {
    */
   private handleCjsParseError<T>(
     modulePath: string,
+    from: string,
     parseError: CjsParseError,
   ): T {
     if (supportsSyncEvaluate) {
       try {
-        return this.requireEsm<T>(modulePath);
+        return this.requireEsm<T>(modulePath, from);
       } catch (esmError) {
         // Both CJS and ESM parsers rejected it — surface the original CJS error.
         if (esmError instanceof Error && esmError.name === 'SyntaxError') {

--- a/packages/jest-runtime/src/internals/EsmLoader.ts
+++ b/packages/jest-runtime/src/internals/EsmLoader.ts
@@ -439,15 +439,15 @@ export class EsmLoader {
     const activeWalk = new Set<string>();
     this.activeSyncWalks.push({keys: activeWalk, registry});
     try {
-      return this.walkGraphSync(
-        rootKey,
+      return this.walkGraphSync({
         activeWalk,
-        worklist,
-        scratch,
-        registry,
         context,
         mode,
-      );
+        registry,
+        rootKey,
+        scratch,
+        worklist,
+      });
     } finally {
       this.activeSyncWalks.pop();
     }
@@ -462,15 +462,23 @@ export class EsmLoader {
     );
   }
 
-  private walkGraphSync(
-    rootKey: string,
-    activeWalk: Set<string>,
-    worklist: Array<WorklistEntry>,
-    scratch: Map<string, ScratchEntry>,
-    registry: Map<string, JestModule>,
-    context: VMContext,
-    mode: SyncEsmMode,
-  ): ESModule | LoadAsync {
+  private walkGraphSync({
+    rootKey,
+    activeWalk,
+    worklist,
+    scratch,
+    registry,
+    context,
+    mode,
+  }: {
+    rootKey: string;
+    activeWalk: Set<string>;
+    worklist: Array<WorklistEntry>;
+    scratch: Map<string, ScratchEntry>;
+    registry: Map<string, JestModule>;
+    context: VMContext;
+    mode: SyncEsmMode;
+  }): ESModule | LoadAsync {
     while (worklist.length > 0) {
       const {cacheKey, modulePath} = worklist.pop()!;
       activeWalk.add(cacheKey);

--- a/packages/jest-runtime/src/internals/EsmLoader.ts
+++ b/packages/jest-runtime/src/internals/EsmLoader.ts
@@ -313,8 +313,14 @@ export class EsmLoader {
   private readonly testState: TestState;
   // Every cacheKey popped by a sync walk that is still on the stack. Walks
   // nest (a CJS body executing mid-walk can require() an unrelated ESM root),
-  // so this is a stack of one Set per walk rather than a single Set.
-  private readonly activeSyncWalks: Array<Set<string>> = [];
+  // so this is a stack of one entry per walk rather than a single Set. Each
+  // walk records the registry it ran against: an isolation overlay or an
+  // automock scratch registry is a separate instance space, so a key match
+  // across registries is a fresh build, not a cycle.
+  private readonly activeSyncWalks: Array<{
+    registry: Map<string, JestModule>;
+    keys: Set<string>;
+  }> = [];
   // Used only by the legacy async path; deletable when min-Node ≥ v24.9
   // (delete the block at the bottom of this file too - eslint/tsc will
   // surface anything else that becomes unused).
@@ -397,6 +403,15 @@ export class EsmLoader {
       if (cached.status === 'linked') {
         return this.evaluateLinkedModule(cached, mode);
       }
+      // `'unlinked'` / `'linking'` / `'evaluating'`. When the key belongs to
+      // a walk still on the stack this is a require() of a module whose own
+      // evaluation is in progress - a cycle, not a concurrent import().
+      if (
+        mode === 'sync-required' &&
+        this.isReEnteringActiveWalk(rootKey, registry)
+      ) {
+        throw makeRequireCycleError(canonicalRootPath, requiredFrom);
+      }
       return LOAD_ASYNC;
     }
 
@@ -405,12 +420,11 @@ export class EsmLoader {
     // reach the registry only after the root instantiates). Node throws
     // ERR_REQUIRE_CYCLE_MODULE here; a dynamic import() of the same shape is
     // a legal ESM cycle, so `'sync-preferred'` is exempt.
-    if (mode === 'sync-required') {
-      for (const walk of this.activeSyncWalks) {
-        if (walk.has(rootKey)) {
-          throw makeRequireCycleError(canonicalRootPath, requiredFrom);
-        }
-      }
+    if (
+      mode === 'sync-required' &&
+      this.isReEnteringActiveWalk(rootKey, registry)
+    ) {
+      throw makeRequireCycleError(canonicalRootPath, requiredFrom);
     }
 
     const context = this.getContext();
@@ -423,7 +437,7 @@ export class EsmLoader {
     ];
 
     const activeWalk = new Set<string>();
-    this.activeSyncWalks.push(activeWalk);
+    this.activeSyncWalks.push({keys: activeWalk, registry});
     try {
       return this.walkGraphSync(
         rootKey,
@@ -437,6 +451,15 @@ export class EsmLoader {
     } finally {
       this.activeSyncWalks.pop();
     }
+  }
+
+  private isReEnteringActiveWalk(
+    rootKey: string,
+    registry: Map<string, JestModule>,
+  ): boolean {
+    return this.activeSyncWalks.some(
+      walk => walk.registry === registry && walk.keys.has(rootKey),
+    );
   }
 
   private walkGraphSync(

--- a/packages/jest-runtime/src/internals/EsmLoader.ts
+++ b/packages/jest-runtime/src/internals/EsmLoader.ts
@@ -124,6 +124,18 @@ function makeRequireAsyncError(
   return error;
 }
 
+function makeRequireCycleError(
+  modulePath: string,
+  requiredFrom: string | undefined,
+): NodeJS.ErrnoException {
+  const fromPart = requiredFrom === undefined ? '' : ` (from ${requiredFrom})`;
+  const error: NodeJS.ErrnoException = new Error(
+    `Cannot require() ES Module ${modulePath} in a cycle.${fromPart} A cycle involving require(esm) is not allowed to maintain invariants mandated by the ECMAScript specification. Try making at least part of the dependency in the graph lazily loaded.`,
+  );
+  error.code = 'ERR_REQUIRE_CYCLE_MODULE';
+  return error;
+}
+
 // Decode a `data:` URI specifier into its mime type and decoded code/body.
 // `application/wasm` returns a Buffer; everything else returns a UTF-8 string.
 const dataURIRegex =
@@ -299,6 +311,10 @@ export class EsmLoader {
     moduleName: string,
   ) => unknown;
   private readonly testState: TestState;
+  // Every cacheKey popped by a sync walk that is still on the stack. Walks
+  // nest (a CJS body executing mid-walk can require() an unrelated ESM root),
+  // so this is a stack of one Set per walk rather than a single Set.
+  private readonly activeSyncWalks: Array<Set<string>> = [];
   // Used only by the legacy async path; deletable when min-Node ≥ v24.9
   // (delete the block at the bottom of this file too - eslint/tsc will
   // surface anything else that becomes unused).
@@ -328,8 +344,13 @@ export class EsmLoader {
   // are not consulted - driving a SyntheticModule from `unlinked` to
   // `evaluated` needs the async link()/evaluate() pair. Transitive-dep mocks
   // still apply via the graph walker.
-  requireEsmModule<T>(modulePath: string): T {
-    const module = this.tryLoadGraphSync(modulePath, '', 'sync-required');
+  requireEsmModule<T>(modulePath: string, requiredFrom?: string): T {
+    const module = this.tryLoadGraphSync(
+      modulePath,
+      '',
+      'sync-required',
+      requiredFrom,
+    );
     if (module === LOAD_ASYNC) {
       const error: NodeJS.ErrnoException = new Error(
         `Cannot require() ES Module ${modulePath} synchronously: it is currently being loaded by a concurrent \`import()\`. Await that import before calling require(), or import this module instead of requiring it.`,
@@ -350,6 +371,7 @@ export class EsmLoader {
     rootPath: string,
     rootQuery: string,
     mode: SyncEsmMode,
+    requiredFrom?: string,
   ): ESModule | LoadAsync {
     this.testState.throwIfTornDown(
       'You are trying to `import` a file after the Jest environment has been torn down.',
@@ -378,6 +400,19 @@ export class EsmLoader {
       return LOAD_ASYNC;
     }
 
+    // A require() re-entering a graph that is still being walked would build
+    // and evaluate a second copy of every uncommitted module (scratch entries
+    // reach the registry only after the root instantiates). Node throws
+    // ERR_REQUIRE_CYCLE_MODULE here; a dynamic import() of the same shape is
+    // a legal ESM cycle, so `'sync-preferred'` is exempt.
+    if (mode === 'sync-required') {
+      for (const walk of this.activeSyncWalks) {
+        if (walk.has(rootKey)) {
+          throw makeRequireCycleError(canonicalRootPath, requiredFrom);
+        }
+      }
+    }
+
     const context = this.getContext();
 
     if (this.transformCache.hasMutex(rootKey)) return LOAD_ASYNC;
@@ -387,8 +422,35 @@ export class EsmLoader {
       {cacheKey: rootKey, modulePath: canonicalRootPath},
     ];
 
+    const activeWalk = new Set<string>();
+    this.activeSyncWalks.push(activeWalk);
+    try {
+      return this.walkGraphSync(
+        rootKey,
+        activeWalk,
+        worklist,
+        scratch,
+        registry,
+        context,
+        mode,
+      );
+    } finally {
+      this.activeSyncWalks.pop();
+    }
+  }
+
+  private walkGraphSync(
+    rootKey: string,
+    activeWalk: Set<string>,
+    worklist: Array<WorklistEntry>,
+    scratch: Map<string, ScratchEntry>,
+    registry: Map<string, JestModule>,
+    context: VMContext,
+    mode: SyncEsmMode,
+  ): ESModule | LoadAsync {
     while (worklist.length > 0) {
       const {cacheKey, modulePath} = worklist.pop()!;
+      activeWalk.add(cacheKey);
       if (scratch.has(cacheKey)) continue;
 
       // Registry first, mutex second. `'unlinked'` / `'linking'` /

--- a/packages/jest-runtime/src/internals/__tests__/CjsLoader.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/CjsLoader.test.ts
@@ -24,7 +24,9 @@ type Stubs = {
   environment: JestEnvironment;
   coreModule: jest.Mocked<CoreModuleProvider>;
   executor: jest.Mocked<ModuleExecutor>;
-  requireEsm: jest.MockedFunction<<T>(modulePath: string) => T>;
+  requireEsm: jest.MockedFunction<
+    <T>(modulePath: string, requiredFrom: string) => T
+  >;
   testState: TestState;
   logFormattedReferenceError: jest.MockedFunction<(msg: string) => void>;
 };
@@ -191,7 +193,7 @@ describe('CjsLoader.requireModule', () => {
 
     stubs.requireEsm.mockReturnValue('esm-result' as any);
     expect(loader.requireModule('/from.js', './m.mjs')).toBe('esm-result');
-    expect(stubs.requireEsm).toHaveBeenCalledWith('/m.mjs');
+    expect(stubs.requireEsm).toHaveBeenCalledWith('/m.mjs', '/from.js');
   });
 });
 


### PR DESCRIPTION
## Summary

A CommonJS dependency in a sync ESM graph executes while the walker is still building the graph — before any scratch entry reaches the registry. A `require()` from that CJS body back into the in-progress graph found nothing cached, built a second copy of every uncommitted module, and evaluated the graph twice: the module body ran twice, and `require()`/`import()` handed out two different namespace objects for one file. Node refuses this shape with `ERR_REQUIRE_CYCLE_MODULE`; Jest silently split the module identity.

```js
// A.mjs
import './B.cjs';
export const marker = {};

// B.cjs
const A = require('./A.mjs'); // second full graph build, second evaluation
```

Now Jest throws the same error Node does, with the same message — including the `(from <requiring file>)` detail, for which the requiring path travels from `CjsLoader` through `requireEsmModule` into the walker:

```
Cannot require() ES Module <A.mjs> in a cycle. (from <B.cjs>) A cycle involving
require(esm) is not allowed to maintain invariants mandated by the ECMAScript
specification. Try making at least part of the dependency in the graph lazily loaded.
```

Detection is a stack of walk records on `EsmLoader`, each holding the keys the walk has popped and the registry it runs against. A `'sync-required'` load re-enters a walk — and throws — when its root key is in a still-active walk **for the same registry**. That fires at two points, covering both halves of a walk's lifetime:

- On a registry miss, before a new walk starts: the build-time re-entry above, where the module exists only as an uncommitted scratch entry.
- In the cached branch, when the registry holds the module as `'unlinked'`/`'linking'`/`'evaluating'`: re-entry after the walk committed its graph, while the module's own body is running. A self-`require()` from an evaluating ESM body previously fell through to `LOAD_ASYNC` and surfaced the concurrent-import `ERR_REQUIRE_ESM`; plain `node` throws the cycle error there, and now Jest does too. A module that finished evaluating is still served from the registry, never flagged.

Two boundaries keep the check honest:

- Walks nest legitimately — a CJS body built mid-walk can `require()` an unrelated ESM root, starting a fresh inner walk. Hence a stack rather than one Set.
- The registry identity matters: `jest.isolateModules` mid-walk supplies a fresh isolation overlay, and automock generation swaps in scratch registries. Requiring the same path there is a fresh build in a separate instance space, not a cycle — matching on key alone would throw a false `ERR_REQUIRE_CYCLE_MODULE`.

A dynamic `import()` of a cyclic shape is legal ESM, so `'sync-preferred'` walks are exempt; what that path does today is unchanged. The walk body moved from `tryLoadGraphSync` into a private `walkGraphSync` so the stack push/pop wraps it in one `try`/`finally` instead of reindenting the whole loop.

One deliberate divergence: Node allows a mid-walk CJS body to require an ESM sibling the walker has already scanned, because Node executes CJS during evaluation, when siblings are at least linked. In Jest that module exists only as an uninstantiated scratch entry, so permitting the require means the double-evaluation bug and refusing it with `LOAD_ASYNC` means a false "concurrent `import()`" error. Jest throws the cycle error there too. The case is narrow (dep-order dependent), and the message names the same workaround Node's documentation gives.

Also corrects a line in `.github/copilot-instructions.md`: `yarn typecheck:tests` resolves cross-package types from `build/*.d.ts`, so it needs the full `yarn build`, not just `build:js` — without it a fresh checkout reports phantom errors (missing custom matchers) that do not exist in CI.

## Test plan

Five tests in `runtime_esm_sync_graph.test.ts`, gated on `testWithSyncEsm`. The first two fail against `main`; the other three pin behavior the detection must not break, and each guard's failure mode was demonstrated too:

- `throws ERR_REQUIRE_CYCLE_MODULE when a CJS dep requires back into the graph` — asserts the code and the `(from …)` message. On `main`: `Received function did not throw`, i.e. the silent double build.
- `throws ERR_REQUIRE_CYCLE_MODULE for a self-require during evaluation` — an ESM body uses `createRequire(import.meta.url)` to require itself and exports the caught code. On `main` it observes the concurrent-import `ERR_REQUIRE_ESM` instead.
- `scopes cycle detection to the registry the walk runs against` — a CJS dep calls `jest.isolateModules(() => require(<the root being walked>))`; the isolated build must succeed with a distinct namespace. Matching walks on key alone (dropping the registry comparison) makes it die on a false cycle error.
- `allows a CJS dep to require an unrelated ESM root mid-walk` — the nested-walk case the per-walk stack exists for.
- `serves an already-evaluated module to a CJS dep mid-walk` — registry-first ordering.

The A/B fixture above, run from a scratch directory against the built CLI, throws `ERR_REQUIRE_CYCLE_MODULE` with the message matching what plain `node` v26.7.0 prints for the same files — as does the self-require fixture.

Full suites:

```
yarn jest packages/jest-runtime
  Test Suites: 2 skipped, 36 passed, 36 of 38 total
  Tests:       99 skipped, 330 passed, 429 total

yarn jest-runtime-vm-modules
  Test Suites: 38 passed, 38 total
  Tests:       4 skipped, 425 passed, 429 total
```

`yarn lint`, `yarn check-changelog`, and `yarn typecheck:tests` (after a full `yarn build`) all exit 0.