### PR TITLE
feat: expose failed matcher metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `[@jest/expect-utils, jest-mock]` Add `mockFn.whenCalledWith(...args)` for configuring return values per argument list, with first-class asymmetric-matcher support ([#16053](https://github.com/jestjs/jest/pull/16053))
 - `[@jest/expect-utils]` Export `AsymmetricMatcher` and `FunctionParameters` types (previously private to `expect`) ([#16053](https://github.com/jestjs/jest/pull/16053))
+- `[expect, jest-circus, jest-test-result, jest-types]` Expose failed custom matcher metadata through `TestCaseResult.matcherResult` for reporters ([#16380](https://github.com/jestjs/jest/pull/16380))
 - `[jest-circus, jest-core, jest-jasmine2, jest-test-result, jest-types]` `--collectTests` now expands `test.each`/`describe.each` cases and reports per-status counts (skipped/todo via the new `wouldRun` flag for selected tests) plus a summary line that match a real run, including under `--testNamePattern` and `.only`/`fdescribe` focus on both the circus and jasmine2 runners ([#16259](https://github.com/jestjs/jest/pull/16259))
 - `[jest-circus, jest-environment, jest-runtime, jest-types]` Add describe-level retries via `jest.retryTimes(..., {entireDescribe: true})` ([#16322](https://github.com/jestjs/jest/pull/16322))
 - `[jest-circus, jest-message-util, jest-reporters, jest-types]` Add `retryMessages` to `AssertionResult` and export `formatErrorStack`, so the retry log renders nested `cause` and `AggregateError` sections with code frames instead of serialized `[cause]:`/`[errors]:` markers ([#16316](https://github.com/jestjs/jest/pull/16316))

--- a/packages/expect/__typetests__/expect.test.ts
+++ b/packages/expect/__typetests__/expect.test.ts
@@ -12,6 +12,7 @@ import {
   type MatcherFunction,
   type MatcherFunctionWithContext,
   type Matchers,
+  type SyncExpectationResult,
   type Tester,
   type TesterContext,
   expect as jestExpect,
@@ -143,6 +144,26 @@ describe('Expect', () => {
 });
 
 describe('MatcherFunction', () => {
+  test('allows interfaces with custom result metadata', () => {
+    interface ImageMatcherResult {
+      diffPath: string;
+      message(): string;
+      pass: boolean;
+    }
+
+    const result: ImageMatcherResult = {
+      diffPath: 'image-diff.png',
+      message: () => 'images differ',
+      pass: false,
+    };
+
+    const expectationResult: SyncExpectationResult = result;
+    const matcher: MatcherFunction = (): ImageMatcherResult => result;
+
+    expect(expectationResult).type.toBe<SyncExpectationResult>();
+    expect(matcher).type.toBe<MatcherFunction>();
+  });
+
   test('models typings of a matcher function', () => {
     type ToBeWithinRange = (
       this: MatcherContext,

--- a/packages/jest-circus/src/__tests__/utils.test.ts
+++ b/packages/jest-circus/src/__tests__/utils.test.ts
@@ -163,6 +163,24 @@ test('makeSingleTestResult keeps primitive retry errors independent', () => {
   expect(asyncError.message).toBe('hook location');
 });
 
+test('parseSingleTestResult exposes failed matcher metadata', () => {
+  const error = new Error('matcher failed') as Error & {
+    matcherResult: unknown;
+  };
+  error.matcherResult = {
+    actual: 'actual',
+    diffPath: 'relative/path.png',
+    expected: 'expected',
+    message: 'matcher failed',
+    name: 'toMatchImageSnapshot',
+    pass: false,
+  };
+
+  const result = parseSingleTestResult(makeFailedTestResult(error));
+
+  expect(result.matcherResult).toEqual(error.matcherResult);
+});
+
 test('makeRunResult keeps the unserialized unhandled errors', () => {
   const error = new Error('unhandled');
   const result = makeRunResult(makeDescribe(ROOT_DESCRIBE_BLOCK_NAME), [error]);

--- a/packages/jest-circus/src/utils.ts
+++ b/packages/jest-circus/src/utils.ts
@@ -12,7 +12,7 @@ import isGeneratorFn from 'is-generator-fn';
 import slash from 'slash';
 import StackUtils from 'stack-utils';
 import type {Status, TestCaseResult} from '@jest/test-result';
-import type {Circus, Global} from '@jest/types';
+import type {Circus, Global, TestResult} from '@jest/types';
 import {flattenErrorStack} from 'jest-message-util';
 import {
   ErrorWithStack,
@@ -517,6 +517,15 @@ export const parseSingleTestResult = (
     testResult.testPath,
   );
 
+  const matcherResult = testResult.errorsDetailed.find(error => {
+    if (!error || typeof error !== 'object') {
+      return false;
+    }
+
+    const candidate = (error as {matcherResult?: unknown}).matcherResult;
+    return Boolean(candidate && typeof candidate === 'object');
+  }) as {matcherResult?: TestResult.MatcherResult} | undefined;
+
   return {
     ancestorTitles,
     duration: testResult.duration,
@@ -526,6 +535,7 @@ export const parseSingleTestResult = (
     fullName,
     invocations: testResult.invocations,
     location: testResult.location,
+    matcherResult: matcherResult?.matcherResult,
     numPassingAsserts: testResult.numPassingAsserts,
     retryMessages: formatRetryError
       ? testResult.retryReasonsDetailed.map(formatRetryError)

--- a/packages/jest-types/src/TestResult.ts
+++ b/packages/jest-types/src/TestResult.ts
@@ -13,6 +13,16 @@ type Callsite = {
   line: number;
 };
 
+/** Metadata returned by a failed custom matcher. */
+export type MatcherResult = {
+  actual?: unknown;
+  expected?: unknown;
+  message?: string;
+  name?: string;
+  pass: boolean;
+  [key: string]: unknown;
+};
+
 // this is here to make it possible to avoid huge dependency trees just for types
 export type AssertionResult = {
   ancestorTitles: Array<string>;
@@ -33,6 +43,7 @@ export type AssertionResult = {
   fullName: string;
   invocations?: number;
   location?: Callsite | null;
+  matcherResult?: MatcherResult;
   numPassingAsserts: number;
   /**
    * Human-readable render of `retryReasons`, formatted where the errors are


### PR DESCRIPTION
## Summary

Resolves #4547

- expose failed custom matcher metadata through `TestCaseResult.matcherResult`
- preserve existing `failureDetails` behavior and worker transport
- add regression coverage and changelog entry

## Validation

- `yarn build:js`
- `yarn typecheck:tests`
- targeted ESLint
- Prettier check
- `git diff --check`

Targeted Jest execution was blocked by existing missing module `react-is-18` while loading `pretty-format`/Jest CLI.