### PR TITLE
fix(jest-runtime): mirror Node's ESM/CJS interop and entry-point metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@
 - `[jest-runtime]` Throw the evaluation error when another caller's `import()` of the same module failed while we awaited it, instead of resolving with the errored module ([#16364](https://github.com/jestjs/jest/pull/16364))
 - `[jest-runtime]` Mark the result of `require()`ing an ES module that has a default export with `__esModule: true` through a live-binding facade, and serve the same object from `require.cache`, matching Node ([#16367](https://github.com/jestjs/jest/pull/16367))
 - `[jest-runtime]` Provide a CommonJS module's exports under the `'module.exports'` named export when imported from ESM, matching Node 23+ ([#16367](https://github.com/jestjs/jest/pull/16367))
+- `[jest-runtime]` Give the test file itself a non-null `require.main` ([#16367](https://github.com/jestjs/jest/pull/16367))
 - `[jest-runtime]` Throw `ERR_REQUIRE_CYCLE_MODULE` like Node when a CommonJS module `require()`s an ES module that is still being loaded, instead of evaluating the module a second time ([#16366](https://github.com/jestjs/jest/pull/16366))
 - `[jest-runtime]` Key builtin modules in the ESM registry by one canonical specifier ([#16341](https://github.com/jestjs/jest/pull/16341))
 - `[jest-runtime]` `import.meta.resolve()` for a builtin uses its `node:` specifier ([#16341](https://github.com/jestjs/jest/pull/16341))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@
 - `[jest-runtime]` Check a cached ES module's status before `require()` returns it, so a module whose evaluation threw rethrows that error and one left linked by a failed sibling is evaluated instead of returning uninitialized bindings ([#16364](https://github.com/jestjs/jest/pull/16364))
 - `[jest-runtime]` Report the original `ERR_REQUIRE_ASYNC_MODULE` when a `require()` of a top-level-await graph is retried, instead of a spurious "concurrent `import()`" error ([#16364](https://github.com/jestjs/jest/pull/16364))
 - `[jest-runtime]` Throw the evaluation error when another caller's `import()` of the same module failed while we awaited it, instead of resolving with the errored module ([#16364](https://github.com/jestjs/jest/pull/16364))
+- `[jest-runtime]` Mark the result of `require()`ing an ES module that has a default export with `__esModule: true` through a live-binding facade, and serve the same object from `require.cache`, matching Node ([#16367](https://github.com/jestjs/jest/pull/16367))
 - `[jest-runtime]` Throw `ERR_REQUIRE_CYCLE_MODULE` like Node when a CommonJS module `require()`s an ES module that is still being loaded, instead of evaluating the module a second time ([#16366](https://github.com/jestjs/jest/pull/16366))
 - `[jest-runtime]` Key builtin modules in the ESM registry by one canonical specifier ([#16341](https://github.com/jestjs/jest/pull/16341))
 - `[jest-runtime]` `import.meta.resolve()` for a builtin uses its `node:` specifier ([#16341](https://github.com/jestjs/jest/pull/16341))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
 - `[jest-runtime]` Report the original `ERR_REQUIRE_ASYNC_MODULE` when a `require()` of a top-level-await graph is retried, instead of a spurious "concurrent `import()`" error ([#16364](https://github.com/jestjs/jest/pull/16364))
 - `[jest-runtime]` Throw the evaluation error when another caller's `import()` of the same module failed while we awaited it, instead of resolving with the errored module ([#16364](https://github.com/jestjs/jest/pull/16364))
 - `[jest-runtime]` Mark the result of `require()`ing an ES module that has a default export with `__esModule: true` through a live-binding facade, and serve the same object from `require.cache`, matching Node ([#16367](https://github.com/jestjs/jest/pull/16367))
+- `[jest-runtime]` Provide a CommonJS module's exports under the `'module.exports'` named export when imported from ESM, matching Node 23+ ([#16367](https://github.com/jestjs/jest/pull/16367))
 - `[jest-runtime]` Throw `ERR_REQUIRE_CYCLE_MODULE` like Node when a CommonJS module `require()`s an ES module that is still being loaded, instead of evaluating the module a second time ([#16366](https://github.com/jestjs/jest/pull/16366))
 - `[jest-runtime]` Key builtin modules in the ESM registry by one canonical specifier ([#16341](https://github.com/jestjs/jest/pull/16341))
 - `[jest-runtime]` `import.meta.resolve()` for a builtin uses its `node:` specifier ([#16341](https://github.com/jestjs/jest/pull/16341))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - `[jest-haste-map]` Replace `NodeWatcher` and `FSEventsWatcher` with `@parcel/watcher` for the non-watchman watch path ([#16188](https://github.com/jestjs/jest/pull/16188))
 - `[jest-resolve]` Bump `unrs-resolver` to 1.12.1, remove `jest-pnp-resolver` and unnecessary checks ([#15721](https://github.com/jestjs/jest/pull/15721))
 - `[jest-resolve]` Honor Node's `--preserve-symlinks` / `NODE_PRESERVE_SYMLINKS` in the default resolver by passing `symlinks: false` to `unrs-resolver` ([#16260](https://github.com/jestjs/jest/pull/16260))
+- `[jest-runtime]` Set `import.meta.main` to `true` in the test file and `false` in every module it loads, matching Node 24+ ([#16367](https://github.com/jestjs/jest/pull/16367))
 - `[jest-runtime]` Resolve the `module-sync` export condition, so a package that exposes its ESM entry point for `require()` loads the same file Node would ([#16336](https://github.com/jestjs/jest/pull/16336))
 
 ### Fixes

--- a/e2e/__tests__/requireMain.test.ts
+++ b/e2e/__tests__/requireMain.test.ts
@@ -11,4 +11,5 @@ test('provides `require.main` set to test suite module', () => {
   const {stderr, stdout} = runJest('require-main');
   expect(stdout).not.toMatch('No tests found');
   expect(stderr).toMatch(/PASS __tests__(\/|\\+)loader\.test\.js/);
+  expect(stderr).toMatch(/PASS __tests__(\/|\\+)entry-main\.test\.js/);
 });

--- a/e2e/native-esm/__tests__/native-esm.test.js
+++ b/e2e/native-esm/__tests__/native-esm.test.js
@@ -31,6 +31,7 @@ test('should have correct import.meta', () => {
     dirname: expect.any(String),
     filename: expect.any(String),
     jest: expect.anything(),
+    main: true,
     resolve: expect.any(Function),
     url: expect.any(String),
   });

--- a/e2e/require-main/__tests__/entry-main.test.js
+++ b/e2e/require-main/__tests__/entry-main.test.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+const mainAtTopLevel = require.main;
+
+test('require.main at the test file top level is the test file', () => {
+  expect(mainAtTopLevel).not.toBeNull();
+  expect(mainAtTopLevel.filename).toBe(__filename);
+});

--- a/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
@@ -153,6 +153,26 @@ describe('Runtime sync ESM graph', () => {
     );
   });
 
+  testWithVmEsm('sets import.meta.main only for the test file', async () => {
+    const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+    const imported = (await runtime.unstable_importModule(
+      FROM,
+      './import-meta-main.mjs',
+    )) as any;
+    expect(imported.namespace.ownMain).toBe(false);
+    expect(imported.namespace.depMain).toBe(false);
+
+    const entryRuntime = await createRuntime(
+      path.join(ROOT_DIR, 'meta-main.mjs'),
+      {rootDir: ROOT_DIR},
+    );
+    const entry = (await entryRuntime.unstable_importModule(
+      FROM,
+      './meta-main.mjs',
+    )) as any;
+    expect(entry.namespace.mainValue).toBe(true);
+  });
+
   testWithVmEsm('pulls a CJS dependency into the sync ESM graph', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(

--- a/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
@@ -162,6 +162,19 @@ describe('Runtime sync ESM graph', () => {
     expect(m.namespace.cjsValue).toBe('from-cjs');
   });
 
+  testWithVmEsm(
+    "exposes a CJS dependency's exports as the 'module.exports' named export",
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const m = (await runtime.unstable_importModule(
+        FROM,
+        './import-cjs-namespace.mjs',
+      )) as any;
+      expect(m.namespace.moduleExportsValue).toEqual({cjsValue: 'from-cjs'});
+      expect(m.namespace.sameAsDefault).toBe(true);
+    },
+  );
+
   testWithVmEsm('imports a wasm module via data: URI', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(
@@ -401,15 +414,12 @@ describe('Runtime sync ESM graph - require(esm)', () => {
     },
   );
 
-  testWithSyncEsm(
-    "keeps a module's own __esModule export as-is",
-    async () => {
-      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
-      const result = runtime.requireModule(FROM, './own-esmodule.mjs');
-      expect(result.__esModule).toBe(false);
-      expect(result.default).toBe('overridden');
-    },
-  );
+  testWithSyncEsm("keeps a module's own __esModule export as-is", async () => {
+    const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+    const result = runtime.requireModule(FROM, './own-esmodule.mjs');
+    expect(result.__esModule).toBe(false);
+    expect(result.default).toBe('overridden');
+  });
 
   testWithSyncEsm('keeps live bindings through the facade', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
@@ -420,14 +430,11 @@ describe('Runtime sync ESM graph - require(esm)', () => {
     expect(result.counter).toBe(1);
   });
 
-  testWithSyncEsm(
-    'exposes the require() result on require.cache',
-    async () => {
-      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
-      const probe = runtime.requireModule(FROM, './reads-cache-for-esm.cjs');
-      expect(probe.cacheMatchesRequire).toBe(true);
-    },
-  );
+  testWithSyncEsm('exposes the require() result on require.cache', async () => {
+    const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+    const probe = runtime.requireModule(FROM, './reads-cache-for-esm.cjs');
+    expect(probe.cacheMatchesRequire).toBe(true);
+  });
 
   testWithSyncEsm(
     'throws ERR_REQUIRE_CYCLE_MODULE when a CJS dep requires back into the graph',

--- a/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
@@ -373,6 +373,63 @@ describe('Runtime sync ESM graph - require(esm)', () => {
   );
 
   testWithSyncEsm(
+    'marks a required module that has a default export with __esModule',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const result = runtime.requireModule(FROM, './with-default.mjs');
+      expect(
+        Object.getOwnPropertyDescriptor(result, '__esModule'),
+      ).toStrictEqual({
+        configurable: false,
+        enumerable: true,
+        value: true,
+        writable: true,
+      });
+      expect(result.default).toBe('D');
+      expect(result.x).toBe(1);
+      expect(runtime.requireModule(FROM, './with-default.mjs')).toBe(result);
+    },
+  );
+
+  testWithSyncEsm(
+    'adds no __esModule marker without a default export',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const result = runtime.requireModule(FROM, './a.mjs');
+      expect('__esModule' in result).toBe(false);
+      expect(result.valueA).toBe('a');
+    },
+  );
+
+  testWithSyncEsm(
+    "keeps a module's own __esModule export as-is",
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const result = runtime.requireModule(FROM, './own-esmodule.mjs');
+      expect(result.__esModule).toBe(false);
+      expect(result.default).toBe('overridden');
+    },
+  );
+
+  testWithSyncEsm('keeps live bindings through the facade', async () => {
+    const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+    const result = runtime.requireModule(FROM, './live-bindings.mjs');
+    expect(result.__esModule).toBe(true);
+    expect(result.counter).toBe(0);
+    result.bump();
+    expect(result.counter).toBe(1);
+  });
+
+  testWithSyncEsm(
+    'exposes the require() result on require.cache',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const probe = runtime.requireModule(FROM, './reads-cache-for-esm.cjs');
+      expect(probe.cacheMatchesRequire).toBe(true);
+    },
+  );
+
+  testWithSyncEsm(
     'throws ERR_REQUIRE_CYCLE_MODULE when a CJS dep requires back into the graph',
     async () => {
       const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});

--- a/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
+++ b/packages/jest-runtime/src/__tests__/runtime_require_module.test.js
@@ -155,6 +155,17 @@ describe('Runtime requireModule', () => {
     }
   });
 
+  it('reflects a main module assigned after `require` was built', async () => {
+    const runtime = await createRuntime(__filename);
+    const lazy = runtime.requireModule(
+      __filename,
+      './test_root/modules_with_main/lazy_main.js',
+    );
+    expect(lazy.getMain()).toBeNull();
+    runtime.testMainModule.current = module;
+    expect(lazy.getMain()).toBe(module);
+  });
+
   it('throws on non-existent haste modules', async () => {
     const runtime = await createRuntime(__filename);
     expect(() => {

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/import-cjs-namespace.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/import-cjs-namespace.mjs
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as namespace from './cjs-dep.cjs';
+export const moduleExportsValue = namespace['module.exports'];
+export const sameAsDefault = namespace['module.exports'] === namespace.default;

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/import-meta-main.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/import-meta-main.mjs
@@ -1,0 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {mainValue} from './meta-main.mjs';
+export const depMain = mainValue;
+export const ownMain = import.meta.main;

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/live-bindings.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/live-bindings.mjs
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export let counter = 0;
+export function bump() {
+  counter += 1;
+}
+export default 'live';

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/meta-main.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/meta-main.mjs
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const mainValue = import.meta.main;

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/own-esmodule.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/own-esmodule.mjs
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const __esModule = false;
+export default 'overridden';

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/reads-cache-for-esm.cjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/reads-cache-for-esm.cjs
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+const path = require('path');
+const withDefault = require('./with-default.mjs');
+exports.cacheMatchesRequire =
+  require.cache[path.join(__dirname, 'with-default.mjs')].exports ===
+  withDefault;

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/with-default.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/with-default.mjs
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export default 'D';
+export const x = 1;

--- a/packages/jest-runtime/src/__tests__/test_root/modules_with_main/lazy_main.js
+++ b/packages/jest-runtime/src/__tests__/test_root/modules_with_main/lazy_main.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+'use strict';
+
+module.exports.getMain = () => require.main;

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -223,6 +223,7 @@ export default class Runtime {
         this.requireModuleOrMock(from, moduleName),
       resolution: this._resolution,
       shouldLoadAsEsm: modulePath => this.unstable_shouldLoadAsEsm(modulePath),
+      testPath: this._testPath,
       testState: this.testState,
       transformCache: this.transformCache,
     });

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -133,7 +133,9 @@ export default class Runtime {
     this._config = config;
     this._coverageOptions = coverageOptions;
     this._environment = environment;
-    this.registries = new ModuleRegistries();
+    this.registries = new ModuleRegistries(module =>
+      this.esmLoader.requireResultFromModule(module),
+    );
     invariant(
       this._environment.moduleMocker,
       '`moduleMocker` must be set on an environment when created',

--- a/packages/jest-runtime/src/internals/EsmLoader.ts
+++ b/packages/jest-runtime/src/internals/EsmLoader.ts
@@ -382,7 +382,12 @@ export class EsmLoader {
     if ('module.exports' in namespace) {
       return namespace['module.exports'];
     }
+    // The facade needs `linkRequests`/`instantiate` and a synchronously
+    // settling evaluate - the capabilities `require(esm)` itself is gated on.
+    // Below that gate this is reached only through `require.cache` reads,
+    // which keep handing out the raw namespace.
     if (
+      !supportsSyncEvaluate ||
       module.status !== 'evaluated' ||
       !('default' in namespace) ||
       '__esModule' in namespace

--- a/packages/jest-runtime/src/internals/EsmLoader.ts
+++ b/packages/jest-runtime/src/internals/EsmLoader.ts
@@ -311,6 +311,7 @@ export class EsmLoader {
     moduleName: string,
   ) => unknown;
   private readonly testState: TestState;
+  private readonly requireFacades = new WeakMap<ESModule, ESModule>();
   // Every cacheKey popped by a sync walk that is still on the stack. Walks
   // nest (a CJS body executing mid-walk can require() an unrelated ESM root),
   // so this is a stack of one entry per walk rather than a single Set. Each
@@ -364,10 +365,58 @@ export class EsmLoader {
       error.code = 'ERR_REQUIRE_ESM';
       throw error;
     }
+    return this.requireResultFromModule(module) as T;
+  }
+
+  // Mirrors Node's `populateCJSExportsFromESM`: a `'module.exports'` named
+  // export wins outright; a module without a `default` export - or one that
+  // defines its own `__esModule`, which users may set to override tooling
+  // detection - hands back the raw namespace. Everything else gets a facade
+  // namespace carrying `__esModule: true`, so transpiled consumers that pick
+  // `mod.__esModule ? mod.default : mod` see require()d real ESM as ESM.
+  requireResultFromModule(module: ESModule): unknown {
     const namespace = module.namespace as Record<string, unknown>;
-    return (
-      'module.exports' in namespace ? namespace['module.exports'] : namespace
-    ) as T;
+    if ('module.exports' in namespace) {
+      return namespace['module.exports'];
+    }
+    if (
+      module.status !== 'evaluated' ||
+      !('default' in namespace) ||
+      '__esModule' in namespace
+    ) {
+      return namespace;
+    }
+    return this.requireFacadeFor(module).namespace;
+  }
+
+  // Node builds the facade as a real source-text module rather than a copy or
+  // a Proxy - re-exporting keeps the original's bindings live and enumerable
+  // with no per-access overhead. The original is already evaluated and the
+  // facade body has no top-level await, so evaluation completes synchronously.
+  private requireFacadeFor(module: ESModule): ESModule {
+    const cached = this.requireFacades.get(module);
+    if (cached) return cached;
+    const facade: VMModuleWithAsyncGraph = new SourceTextModule(
+      "export * from 'original';\nexport {default} from 'original';\nexport const __esModule = true;",
+      {
+        context: this.getContext(),
+        identifier: `jest-require-facade:${module.identifier}`,
+      },
+    );
+    invariant(
+      typeof facade.linkRequests === 'function' &&
+        typeof facade.instantiate === 'function',
+      'linkRequests/instantiate unavailable on the require facade',
+    );
+    facade.linkRequests([module]);
+    facade.instantiate();
+    facade.evaluate().catch(noop);
+    invariant(
+      facade.status === 'evaluated',
+      `Expected the require facade for ${module.identifier} to evaluate synchronously, but its status is "${facade.status}". This is a bug in Jest, please report it!`,
+    );
+    this.requireFacades.set(module, facade);
+    return facade;
   }
 
   // Public for unit-test access. Production callers reach the sync graph

--- a/packages/jest-runtime/src/internals/EsmLoader.ts
+++ b/packages/jest-runtime/src/internals/EsmLoader.ts
@@ -293,6 +293,7 @@ export interface EsmLoaderOptions {
   shouldLoadAsEsm: (modulePath: string) => boolean;
   requireModuleOrMock: (from: string, moduleName: string) => unknown;
   testState: TestState;
+  testPath: string;
 }
 
 export class EsmLoader {
@@ -311,6 +312,7 @@ export class EsmLoader {
     moduleName: string,
   ) => unknown;
   private readonly testState: TestState;
+  private readonly testPath: string;
   private readonly requireFacades = new WeakMap<ESModule, ESModule>();
   // Every cacheKey popped by a sync walk that is still on the stack. Walks
   // nest (a CJS body executing mid-walk can require() an unrelated ESM root),
@@ -341,6 +343,7 @@ export class EsmLoader {
     this.shouldLoadAsEsm = options.shouldLoadAsEsm;
     this.requireModuleOrMock = options.requireModuleOrMock;
     this.testState = options.testState;
+    this.testPath = options.testPath;
   }
 
   // `'load-async'` means the sync graph could not be completed — a concurrent
@@ -644,6 +647,8 @@ export class EsmLoader {
               const parentPath = fileURLToPath(parent);
               return this.resolveForImportMeta(parentPath, specifier);
             };
+            // @ts-expect-error Jest uses @types/node@18.
+            meta.main = modulePath === this.testPath;
             (meta as JestImportMeta).jest =
               this.jestGlobals.jestObjectFor(modulePath);
           },
@@ -1080,6 +1085,8 @@ export class EsmLoader {
       importModuleDynamically: esmDynamicImport,
       initializeImportMeta(meta) {
         meta.url = specifier;
+        // @ts-expect-error Jest uses @types/node@18.
+        meta.main = false;
         if (meta.url.startsWith('file://')) {
           // @ts-expect-error Jest uses @types/node@18.
           meta.filename = fileURLToPath(meta.url);
@@ -1274,6 +1281,8 @@ export class EsmLoader {
                 const parentPath = fileURLToPath(parent);
                 return this.resolveForImportMeta(parentPath, specifier);
               };
+              // @ts-expect-error Jest uses @types/node@18.
+              meta.main = modulePath === this.testPath;
               (meta as JestImportMeta).jest =
                 this.jestGlobals.jestObjectFor(modulePath);
             },
@@ -1360,6 +1369,8 @@ export class EsmLoader {
           importModuleDynamically: this.dynamicImport,
           initializeImportMeta(meta) {
             meta.url = specifier;
+            // @ts-expect-error Jest uses @types/node@18.
+            meta.main = false;
             if (meta.url.startsWith('file://')) {
               // @ts-expect-error Jest uses @types/node@18.
               meta.filename = fileURLToPath(meta.url);

--- a/packages/jest-runtime/src/internals/ModuleRegistries.ts
+++ b/packages/jest-runtime/src/internals/ModuleRegistries.ts
@@ -38,6 +38,8 @@ class Isolation {
 }
 
 export class ModuleRegistries {
+  private readonly requireEsmResult: (module: VMModule) => unknown;
+
   private moduleRegistry: ModuleRegistry = new Map();
   private readonly internalModuleRegistry: ModuleRegistry = new Map();
   private esModuleRegistry = new Map<string, JestModule>();
@@ -50,6 +52,10 @@ export class ModuleRegistries {
     VMModule,
     NodeModule
   >();
+
+  constructor(requireEsmResult: (module: VMModule) => unknown) {
+    this.requireEsmResult = requireEsmResult;
+  }
 
   getCjs(modulePath: string): InitialModule | Module | JestModule | undefined {
     return (this.isolation?.cjs ?? this.moduleRegistry).get(modulePath);
@@ -208,7 +214,7 @@ export class ModuleRegistries {
     const dir = path.dirname(filename);
     const wrapper = {
       children: [],
-      exports: esm.namespace,
+      exports: this.requireEsmResult(esm),
       filename,
       id: filename,
       isPreloading: false,

--- a/packages/jest-runtime/src/internals/__tests__/EsmLoader.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/EsmLoader.test.ts
@@ -103,6 +103,7 @@ function makeLoader(overrides: Partial<Stubs> = {}) {
     requireModuleOrMock: stubs.requireModuleOrMock,
     resolution: stubs.resolution,
     shouldLoadAsEsm: stubs.shouldLoadAsEsm,
+    testPath: '/test.js',
     testState: stubs.testState,
     transformCache: stubs.transformCache,
   });

--- a/packages/jest-runtime/src/internals/__tests__/EsmLoader.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/EsmLoader.test.ts
@@ -884,7 +884,9 @@ describe('validateImportAttributes', () => {
       const {stubs} = makeLoader();
       jest.isolateModules(() => {
         jest.doMock('../nodeCapabilities', () => ({
-          ...jest.requireActual('../nodeCapabilities'),
+          ...jest.requireActual<typeof import('../nodeCapabilities')>(
+            '../nodeCapabilities',
+          ),
           supportsSyncEvaluate: false,
         }));
         const {EsmLoader: GatedEsmLoader} = require('../EsmLoader');

--- a/packages/jest-runtime/src/internals/__tests__/EsmLoader.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/EsmLoader.test.ts
@@ -878,4 +878,39 @@ describe('validateImportAttributes', () => {
       expect(error?.code).toBe('ERR_IMPORT_ATTRIBUTE_UNSUPPORTED');
     });
   });
+
+  describe('requireResultFromModule', () => {
+    test('hands out the raw namespace when sync evaluation is unavailable', () => {
+      const {stubs} = makeLoader();
+      jest.isolateModules(() => {
+        jest.doMock('../nodeCapabilities', () => ({
+          ...jest.requireActual('../nodeCapabilities'),
+          supportsSyncEvaluate: false,
+        }));
+        const {EsmLoader: GatedEsmLoader} = require('../EsmLoader');
+        const loader = new GatedEsmLoader({
+          cjsExportsCache: stubs.cjsExportsCache,
+          coreModule: stubs.coreModule,
+          environment: stubs.environment,
+          fileCache: stubs.fileCache,
+          jestGlobals: stubs.jestGlobals,
+          mockState: stubs.mockState,
+          registries: stubs.registries,
+          requireModuleOrMock: stubs.requireModuleOrMock,
+          resolution: stubs.resolution,
+          shouldLoadAsEsm: stubs.shouldLoadAsEsm,
+          testPath: '/test.js',
+          testState: stubs.testState,
+          transformCache: stubs.transformCache,
+        });
+        const namespace = {default: 'D', x: 1};
+        const module = {
+          identifier: '/m.mjs',
+          namespace,
+          status: 'evaluated',
+        };
+        expect(loader.requireResultFromModule(module)).toBe(namespace);
+      });
+    });
+  });
 });

--- a/packages/jest-runtime/src/internals/__tests__/ModuleRegistries.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/ModuleRegistries.test.ts
@@ -29,7 +29,7 @@ const fakeEsm = (status: VMModule['status'] = 'evaluated'): VMModule =>
 describe('ModuleRegistries', () => {
   describe('CJS routing through isolation', () => {
     test('reads/writes go to the main map outside isolation', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       const cjsModule = fakeCjs('/a.js');
       registries.setCjs('/a.js', cjsModule);
       expect(registries.hasCjs('/a.js')).toBe(true);
@@ -37,7 +37,7 @@ describe('ModuleRegistries', () => {
     });
 
     test('reads/writes go to the isolated overlay during isolation', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       const main = fakeCjs('/a.js');
       registries.setCjs('/a.js', main);
 
@@ -53,7 +53,7 @@ describe('ModuleRegistries', () => {
     });
 
     test('internal CJS bypasses isolation', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       const cjsModule = fakeCjs('/a.js');
       registries.setInternalCjs('/a.js', cjsModule);
 
@@ -65,7 +65,7 @@ describe('ModuleRegistries', () => {
 
   describe('isolation lifecycle', () => {
     test('throws on nested entry with caller-specific message', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       registries.enterIsolated('isolateModules');
       expect(() => registries.enterIsolated('isolateModulesAsync')).toThrow(
         'isolateModulesAsync cannot be nested inside another isolateModulesAsync or isolateModules.',
@@ -73,7 +73,7 @@ describe('ModuleRegistries', () => {
     });
 
     test('exitIsolated empties the overlay maps before dropping the reference', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       registries.enterIsolated('isolateModules');
       registries.setCjs('/a.js', fakeCjs('/a.js'));
       registries.setEsm('/b.mjs', fakeEsm() as JestModule);
@@ -102,7 +102,7 @@ describe('ModuleRegistries', () => {
 
   describe('module mocks through isolation', () => {
     test('inherits module mocks created outside the isolation block', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       const outer = fakeEsm();
       registries.setModuleMock('id', outer);
 
@@ -113,7 +113,7 @@ describe('ModuleRegistries', () => {
     });
 
     test('drops module mocks created inside the isolation block on exit', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
 
       registries.enterIsolated('isolateModulesAsync');
       registries.setModuleMock('id', fakeEsm());
@@ -125,7 +125,7 @@ describe('ModuleRegistries', () => {
     });
 
     test('an inner module mock shadows the outer one without replacing it', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       const outer = fakeEsm();
       const inner = fakeEsm();
       registries.setModuleMock('id', outer);
@@ -141,7 +141,7 @@ describe('ModuleRegistries', () => {
 
   describe('withScratchRegistries', () => {
     test('suspends the isolation overlay so the scratch load cannot leak', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       registries.enterIsolated('isolateModules');
       registries.setCjs('/isolated.js', fakeCjs('/isolated.js'));
 
@@ -158,7 +158,7 @@ describe('ModuleRegistries', () => {
     });
 
     test('runs fn against fresh CJS + mock maps and restores originals', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       const orig = fakeCjs('/a.js');
       registries.setCjs('/a.js', orig);
       registries.setMock('id', 'orig-mock');
@@ -179,7 +179,7 @@ describe('ModuleRegistries', () => {
     });
 
     test('keeps ESM and module-mock writes out of the long-lived registries', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       registries.enterIsolated('isolateModules');
 
       registries.withScratchRegistries(() => {
@@ -194,7 +194,7 @@ describe('ModuleRegistries', () => {
     });
 
     test('restores originals even when fn throws', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       const orig = fakeCjs('/a.js');
       registries.setCjs('/a.js', orig);
 
@@ -209,7 +209,7 @@ describe('ModuleRegistries', () => {
 
   describe('require.cache Proxy', () => {
     test('exposes CJS modules and live ESM entries; hides Promise / unlinked', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       const cjs = fakeCjs('/cjs.js');
       registries.setCjs('/cjs.js', cjs);
 
@@ -246,7 +246,7 @@ describe('ModuleRegistries', () => {
     });
 
     test('mutators silently no-op rather than throw', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       const cache = registries.createRequireCacheProxy();
       // @ts-expect-error: write-through is intentionally not supported
       cache['/x.js'] = fakeCjs('/x.js');
@@ -255,7 +255,7 @@ describe('ModuleRegistries', () => {
     });
 
     test('wrapEsmForRequireCache caches the wrapper per VMModule', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       const esm = fakeEsm('evaluated');
       const wrapper = registries.wrapEsmForRequireCache('/x.mjs', esm);
       const wrapperAgain = registries.wrapEsmForRequireCache('/x.mjs', esm);
@@ -265,7 +265,7 @@ describe('ModuleRegistries', () => {
 
   describe('clear semantics', () => {
     test('clearForReset drops everything except internal CJS', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       registries.setCjs('/a.js', fakeCjs('/a.js'));
       registries.setEsm('/b.mjs', fakeEsm() as JestModule);
       registries.setMock('id', 'mock');
@@ -281,7 +281,7 @@ describe('ModuleRegistries', () => {
     });
 
     test('clear drops everything including internal CJS', () => {
-      const registries = new ModuleRegistries();
+      const registries = new ModuleRegistries(module => module.namespace);
       registries.setInternalCjs('/i.js', fakeCjs('/i.js'));
       registries.clear();
       expect(registries.hasInternalCjs('/i.js')).toBe(false);

--- a/packages/jest-runtime/src/internals/__tests__/cjsRequire.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/cjsRequire.test.ts
@@ -116,7 +116,7 @@ describe('RequireBuilder', () => {
       expect(requireDispatch).not.toHaveBeenCalled();
     });
 
-    test('snapshots `main` at build time, not per call', () => {
+    test('reads `main` live, not as a build-time snapshot', () => {
       const testMainModule = new TestMainModule();
       const builder = makeBuilder({testMainModule});
 
@@ -124,10 +124,7 @@ describe('RequireBuilder', () => {
       expect(requireFn.main).toBeNull();
 
       testMainModule.current = {filename: '/test.js'} as Module;
-      expect(requireFn.main).toBeNull();
-
-      const laterRequire = builder.for(sampleFrom, undefined);
-      expect(laterRequire.main).toBe(testMainModule.current);
+      expect(requireFn.main).toBe(testMainModule.current);
     });
   });
 

--- a/packages/jest-runtime/src/internals/cjsRequire.ts
+++ b/packages/jest-runtime/src/internals/cjsRequire.ts
@@ -86,9 +86,12 @@ export class RequireBuilder {
     moduleRequire.resolve = resolveImpl;
     moduleRequire.cache = this.registries.createRequireCacheProxy();
 
+    // A getter, not a snapshot: the test file's own require object is built
+    // before the executor assigns the main module, so a captured value would
+    // leave the entry point's require.main null.
     Object.defineProperty(moduleRequire, 'main', {
       enumerable: true,
-      value: this.testMainModule.current,
+      get: () => this.testMainModule.current,
     });
 
     return moduleRequire;

--- a/packages/jest-runtime/src/internals/syntheticBuilders.ts
+++ b/packages/jest-runtime/src/internals/syntheticBuilders.ts
@@ -123,15 +123,20 @@ export function buildCjsAsEsmSyntheticModule(
   ]);
 
   const cjsExports = [...allCandidates].filter(exportName => {
-    // `default` is handled separately below as the whole module.exports.
-    if (exportName === 'default' || cjsRecord == null) {
+    // `default` and `module.exports` are handled separately below as the
+    // whole module.exports.
+    if (
+      exportName === 'default' ||
+      exportName === 'module.exports' ||
+      cjsRecord == null
+    ) {
       return false;
     }
     return Object.hasOwn(cjsRecord, exportName);
   });
 
   return new SyntheticModule(
-    [...cjsExports, 'default'],
+    [...cjsExports, 'default', 'module.exports'],
     function () {
       if (cjsRecord != null) {
         for (const exportName of cjsExports) {
@@ -141,6 +146,7 @@ export function buildCjsAsEsmSyntheticModule(
       // module.exports is the ESM default, matching Node's CJS-from-ESM behavior.
       // __esModule is not honored — see Node docs on named exports from CJS.
       this.setExport('default', cjs);
+      this.setExport('module.exports', cjs);
     },
     {context, identifier: modulePath},
   );


### PR DESCRIPTION
## Summary

Four places where the module system's interop metadata diverged from Node, one commit per fix, each verified against plain `node` v26.7.0 output before implementing. Together they make both interop directions — `require(esm)` and `import`-of-CJS — byte-compatible with Node's markers.

**`require(esm)` results carry `__esModule: true`.** Node hands the result through the decision tree in `populateCJSExportsFromESM`: a `'module.exports'` named export wins outright; a module without a `default` export — or one defining its own `__esModule`, which users may set to override tooling detection — returns the raw namespace; everything else returns the namespace of a facade module. Jest only implemented the first branch, so transpiled consumers (`mod.__esModule ? mod.default : mod`) received the whole namespace instead of the default export. `requireResultFromModule` now mirrors the whole tree. The facade is built the way Node builds it — a real source-text module (`export * from` / `export {default} from` / `export const __esModule = true`) linked against the original — so re-exported bindings stay live and enumerable with no per-access overhead. Probed descriptor matches Node exactly: `{value: true, writable: true, enumerable: true, configurable: false}`, sealed namespace, `Symbol.toStringTag: 'Module'`. Facades are cached per module instance, so repeat `require()` returns the identical object, and isolation registries get their own. The `require.cache` proxy serves the same value through the shared helper — in Node, the cache entry's `exports` *is* the `require()` result.

**Imported-CJS namespaces expose `'module.exports'`.** Node's CJS→ESM translation provides the default export under a `'module.exports'` named export as well (v23.0.0, https://github.com/nodejs/node/pull/53848), unambiguously marking which value the CommonJS representation uses. Added unconditionally in `buildCjsAsEsmSyntheticModule` — a synthetic wrapper behaving the same on every supported Node beats mirroring each host's vintage. A runtime `module.exports` property on the exports object itself is filtered from the named-export scan so it cannot collide.

**The test file's own `require.main` is no longer `null`.** The require object snapshotted `testMainModule.current` at build time, and the executor builds it before assigning the main module — an ordering that only bites the entry point: every module the test file loads saw `require.main` correctly, while the test file itself got `null`. `main` is now a getter over the live value. `module.main` was already assigned after the main module and is unchanged.

**`import.meta.main` is set.** Node 24+ gives every module a `main` boolean that is true only for the entry point. Jest's entry point is the test file: `testPath` travels into `EsmLoaderOptions`, both file-module `initializeImportMeta` blocks set `main = modulePath === testPath`, and both data:-URI blocks set `false`.

## Test plan

Every behavior change has a demonstrated baseline failure against `main`, and every deliberately-unchanged branch has a test that passes on both sides:

- `marks a required module that has a default export with __esModule` — asserts the exact Node descriptor and repeat-require identity. Fails on `main` (no marker).
- `keeps live bindings through the facade` — an exported `let` mutated through an exported function, observed through the facade. Fails on `main`.
- `adds no __esModule marker without a default export` and `keeps a module's own __esModule export as-is` — the raw-namespace branches; green on `main` too, pinning them through the change.
- `exposes the require() result on require.cache` — identity between `require()` and the cache entry. Green on `main` as well (raw namespace on both sides there); pins that the facade lands on both sides together.
- `exposes a CJS dependency's exports as the 'module.exports' named export` — fails on `main`.
- `reflects a main module assigned after require was built` (unit, `Received: null` on `main`) and the new `e2e/require-main/__tests__/entry-main.test.js`, where the test file reads its own `require.main` at top level — the e2e suite fails on `main`.
- `sets import.meta.main only for the test file` — imported module and its dep read `false`, a runtime whose test path is the fixture reads `true`. `Received: undefined` on `main`. The `native-esm` e2e suite's exact `import.meta` shape assertion now includes `main: true`, covering the real entry file end to end.

Suites:

```
yarn jest packages/jest-runtime
  Tests: 107 skipped, 331 passed, 438 total
yarn jest-runtime-vm-modules
  Tests: 4 skipped, 434 passed, 438 total
```

E2E: `nativeEsm`, `nativeEsmCjsRequire`, `nativeEsmRequireModule`, `nativeEsmSyncLinker`, `nativeEsmJsEsmSyntaxFallback`, `isolateModulesCjsEsm`, `requireMain` — all green. `yarn lint`, `yarn typecheck:tests` (after full `yarn build`), `yarn check-changelog`, and `yarn check-copyright-headers` all exit 0.

The facade only exists on the sync path (`require(esm)`, Node 24.9+) because that is the only place `require()` of ESM exists; its tests are `testWithSyncEsm`-gated, while the `'module.exports'` and `import.meta.main` tests run under `testWithVmEsm` and exercise the legacy path as well.

Related: this is the *producing* half of the `__esModule` convention — the half Node implements. #16144 asks for the *consuming* half (honoring `__esModule` when importing transpiled CJS), which Node deliberately does not do; behavior there is unchanged.