### PR TITLE
fix(jest-reporters): do not check coverageThreshold when running a shard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,7 @@
 
 ### Fixes
 
-- `[jest-reporters]` Do not check `coverageThreshold` when the run is one shard of several, since a shard only covers the test files it ran ([#12751](https://github.com/jestjs/jest/issues/12751))
+- `[jest-reporters]` Do not check `coverageThreshold` when the run is one shard of several, since a shard only covers the test files it ran ([#16372](https://github.com/jestjs/jest/pull/16372))
 - `[jest-console, jest-reporters]` `CustomConsole` now buffers console output so `TestResult.console` is populated for reporters when `verbose` is enabled, while `GitHubActionsReporter` avoids replaying buffered output in verbose mode ([#16155](https://github.com/jestjs/jest/pull/16155))
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- `[jest-reporters]` Do not check `coverageThreshold` when the run is one shard of several, since a shard only covers the test files it ran ([#16372](https://github.com/jestjs/jest/pull/16372))
 - `[jest-core, jest-haste-map, jest-transform]` Keep `require('../package.json')` external when bundling, so `jest --version` and the transform and haste-map cache keys report the released version instead of the previous one ([#16422](https://github.com/jestjs/jest/pull/16422))
 - `[jest-each]` Escape a table row's keys before building the `$variable` interpolation `RegExp`, so a column name such as `count(*)` no longer fails the whole table with `Invalid regular expression`, and a `.` or `|` in a column name is matched literally ([#16345](https://github.com/jestjs/jest/pull/16345))
 
@@ -50,7 +51,6 @@
 
 ### Fixes
 
-- `[jest-reporters]` Do not check `coverageThreshold` when the run is one shard of several, since a shard only covers the test files it ran ([#16372](https://github.com/jestjs/jest/pull/16372))
 - `[jest-console, jest-reporters]` `CustomConsole` now buffers console output so `TestResult.console` is populated for reporters when `verbose` is enabled, while `GitHubActionsReporter` avoids replaying buffered output in verbose mode ([#16155](https://github.com/jestjs/jest/pull/16155))
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ### Fixes
 
+- `[jest-reporters]` Do not check `coverageThreshold` when the run is one shard of several, since a shard only covers the test files it ran ([#12751](https://github.com/jestjs/jest/issues/12751))
 - `[jest-console, jest-reporters]` `CustomConsole` now buffers console output so `TestResult.console` is populated for reporters when `verbose` is enabled, while `GitHubActionsReporter` avoids replaying buffered output in verbose mode ([#16155](https://github.com/jestjs/jest/pull/16155))
 - `[expect, jest-message-util, jest-pattern, jest-regex-util, jest-util]` Revert `node:` protocol imports to restore webpack/browser-bundle compatibility ([#16167](https://github.com/jestjs/jest/pull/16167))
 - `[expect]` Widen `toMatchObject` and `objectContaining` parameter type from `Record<string, unknown>` to `object` so class instances are accepted ([#16196](https://github.com/jestjs/jest/pull/16196))

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -464,6 +464,8 @@ jest --shard=2/3
 jest --shard=3/3
 ```
 
+[`coverageThreshold`](Configuration.md#coveragethreshold-object) is not checked for a run split across several shards, because each shard covers only the test files it ran. Collect coverage from each shard, merge the reports, and check the thresholds against the merged report.
+
 ### `--showConfig`
 
 Print your Jest config and then exits.

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -464,7 +464,7 @@ jest --shard=2/3
 jest --shard=3/3
 ```
 
-[`coverageThreshold`](Configuration.md#coveragethreshold-object) is not checked for a run split across several shards, because each shard covers only the test files it ran. Collect coverage from each shard, merge the reports, and check the thresholds against the merged report.
+[`coverageThreshold`](Configuration.md#coveragethreshold-object) is not checked for a run split across several shards, because each shard covers only the test files it ran. Jest does not merge coverage across shards or check a threshold against a merged report, so a whole-project number has to be enforced outside Jest — see [`coverageThreshold`](Configuration.md#coveragethreshold-object) for the workflow and the threshold features that do not carry over.
 
 ### `--showConfig`
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -394,6 +394,8 @@ Default: `undefined`
 
 This will be used to configure minimum threshold enforcement for coverage results. Thresholds can be specified as `global`, as a [glob](https://github.com/isaacs/node-glob#glob-primer), and as a directory or file path. If thresholds aren't met, jest will fail.
 
+Thresholds are not checked when the run is a shard of several (see [`--shard`](CLI.md#--shard)). A shard runs only part of the suite, so its coverage is only part of the project's and a `global` threshold checked against it would fail for every shard. Merge the coverage reports from all shards and check the thresholds against the merged report instead.
+
 - If a threshold is set to a **positive** number, it will be interpreted as the **minimum** percentage of coverage required.
 
 - If a threshold is set to a **negative** number, it will be treated as the **maximum** number of uncovered items allowed.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -394,7 +394,11 @@ Default: `undefined`
 
 This will be used to configure minimum threshold enforcement for coverage results. Thresholds can be specified as `global`, as a [glob](https://github.com/isaacs/node-glob#glob-primer), and as a directory or file path. If thresholds aren't met, jest will fail.
 
-Thresholds are not checked when the run is a shard of several (see [`--shard`](CLI.md#--shard)). A shard runs only part of the suite, so its coverage is only part of the project's and a `global` threshold checked against it would fail for every shard. Merge the coverage reports from all shards and check the thresholds against the merged report instead.
+Thresholds are not checked when the run is a shard of several (see [`--shard`](CLI.md#--shard)). A shard runs only part of the suite, so its coverage is only part of the project's and a `global` threshold checked against it would fail for every shard.
+
+Jest has no built-in step for enforcing thresholds across shards: it cannot merge the shards' coverage, and it cannot check a threshold against a coverage file it did not just produce. Enforcing a whole-project number therefore happens outside Jest — have each shard write the `json` reporter, merge the resulting `coverage-final.json` files (`istanbul-lib-coverage`, `nyc merge`), and check the merged report with your coverage service or `nyc check-coverage`.
+
+Note what that does not carry over. `nyc check-coverage` takes global and per-file thresholds; it does not reproduce this option's glob and path groups, and it has no equivalent of a **negative** threshold's "maximum uncovered items" rule. A `coverageThreshold` using those features has no exact equivalent outside Jest, and reproducing it means driving the reporter yourself.
 
 - If a threshold is set to a **positive** number, it will be interpreted as the **minimum** percentage of coverage required.
 

--- a/e2e/__tests__/coverageThreshold.test.ts
+++ b/e2e/__tests__/coverageThreshold.test.ts
@@ -347,3 +347,93 @@ test('file is matched by all path and glob threshold groups', () => {
   expect(summary).toMatchSnapshot();
   expect(stdout).toMatchSnapshot('stdout');
 });
+
+describe('shard', () => {
+  // A shard runs a subset of the test files, so it only ever covers part of
+  // the project. Checking a `global` threshold against that fails for every
+  // shard no matter how well covered the code is (#12751).
+  const pkgJson = {
+    jest: {
+      collectCoverage: true,
+      collectCoverageFrom: ['**/*.js'],
+      coverageThreshold: {
+        global: {
+          lines: 90,
+        },
+      },
+    },
+  };
+
+  const files = {
+    '__tests__/a.test.js': `
+      const a = require('../a.js');
+      test('a', () => expect(a()).toBe(1));
+    `,
+    '__tests__/b.test.js': `
+      const b = require('../b.js');
+      test('b', () => expect(b()).toBe(2));
+    `,
+    'a.js': 'module.exports = () => 1;',
+    'b.js': 'module.exports = () => 2;',
+    'package.json': JSON.stringify(pkgJson, null, 2),
+  };
+
+  test('does not check the threshold when running one shard of several', () => {
+    writeFiles(DIR, files);
+
+    const {stderr, exitCode} = runJest(
+      DIR,
+      ['--coverage', '--ci=false', '--shard=1/2'],
+      {stripAnsi: true},
+    );
+
+    // Every file the shard did not run is reported at zero, so the threshold
+    // would otherwise be judged against coverage the run never set out to
+    // collect.
+    expect(exitCode).toBe(0);
+    expect(stderr).toContain(
+      'Coverage thresholds are not checked when running a shard',
+    );
+    expect(stderr).toContain('shard 1/2');
+    expect(stderr).not.toContain('does not meet "global" threshold');
+  });
+
+  test('checks the threshold when the run is a single shard', () => {
+    writeFiles(DIR, files);
+
+    // `--shard=1/1` runs every test file, so the coverage is the whole
+    // project's and the threshold means what it usually means.
+    const {stderr, exitCode} = runJest(
+      DIR,
+      ['--coverage', '--ci=false', '--shard=1/1'],
+      {stripAnsi: true},
+    );
+
+    expect(exitCode).toBe(0);
+    expect(stderr).not.toContain(
+      'Coverage thresholds are not checked when running a shard',
+    );
+  });
+
+  test('checks the threshold on a single shard that misses it', () => {
+    writeFiles(DIR, {
+      ...files,
+      // Nothing requires this, so a complete run is under the threshold and
+      // must still fail - the skip is about sharding, not about coverage.
+      'uncovered.js': `
+        module.exports = () => {
+          return 1 + 2;
+        };
+      `,
+    });
+
+    const {stderr, exitCode} = runJest(
+      DIR,
+      ['--coverage', '--ci=false', '--shard=1/1'],
+      {stripAnsi: true},
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain('threshold');
+  });
+});

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -252,8 +252,10 @@ export default class CoverageReporter extends BaseReporter {
     //
     // The check is skipped rather than adjusted because there is no adjustment
     // to make: the number a `global` threshold is about is the whole project's
-    // coverage, and no single shard has it. Enforcing it belongs after the
-    // shards' coverage is merged (#12751).
+    // coverage, and no single shard has it. Jest has no step that merges the
+    // shards' coverage or checks a threshold against a report it did not just
+    // produce, so enforcing a whole-project number happens outside Jest
+    // (#12751).
     //
     // `--shard=1/1` is a complete run, so it keeps its thresholds.
     if (coverageThreshold && shard && shard.shardCount > 1) {
@@ -261,8 +263,9 @@ export default class CoverageReporter extends BaseReporter {
         WARN_COLOR(
           'Jest: Coverage thresholds are not checked when running a shard, ' +
             `as shard ${shard.shardIndex}/${shard.shardCount} only covers ` +
-            'part of the project. Merge the coverage reports from all shards ' +
-            'and check the thresholds against the merged report.',
+            'part of the project. Jest cannot merge coverage across shards, ' +
+            'so enforce a whole-project threshold outside Jest, against the ' +
+            'merged coverage from every shard.',
         ),
       );
       return;

--- a/packages/jest-reporters/src/CoverageReporter.ts
+++ b/packages/jest-reporters/src/CoverageReporter.ts
@@ -36,6 +36,7 @@ import type {ReporterContext} from './types';
 type CoverageWorker = typeof import('./CoverageWorker');
 
 const FAIL_COLOR = chalk.bold.red;
+const WARN_COLOR = chalk.bold.yellow;
 const RUNNING_TEST_COLOR = chalk.bold.dim;
 
 function getMaxCols(): number {
@@ -241,7 +242,31 @@ export default class CoverageReporter extends BaseReporter {
   }
 
   private _checkThreshold(map: istanbulCoverage.CoverageMap) {
-    const {coverageThreshold} = this._globalConfig;
+    const {coverageThreshold, shard} = this._globalConfig;
+
+    // A shard runs a subset of the test files, so the coverage it collects is
+    // a subset of the project's. Every file the shard did not exercise is
+    // still reported, at zero, so a threshold checked here is checked against
+    // a run that was never meant to cover everything - it fails for the shards
+    // and passes for none of them, whatever the code actually covers.
+    //
+    // The check is skipped rather than adjusted because there is no adjustment
+    // to make: the number a `global` threshold is about is the whole project's
+    // coverage, and no single shard has it. Enforcing it belongs after the
+    // shards' coverage is merged (#12751).
+    //
+    // `--shard=1/1` is a complete run, so it keeps its thresholds.
+    if (coverageThreshold && shard && shard.shardCount > 1) {
+      this.log(
+        WARN_COLOR(
+          'Jest: Coverage thresholds are not checked when running a shard, ' +
+            `as shard ${shard.shardIndex}/${shard.shardCount} only covers ` +
+            'part of the project. Merge the coverage reports from all shards ' +
+            'and check the thresholds against the merged report.',
+        ),
+      );
+      return;
+    }
 
     if (coverageThreshold) {
       function check(

--- a/packages/jest-reporters/src/__tests__/CoverageReporter.test.js
+++ b/packages/jest-reporters/src/__tests__/CoverageReporter.test.js
@@ -142,6 +142,62 @@ describe('onRunComplete', () => {
     expect(testReporter.getLastError().message.split('\n')).toHaveLength(1);
   });
 
+  test('does not check the threshold when the run is one shard of several', async () => {
+    // The shard covers only the test files it ran, so every file it did not
+    // run reports zero and the threshold would fail for each shard (#12751).
+    const testReporter = new CoverageReporter(
+      {
+        collectCoverage: true,
+        coverageThreshold: {
+          global: {
+            statements: 100,
+          },
+        },
+        shard: {shardCount: 4, shardIndex: 1},
+      },
+      {
+        maxWorkers: 2,
+      },
+    );
+    testReporter.log = jest.fn();
+
+    await testReporter.onRunComplete(new Set(), {}, mockAggResults);
+
+    expect(testReporter.getLastError()).toBeUndefined();
+    expect(testReporter.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Coverage thresholds are not checked when running a shard',
+      ),
+    );
+    expect(testReporter.log).toHaveBeenCalledWith(
+      expect.stringContaining('shard 1/4'),
+    );
+  });
+
+  test('checks the threshold when the run is a single shard', async () => {
+    // `--shard=1/1` runs every test file, so it is a complete run and the
+    // threshold means what it usually means.
+    const testReporter = new CoverageReporter(
+      {
+        collectCoverage: true,
+        coverageThreshold: {
+          global: {
+            statements: 100,
+          },
+        },
+        shard: {shardCount: 1, shardIndex: 1},
+      },
+      {
+        maxWorkers: 2,
+      },
+    );
+    testReporter.log = jest.fn();
+
+    await testReporter.onRunComplete(new Set(), {}, mockAggResults);
+
+    expect(testReporter.getLastError()).toBeDefined();
+  });
+
   test('getLastError() returns an error when threshold is not met for file', async () => {
     const covThreshold = {};
     const paths = [


### PR DESCRIPTION
## Summary

Refs #12751.

A shard runs a subset of the test files, but coverage is still reported for every file matching `collectCoverageFrom` — the ones the shard did not exercise come out at zero. `_checkThreshold` then runs against that mix, so a `global` threshold fails on every shard however well the project is actually covered.

Reproduced on **29.7.0 and on 30.4.2**. Four sources, each fully covered by its own test file, `global` thresholds at 90%:

```console
$ npx jest                       # full run
All files |     100 |      100 |     100 |     100 |
Tests:       4 passed, 4 total          # exit 0

$ npx jest --shard=1/4
 mod1.js  |       0 |        0 |       0 |       0 |
 mod2.js  |       0 |        0 |       0 |       0 |
 mod3.js  |       0 |        0 |       0 |       0 |
 mod4.js  |     100 |      100 |     100 |     100 |
All files |      25 |       25 |      25 |      25 |
Jest: Coverage for statements (25%) does not meet "global" threshold (90%)
Jest: Coverage for branches (25%) does not meet "global" threshold (90%)
Jest: Coverage for lines (25%) does not meet "global" threshold (90%)
Jest: Coverage for functions (25%) does not meet "global" threshold (90%)
Tests:       1 passed, 1 total          # exit 1
```

Every test that ran passed. The failure is entirely the three files this shard was never going to run.

## The change

Skip the threshold check for a sharded run and say so, rather than reporting a verdict on coverage the run never set out to collect:

```
Jest: Coverage thresholds are not checked when running a shard, as shard 1/4
only covers part of the project. Merge the coverage reports from all shards
and check the thresholds against the merged report.
```

Skipped rather than adjusted because there is no adjustment to make: what a `global` threshold describes is the whole project's coverage, and no single shard has it.

**`--shard=1/1` keeps its thresholds.** It runs every test file, so it is a complete run. The condition is `shardCount > 1`, not "shard is set" — getting that wrong would quietly stop enforcing coverage for anyone who shards by one.

No new option and no merge mode. @SimenB [wrote in 2022](https://github.com/jestjs/jest/issues/12751#issuecomment-1289345236) that multiple runs are the only way to make the threshold check work and that he was unsure Jest wants coverage merging as a mode; this follows from that rather than arguing with it. Collecting per shard and merging is already the documented route to a whole-project number, and the warning points at it.

## A decision worth your call

The skip covers **all** threshold groups, not only `global`. A `path` or `glob` threshold on a file the shard *did* cover would still be meaningful, so there is a narrower fix available.

I did not take it because Jest cannot tell which files a given shard *should* cover — the split is by test file, so any group can contain files at zero purely because their tests landed in another shard. Skipping everything is predictable; skipping some groups but not others depends on where the sequencer happened to put things. Happy to narrow it to `global` if you would rather.

## Tests

Three e2e cases in `coverageThreshold.test.ts`:

- `does not check the threshold when running one shard of several` — the fix. **Fails without it** (exit 1 instead of 0); I checked by neutralising the guard and re-running.
- `checks the threshold when the run is a single shard` — `--shard=1/1` is unaffected.
- `checks the threshold on a single shard that misses it` — a complete run genuinely short of the threshold **still fails**, so the skip is about sharding and not a way to switch thresholds off.

The last two pass with or without the change by design; they are there to pin the boundary, not to detect the bug.

| check | result |
| --- | --- |
| `packages/jest-reporters` + coverage/shard/summary e2e | 122 tests, 74 snapshots pass |
| all `e2e/__tests__/coverage*` | 36 tests, 40 snapshots pass |
| `tsc --noEmit` on `jest-reporters` | 0 errors |
| ESLint + Prettier on changed files | clean |

Docs updated on both sides — `coverageThreshold` in Configuration.md and `--shard` in CLI.md — since the two are only surprising together. CHANGELOG entry under Fixes.

I have not run the full suite; the above is the coverage, reporter and shard surface plus the gates.
