### PR TITLE
fix(jest-resolve): build and cache `data:` URI module IDs the same way sync and async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
 - `[@jest-environment/jsdom-abstract]` Make `@types/jsdom` a peer dependency ([#16166](https://github.com/jestjs/jest/pull/16166))
 - `[jest-mock]` Remove the leftover own accessor descriptor when restoring a `spyOn` of an inherited getter or setter, so the instance keeps reflecting the prototype ([#16226](https://github.com/jestjs/jest/pull/16226))
 - `[jest-resolve]` Include `extensionsToTreatAsEsm` in the `shouldLoadAsEsm` cache key, so projects with different extension lists don't read each other's answers ([#16369](https://github.com/jestjs/jest/pull/16369))
+- `[jest-resolve]` Make `getModuleIDAsync` build and cache `data:` URI module IDs the same way as `getModuleID` ([#16370](https://github.com/jestjs/jest/pull/16370))
 - `[jest-resolve]` Keep virtual and ordinary mock module IDs isolated across test files ([#16296](https://github.com/jestjs/jest/pull/16296))
 - `[jest-resolve]` Guard missing `require.resolve.paths` ([#16052](https://github.com/jestjs/jest/pull/16052))
 - `[jest-resolve, jest-config, jest-runner]` Support a user resolver written as an ES module ([#16332](https://github.com/jestjs/jest/pull/16332))

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -810,6 +810,52 @@ describe('getModuleID', () => {
 
     expect(normalID).not.toBe(virtualID);
   });
+
+  test('sync and async produce the same ID for a data: URI', async () => {
+    const resolver = new Resolver(moduleMap, {
+      extensions: ['.js'],
+    } as ResolverConfig);
+    const from = require.resolve('../');
+    const moduleName = 'data:text/javascript,export default 42';
+
+    const syncID = resolver.getModuleID(new Map(), from, moduleName, {});
+    const asyncID = await resolver.getModuleIDAsync(
+      new Map(),
+      from,
+      moduleName,
+      {},
+    );
+
+    expect(asyncID).toBe(syncID);
+  });
+
+  test('async caches data: URI IDs', async () => {
+    const resolver = new Resolver(moduleMap, {
+      extensions: ['.js'],
+    } as ResolverConfig);
+    const from = require.resolve('../');
+    const moduleName = 'data:text/javascript,export default 42';
+    const getAbsolutePath = jest.spyOn(
+      resolver as unknown as {_getAbsolutePathAsync: () => Promise<string>},
+      '_getAbsolutePathAsync',
+    );
+
+    const firstID = await resolver.getModuleIDAsync(
+      new Map(),
+      from,
+      moduleName,
+      {},
+    );
+    const secondID = await resolver.getModuleIDAsync(
+      new Map(),
+      from,
+      moduleName,
+      {},
+    );
+
+    expect(secondID).toBe(firstID);
+    expect(getAbsolutePath).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('nodeModulesPaths', () => {

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -636,9 +636,6 @@ export default class Resolver {
     if (cachedModuleID) {
       return cachedModuleID;
     }
-    if (moduleName.startsWith('data:')) {
-      return moduleName;
-    }
 
     const moduleType = this._getModuleType(moduleName);
     const absolutePath = await this._getAbsolutePathAsync(


### PR DESCRIPTION
## Summary

`getModuleIDAsync` short-circuits `data:` specifiers to the raw specifier, while `getModuleID` builds a `user:<uri>:` ID through `_getAbsolutePath`. The two variants disagree on the ID for the same module, and the early return also sits after the cache-key computation but before the `_moduleIDCache.set`, so the async result is recomputed on every call.

`_getAbsolutePathAsync` already handles `data:` URIs the same way the sync path does, so the short-circuit can just go: both variants now produce the same ID and the async result is cached. All mock-decision sites recompute IDs through the same function, so the format change is internally consistent.

## Test plan

New tests assert `getModuleID` and `getModuleIDAsync` return the same ID for a `data:text/javascript` specifier, and that a second async call hits the cache (`_getAbsolutePathAsync` runs once).

```
yarn jest packages/jest-resolve
yarn jest-runtime-vm-modules
```

Both green (the vm-modules suite covers the data-URI ESM paths).