### PR TITLE
refactor(jest-runtime): remove dead accessors and collapse duplicated module-loading shapes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@
 - `[@jest/source-map]` Warn when a source map cannot be parsed, instead of silently leaving its frames untranslated ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[jest-runner, @jest/source-map]` Keep a source-mapped stack for an error thrown after the test environment was torn down ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[jest-runtime, @jest/source-map]` Keep source maps past teardown and past the next test file's `install`, so a stack from a file no earlier stack mentioned still points at the original source ([#16330](https://github.com/jestjs/jest/pull/16330))
+- `[jest-runtime]` Report that no coverage was collected when `getAllV8CoverageInfoCopy` is called after `teardown`, instead of returning an empty result ([#16385](https://github.com/jestjs/jest/pull/16385))
 - `[jest-runtime]` Cache a CJS module's parsed exports before walking its re-exports, so two modules that re-export each other no longer overflow the stack when imported from ESM ([#16363](https://github.com/jestjs/jest/pull/16363))
 - `[jest-runtime]` Keep a re-exported ES module's parse failure from marking the re-exporting CommonJS file as ESM, so `module.exports = require('./dep.mjs')` loads instead of failing with `module is not defined` ([#16363](https://github.com/jestjs/jest/pull/16363))
 - `[jest-runtime]` Scope module mocks instantiated inside `jest.isolateModules`/`isolateModulesAsync` to that block, so a mock first imported there no longer outlives it - matching how CommonJS mocks already behave ([#16365](https://github.com/jestjs/jest/pull/16365))

--- a/packages/jest-runtime/src/__tests__/helpers.test.ts
+++ b/packages/jest-runtime/src/__tests__/helpers.test.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {
+  createOutsideJestVmPath,
+  decodePossibleOutsideJestVmPath,
+} from '../helpers';
+
+describe('outsideJestVmPath', () => {
+  test.each([
+    '/plain/module.js',
+    '/with space/module.js',
+    '/with#hash/module.js',
+    '/with?query/module.js',
+  ])('round trips %s', filename => {
+    expect(
+      decodePossibleOutsideJestVmPath(createOutsideJestVmPath(filename)),
+    ).toBe(filename);
+  });
+
+  test('leaves an ordinary specifier alone', () => {
+    expect(decodePossibleOutsideJestVmPath('/plain/module.js')).toBeUndefined();
+    expect(decodePossibleOutsideJestVmPath('jest-main')).toBeUndefined();
+  });
+
+  test('ignores the protocol without its authority delimiter', () => {
+    expect(decodePossibleOutsideJestVmPath('jest-main:x.js')).toBeUndefined();
+  });
+});

--- a/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
@@ -755,10 +755,9 @@ describe('Runtime sync ESM graph - require(esm)', () => {
       const aPath = path.join(ROOT_DIR, 'a.mjs');
       // Simulate a concurrent `await import()` by stashing a pending Promise
       // in the registry under the key require() will look up.
-      runtime.registries.setEsm(
-        pathToFileURL(aPath).href,
-        new Promise(() => {}),
-      );
+      runtime.registries
+        .getActiveEsmRegistry()
+        .set(pathToFileURL(aPath).href, new Promise(() => {}));
       expect(() => runtime.requireModule(FROM, './a.mjs')).toThrow(
         expect.objectContaining({
           code: 'ERR_REQUIRE_ESM',
@@ -846,7 +845,9 @@ describe('Runtime sync ESM graph - require(esm)', () => {
       await m.namespace.loadCjs();
 
       const cjsPath = path.join(ROOT_DIR, 'cjs-dep.cjs');
-      const entry = runtime.registries.getEsm(pathToFileURL(cjsPath).href);
+      const entry = runtime.registries
+        .getActiveEsmRegistry()
+        .get(pathToFileURL(cjsPath).href);
       expect(entry).toBeDefined();
       expect(entry).not.toBeInstanceOf(Promise);
     },

--- a/packages/jest-runtime/src/helpers.ts
+++ b/packages/jest-runtime/src/helpers.ts
@@ -18,12 +18,9 @@ export const createOutsideJestVmPath = (path: string): string =>
 export const decodePossibleOutsideJestVmPath = (
   outsideJestVmPath: string,
 ): string | undefined => {
-  if (outsideJestVmPath.startsWith(OUTSIDE_JEST_VM_PROTOCOL)) {
+  if (outsideJestVmPath.startsWith(`${OUTSIDE_JEST_VM_PROTOCOL}//`)) {
     return decodeURIComponent(
-      outsideJestVmPath.replace(
-        new RegExp(`^${OUTSIDE_JEST_VM_PROTOCOL}//`),
-        '',
-      ),
+      outsideJestVmPath.slice(OUTSIDE_JEST_VM_PROTOCOL.length + 2),
     );
   }
   return undefined;

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -7,7 +7,6 @@
 
 import nativeModule from 'node:module';
 import * as path from 'node:path';
-import {SourceTextModule} from 'node:vm';
 import slash from 'slash';
 import type {JestEnvironment} from '@jest/environment';
 import type {SourceMapRegistry} from '@jest/source-map';
@@ -62,8 +61,6 @@ const INTERNAL_MODULE_REQUIRE_OUTSIDE_OPTIMIZED_MODULES = new Set(['chalk']);
 // framework see the same class instances.
 const FRAMEWORK_SINGLETON_MODULES = new Set(['@jest/expect', 'expect']);
 
-const esmIsAvailable = typeof SourceTextModule === 'function';
-
 type HasteMapOptions = {
   console?: Console;
   maxWorkers: number;
@@ -75,7 +72,7 @@ type HasteMapOptions = {
 
 const defaultTransformOptions: TransformOptions = {
   isInternalModule: false,
-  supportsDynamicImport: esmIsAvailable,
+  supportsDynamicImport: runtimeSupportsVmModules,
   supportsExportNamespaceFrom: false,
   supportsStaticESM: false,
   supportsTopLevelAwait: false,

--- a/packages/jest-runtime/src/index.ts
+++ b/packages/jest-runtime/src/index.ts
@@ -46,7 +46,10 @@ import {
 } from './internals/TransformCache';
 import {V8CoverageCollector} from './internals/V8CoverageCollector';
 import {CoreModuleProvider, RequireBuilder} from './internals/cjsRequire';
-import type {InitialModule, ModuleRegistry} from './internals/moduleTypes';
+import {
+  type ModuleRegistry,
+  createInitialModule,
+} from './internals/moduleTypes';
 import {runtimeSupportsVmModules} from './internals/nodeCapabilities';
 import type {EnvironmentGlobals} from './internals/types';
 
@@ -439,15 +442,7 @@ export default class Runtime {
     const manualMockPath = this._resolution.findManualMock(from, moduleName);
 
     if (manualMockPath) {
-      const localModule: InitialModule = {
-        children: [],
-        exports: {},
-        filename: manualMockPath,
-        id: manualMockPath,
-        isPreloading: false,
-        loaded: false,
-        path: path.dirname(manualMockPath),
-      };
+      const localModule = createInitialModule(manualMockPath);
 
       this.cjsLoader.loadModule(
         localModule,

--- a/packages/jest-runtime/src/internals/CjsLoader.ts
+++ b/packages/jest-runtime/src/internals/CjsLoader.ts
@@ -16,7 +16,11 @@ import type {TestState} from './TestState';
 import type {TransformCache, TransformOptions} from './TransformCache';
 import type {CoreModuleProvider} from './cjsRequire';
 import {hasEsmSyntax} from './esmLexer';
-import type {InitialModule, ModuleRegistry} from './moduleTypes';
+import {
+  type InitialModule,
+  type ModuleRegistry,
+  createInitialModule,
+} from './moduleTypes';
 import {
   runtimeSupportsVmModules,
   supportsSyncEvaluate,
@@ -125,15 +129,7 @@ export class CjsLoader {
     // We must register the pre-allocated module object first so that any
     // circular dependencies that may arise while evaluating the module can
     // be satisfied.
-    const localModule: InitialModule = {
-      children: [],
-      exports: {},
-      filename: modulePath,
-      id: modulePath,
-      isPreloading: false,
-      loaded: false,
-      path: path.dirname(modulePath),
-    };
+    const localModule = createInitialModule(modulePath);
     moduleRegistry.set(modulePath, localModule);
     if (!isInternal) {
       this.recordChildModule(from, localModule as Module, moduleRegistry);

--- a/packages/jest-runtime/src/internals/EsmLoader.ts
+++ b/packages/jest-runtime/src/internals/EsmLoader.ts
@@ -857,63 +857,35 @@ export class EsmLoader {
         ESM_TRANSFORM_OPTIONS,
       );
 
-      const module: VMModuleWithAsyncGraph = new SourceTextModule(
-        transformedCode,
-        {
-          context,
-          identifier: modulePath,
-          importModuleDynamically: this.dynamicImport,
-          initializeImportMeta: meta => {
-            const metaUrl = cacheKey;
-            meta.url = metaUrl;
-            // @ts-expect-error Jest uses @types/node@18.
-            meta.filename = modulePath;
-            // @ts-expect-error Jest uses @types/node@18.
-            meta.dirname = path.dirname(modulePath);
-            meta.resolve = (specifier, parent: string | URL = metaUrl) => {
-              const parentPath = fileURLToPath(parent);
-              return this.resolveForImportMeta(parentPath, specifier);
-            };
-            // @ts-expect-error Jest uses @types/node@18.
-            meta.main = modulePath === this.testPath;
-            (meta as JestImportMeta).jest =
-              this.jestGlobals.jestObjectFor(modulePath);
-          },
+      const entry = this.buildSyncSourceEntry({
+        cacheKey,
+        code: transformedCode,
+        context,
+        identifier: modulePath,
+        initializeImportMeta: meta => {
+          const metaUrl = cacheKey;
+          meta.url = metaUrl;
+          // @ts-expect-error Jest uses @types/node@18.
+          meta.filename = modulePath;
+          // @ts-expect-error Jest uses @types/node@18.
+          meta.dirname = path.dirname(modulePath);
+          meta.resolve = (specifier, parent: string | URL = metaUrl) => {
+            const parentPath = fileURLToPath(parent);
+            return this.resolveForImportMeta(parentPath, specifier);
+          };
+          // @ts-expect-error Jest uses @types/node@18.
+          meta.main = modulePath === this.testPath;
+          (meta as JestImportMeta).jest =
+            this.jestGlobals.jestObjectFor(modulePath);
         },
-      );
+        mode,
+        registry,
+        scratch,
+        worklist,
+      });
+      if (entry === LOAD_ASYNC) return LOAD_ASYNC;
 
-      if (
-        typeof module.hasTopLevelAwait === 'function' &&
-        module.hasTopLevelAwait()
-      ) {
-        if (mode === 'sync-required') {
-          throw makeRequireAsyncError(modulePath, 'top-level await');
-        }
-        return LOAD_ASYNC;
-      }
-
-      // If we got here without `moduleRequests`, the capability gate is lying.
-      invariant(
-        module.moduleRequests !== undefined,
-        `moduleRequests unavailable on ${modulePath}`,
-      );
-      const deps: Array<string> = [];
-      for (const {specifier, attributes} of module.moduleRequests) {
-        const resolved = this.resolveSpecifierForSyncGraph(
-          modulePath,
-          specifier,
-          context,
-          scratch,
-          registry,
-          mode,
-        );
-        if (resolved === LOAD_ASYNC) return LOAD_ASYNC;
-        validateImportAttributes(resolved.modulePath, attributes, modulePath);
-        deps.push(resolved.cacheKey);
-        if (resolved.enqueue) worklist.push(resolved.enqueue);
-      }
-
-      scratch.set(cacheKey, {cacheKey, deps, kind: 'source', module});
+      scratch.set(cacheKey, entry);
     }
 
     this.adoptCommittedScratchEntries(scratch, registry);
@@ -1324,7 +1296,6 @@ export class EsmLoader {
     worklist: Array<WorklistEntry>,
     mode: SyncEsmMode,
   ): ScratchEntry | LoadAsync {
-    const esmDynamicImport = this.dynamicImport;
     const {mime, code} = parseDataUri(specifier);
 
     if (mime === 'application/wasm') {
@@ -1348,10 +1319,11 @@ export class EsmLoader {
       };
     }
 
-    const module = new SourceTextModule(code as string, {
+    return this.buildSyncSourceEntry({
+      cacheKey,
+      code: code as string,
       context,
       identifier: specifier,
-      importModuleDynamically: esmDynamicImport,
       initializeImportMeta: meta => {
         meta.url = specifier;
         // @ts-expect-error Jest uses @types/node@18.
@@ -1360,6 +1332,42 @@ export class EsmLoader {
         (meta as JestImportMeta).jest =
           this.jestGlobals.jestObjectFor(specifier);
       },
+      mode,
+      registry,
+      scratch,
+      worklist,
+    });
+  }
+
+  // The source-module half of a sync walk: construct, refuse top-level await,
+  // then resolve each static import so the caller can link the graph. Callers
+  // differ only in what `import.meta` gets.
+  private buildSyncSourceEntry({
+    cacheKey,
+    code,
+    context,
+    identifier,
+    initializeImportMeta,
+    mode,
+    registry,
+    scratch,
+    worklist,
+  }: {
+    cacheKey: string;
+    code: string;
+    context: VMContext;
+    identifier: string;
+    initializeImportMeta: (meta: ImportMeta) => void;
+    mode: SyncEsmMode;
+    registry: ModuleRegistry | Map<string, JestModule>;
+    scratch: Map<string, ScratchEntry>;
+    worklist: Array<WorklistEntry>;
+  }): ScratchEntry | LoadAsync {
+    const module = new SourceTextModule(code, {
+      context,
+      identifier,
+      importModuleDynamically: this.dynamicImport,
+      initializeImportMeta,
     }) as VMModuleWithAsyncGraph;
 
     if (
@@ -1367,27 +1375,28 @@ export class EsmLoader {
       module.hasTopLevelAwait()
     ) {
       if (mode === 'sync-required') {
-        throw makeRequireAsyncError(specifier, 'top-level await');
+        throw makeRequireAsyncError(identifier, 'top-level await');
       }
       return LOAD_ASYNC;
     }
 
+    // If we got here without `moduleRequests`, the capability gate is lying.
     invariant(
       module.moduleRequests !== undefined,
-      `moduleRequests unavailable on ${specifier}`,
+      `moduleRequests unavailable on ${identifier}`,
     );
     const deps: Array<string> = [];
-    for (const {specifier: depSpec, attributes} of module.moduleRequests) {
+    for (const {specifier, attributes} of module.moduleRequests) {
       const resolved = this.resolveSpecifierForSyncGraph(
+        identifier,
         specifier,
-        depSpec,
         context,
         scratch,
         registry,
         mode,
       );
       if (resolved === LOAD_ASYNC) return LOAD_ASYNC;
-      validateImportAttributes(resolved.modulePath, attributes, specifier);
+      validateImportAttributes(resolved.modulePath, attributes, identifier);
       deps.push(resolved.cacheKey);
       if (resolved.enqueue) worklist.push(resolved.enqueue);
     }

--- a/packages/jest-runtime/src/internals/MockState.ts
+++ b/packages/jest-runtime/src/internals/MockState.ts
@@ -359,35 +359,15 @@ export class MockState {
       moduleName,
     );
   }
-  getEsmModuleId(from: string, moduleName?: string): string {
-    return this.resolution.getEsmModuleId(
-      this.virtualEsmMocks,
-      from,
-      moduleName,
-    );
-  }
-  getEsmModuleIdAsync(from: string, moduleName?: string): Promise<string> {
-    return this.resolution.getEsmModuleIdAsync(
-      this.virtualEsmMocks,
-      from,
-      moduleName,
-    );
-  }
 
   isExplicitlyUnmocked(moduleID: string): boolean {
     return this.explicitCjsMock.get(moduleID) === false;
   }
 
-  hasCjsFactory(moduleID: string): boolean {
-    return this.cjsFactories.has(moduleID);
-  }
   getCjsFactory(moduleID: string): (() => unknown) | undefined {
     return this.cjsFactories.get(moduleID);
   }
 
-  hasEsmFactory(moduleID: string): boolean {
-    return this.esmFactories.has(moduleID);
-  }
   getEsmFactory(
     moduleID: string,
   ): (() => Promise<unknown> | unknown) | undefined {

--- a/packages/jest-runtime/src/internals/ModuleRegistries.ts
+++ b/packages/jest-runtime/src/internals/ModuleRegistries.ts
@@ -9,8 +9,7 @@ import nativeModule from 'node:module';
 import * as path from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import type {Module as VMModule} from 'node:vm';
-import type {Module} from '@jest/environment';
-import type {InitialModule, JestModule, ModuleRegistry} from './moduleTypes';
+import type {JestModule, ModuleRegistry} from './moduleTypes';
 
 // Only expose ESM entries whose `namespace` is readable without throwing or
 // exposing TDZ values: `unlinked`/`linking` throw `ERR_VM_MODULE_STATUS`, and
@@ -58,47 +57,6 @@ export class ModuleRegistries {
 
   constructor(requireEsmResult: (module: VMModule) => unknown) {
     this.requireEsmResult = requireEsmResult;
-  }
-
-  getCjs(modulePath: string): InitialModule | Module | JestModule | undefined {
-    return (this.isolation?.cjs ?? this.moduleRegistry).get(modulePath);
-  }
-  setCjs(
-    modulePath: string,
-    module: InitialModule | Module | JestModule,
-  ): void {
-    (this.isolation?.cjs ?? this.moduleRegistry).set(modulePath, module);
-  }
-  hasCjs(modulePath: string): boolean {
-    return (this.isolation?.cjs ?? this.moduleRegistry).has(modulePath);
-  }
-  deleteCjs(modulePath: string): void {
-    (this.isolation?.cjs ?? this.moduleRegistry).delete(modulePath);
-  }
-
-  getInternalCjs(
-    modulePath: string,
-  ): InitialModule | Module | JestModule | undefined {
-    return this.internalModuleRegistry.get(modulePath);
-  }
-  setInternalCjs(
-    modulePath: string,
-    module: InitialModule | Module | JestModule,
-  ): void {
-    this.internalModuleRegistry.set(modulePath, module);
-  }
-  hasInternalCjs(modulePath: string): boolean {
-    return this.internalModuleRegistry.has(modulePath);
-  }
-
-  getEsm(key: string): JestModule | undefined {
-    return (this.isolation?.esm ?? this.esModuleRegistry).get(key);
-  }
-  setEsm(key: string, module: JestModule): void {
-    (this.isolation?.esm ?? this.esModuleRegistry).set(key, module);
-  }
-  hasEsm(key: string): boolean {
-    return (this.isolation?.esm ?? this.esModuleRegistry).has(key);
   }
 
   // Reads cascade: isolated overlay first, fall back to main. Writes go to
@@ -159,7 +117,7 @@ export class ModuleRegistries {
     return this.isolation?.mock ?? this.mockRegistry;
   }
 
-  isIsolated(): boolean {
+  private isIsolated(): boolean {
     return this.isolation !== null;
   }
 

--- a/packages/jest-runtime/src/internals/TestState.ts
+++ b/packages/jest-runtime/src/internals/TestState.ts
@@ -19,10 +19,6 @@ export class TestState {
     return this.state === 'tornDown';
   }
 
-  isBetweenTests(): boolean {
-    return this.state === 'betweenTests';
-  }
-
   /**
    * Logs a post-teardown reference error and sets `process.exitCode = 1` if
    * the runtime has been torn down. Returns `true` if the caller should bail

--- a/packages/jest-runtime/src/internals/V8CoverageCollector.ts
+++ b/packages/jest-runtime/src/internals/V8CoverageCollector.ts
@@ -97,7 +97,7 @@ export class V8CoverageCollector {
 
   reset(): void {
     this.sources?.clear();
-    this.result = [];
+    this.result = undefined;
     this.instrumenter = undefined;
   }
 }

--- a/packages/jest-runtime/src/internals/__tests__/MockState.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/MockState.test.ts
@@ -236,18 +236,16 @@ describe('MockState', () => {
       const factory = jest.fn(() => ({foo: 1}));
       mockState.setMock('/from', './a', factory);
       const moduleID = mockState.getCjsModuleId('/from', './a');
-      expect(mockState.hasCjsFactory(moduleID)).toBe(true);
       expect(mockState.getCjsFactory(moduleID)).toBe(factory);
       expect(mockState.shouldMockCjs('/from', './a').shouldMock).toBe(true);
     });
 
     test('setModuleMock registers an ESM factory', () => {
-      const {resolution} = makeResolution();
+      const {resolution, stub} = makeResolution();
       const mockState = new MockState(resolution, config({}));
       const factory = jest.fn();
       mockState.setModuleMock('/from', './a', factory);
-      const moduleID = mockState.getEsmModuleId('/from', './a');
-      expect(mockState.hasEsmFactory(moduleID)).toBe(true);
+      const moduleID = stub.getEsmModuleId(new Map(), '/from', './a');
       expect(mockState.getEsmFactory(moduleID)).toBe(factory);
     });
 
@@ -308,7 +306,7 @@ describe('MockState', () => {
 
   describe('clear', () => {
     test('drops factories, explicit marks, virtual marks, callbacks, caches', () => {
-      const {resolution} = makeResolution();
+      const {resolution, stub} = makeResolution();
       const mockState = new MockState(resolution, config({}));
       mockState.setMock('/from', './a', () => ({}));
       mockState.setModuleMock('/from', './b', () => ({}));
@@ -319,11 +317,11 @@ describe('MockState', () => {
       mockState.clear();
 
       expect(
-        mockState.hasCjsFactory(mockState.getCjsModuleId('/from', './a')),
-      ).toBe(false);
+        mockState.getCjsFactory(mockState.getCjsModuleId('/from', './a')),
+      ).toBeUndefined();
       expect(
-        mockState.hasEsmFactory(mockState.getEsmModuleId('/from', './b')),
-      ).toBe(false);
+        mockState.getEsmFactory(stub.getEsmModuleId(new Map(), '/from', './b')),
+      ).toBeUndefined();
       expect(mockState.hasMockMetadata('/path')).toBe(false);
       expect(mockState.notifyMockGenerated('/path', 'x')).toBe('x');
     });

--- a/packages/jest-runtime/src/internals/__tests__/ModuleRegistries.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/ModuleRegistries.test.ts
@@ -36,35 +36,35 @@ describe('ModuleRegistries', () => {
     test('reads/writes go to the main map outside isolation', () => {
       const registries = new ModuleRegistries(module => module.namespace);
       const cjsModule = fakeCjs('/a.js');
-      registries.setCjs('/a.js', cjsModule);
-      expect(registries.hasCjs('/a.js')).toBe(true);
-      expect(registries.getCjs('/a.js')).toBe(cjsModule);
+      registries.getActiveCjsRegistry().set('/a.js', cjsModule);
+      expect(registries.getActiveCjsRegistry().has('/a.js')).toBe(true);
+      expect(registries.getActiveCjsRegistry().get('/a.js')).toBe(cjsModule);
     });
 
     test('reads/writes go to the isolated overlay during isolation', () => {
       const registries = new ModuleRegistries(module => module.namespace);
       const main = fakeCjs('/a.js');
-      registries.setCjs('/a.js', main);
+      registries.getActiveCjsRegistry().set('/a.js', main);
 
       registries.enterIsolated('isolateModules');
-      expect(registries.hasCjs('/a.js')).toBe(false);
+      expect(registries.getActiveCjsRegistry().has('/a.js')).toBe(false);
 
       const isolated = fakeCjs('/a.js');
-      registries.setCjs('/a.js', isolated);
-      expect(registries.getCjs('/a.js')).toBe(isolated);
+      registries.getActiveCjsRegistry().set('/a.js', isolated);
+      expect(registries.getActiveCjsRegistry().get('/a.js')).toBe(isolated);
 
       registries.exitIsolated();
-      expect(registries.getCjs('/a.js')).toBe(main);
+      expect(registries.getActiveCjsRegistry().get('/a.js')).toBe(main);
     });
 
     test('internal CJS bypasses isolation', () => {
       const registries = new ModuleRegistries(module => module.namespace);
       const cjsModule = fakeCjs('/a.js');
-      registries.setInternalCjs('/a.js', cjsModule);
+      registries.getInternalCjsRegistry().set('/a.js', cjsModule);
 
       registries.enterIsolated('isolateModules');
-      expect(registries.hasInternalCjs('/a.js')).toBe(true);
-      expect(registries.getInternalCjs('/a.js')).toBe(cjsModule);
+      expect(registries.getInternalCjsRegistry().has('/a.js')).toBe(true);
+      expect(registries.getInternalCjsRegistry().get('/a.js')).toBe(cjsModule);
     });
   });
 
@@ -80,8 +80,8 @@ describe('ModuleRegistries', () => {
     test('exitIsolated empties the overlay maps before dropping the reference', () => {
       const registries = new ModuleRegistries(module => module.namespace);
       registries.enterIsolated('isolateModules');
-      registries.setCjs('/a.js', fakeCjs('/a.js'));
-      registries.setEsm('/b.mjs', fakeEsm() as JestModule);
+      registries.getActiveCjsRegistry().set('/a.js', fakeCjs('/a.js'));
+      registries.getActiveEsmRegistry().set('/b.mjs', fakeEsm() as JestModule);
       registries.setMock('id', 'mock');
 
       // Capture the live overlay maps so we can prove they are cleared, not
@@ -95,12 +95,12 @@ describe('ModuleRegistries', () => {
 
       registries.exitIsolated();
 
-      expect(registries.isIsolated()).toBe(false);
+      expect(registries.getActiveCjsRegistry()).not.toBe(cjsOverlay);
       expect(cjsOverlay.size).toBe(0);
       expect(esmOverlay.size).toBe(0);
       expect(mockOverlay.size).toBe(0);
 
-      expect(registries.hasCjs('/a.js')).toBe(false);
+      expect(registries.getActiveCjsRegistry().has('/a.js')).toBe(false);
       expect(registries.hasMock('id')).toBe(false);
     });
   });
@@ -148,38 +148,45 @@ describe('ModuleRegistries', () => {
     test('suspends the isolation overlay so the scratch load cannot leak', () => {
       const registries = new ModuleRegistries(module => module.namespace);
       registries.enterIsolated('isolateModules');
-      registries.setCjs('/isolated.js', fakeCjs('/isolated.js'));
+      const isolatedCjs = registries.getActiveCjsRegistry();
+      isolatedCjs.set('/isolated.js', fakeCjs('/isolated.js'));
 
       registries.withScratchRegistries(() => {
-        expect(registries.isIsolated()).toBe(false);
-        expect(registries.hasCjs('/isolated.js')).toBe(false);
-        registries.setCjs('/scratch.js', fakeCjs('/scratch.js'));
+        expect(registries.getActiveCjsRegistry()).not.toBe(isolatedCjs);
+        expect(registries.getActiveCjsRegistry().has('/isolated.js')).toBe(
+          false,
+        );
+        registries
+          .getActiveCjsRegistry()
+          .set('/scratch.js', fakeCjs('/scratch.js'));
       });
 
-      expect(registries.isIsolated()).toBe(true);
-      expect(registries.hasCjs('/isolated.js')).toBe(true);
-      expect(registries.hasCjs('/scratch.js')).toBe(false);
+      expect(registries.getActiveCjsRegistry()).toBe(isolatedCjs);
+      expect(registries.getActiveCjsRegistry().has('/isolated.js')).toBe(true);
+      expect(registries.getActiveCjsRegistry().has('/scratch.js')).toBe(false);
       registries.exitIsolated();
     });
 
     test('runs fn against fresh CJS + mock maps and restores originals', () => {
       const registries = new ModuleRegistries(module => module.namespace);
       const orig = fakeCjs('/a.js');
-      registries.setCjs('/a.js', orig);
+      registries.getActiveCjsRegistry().set('/a.js', orig);
       registries.setMock('id', 'orig-mock');
 
       const result = registries.withScratchRegistries(() => {
-        expect(registries.hasCjs('/a.js')).toBe(false);
+        expect(registries.getActiveCjsRegistry().has('/a.js')).toBe(false);
         expect(registries.hasMock('id')).toBe(false);
-        registries.setCjs('/scratch.js', fakeCjs('/scratch.js'));
+        registries
+          .getActiveCjsRegistry()
+          .set('/scratch.js', fakeCjs('/scratch.js'));
         registries.setMock('scratch-id', 'scratch-mock');
         return 'done';
       });
 
       expect(result).toBe('done');
-      expect(registries.getCjs('/a.js')).toBe(orig);
+      expect(registries.getActiveCjsRegistry().get('/a.js')).toBe(orig);
       expect(registries.getMock('id')).toBe('orig-mock');
-      expect(registries.hasCjs('/scratch.js')).toBe(false);
+      expect(registries.getActiveCjsRegistry().has('/scratch.js')).toBe(false);
       expect(registries.hasMock('scratch-id')).toBe(false);
     });
 
@@ -194,21 +201,21 @@ describe('ModuleRegistries', () => {
 
       registries.exitIsolated();
 
-      expect(registries.hasEsm('/scratch.mjs')).toBe(false);
+      expect(registries.getActiveEsmRegistry().has('/scratch.mjs')).toBe(false);
       expect(registries.hasModuleMock('scratch-id')).toBe(false);
     });
 
     test('restores originals even when fn throws', () => {
       const registries = new ModuleRegistries(module => module.namespace);
       const orig = fakeCjs('/a.js');
-      registries.setCjs('/a.js', orig);
+      registries.getActiveCjsRegistry().set('/a.js', orig);
 
       expect(() =>
         registries.withScratchRegistries(() => {
           throw new Error('boom');
         }),
       ).toThrow('boom');
-      expect(registries.getCjs('/a.js')).toBe(orig);
+      expect(registries.getActiveCjsRegistry().get('/a.js')).toBe(orig);
     });
   });
 
@@ -223,16 +230,18 @@ describe('ModuleRegistries', () => {
     test('exposes CJS modules and live ESM entries; hides Promise / unlinked', () => {
       const registries = new ModuleRegistries(module => module.namespace);
       const cjs = fakeCjs('/cjs.js');
-      registries.setCjs('/cjs.js', cjs);
+      registries.getActiveCjsRegistry().set('/cjs.js', cjs);
 
       const liveEsm = fakeEsm('evaluated');
-      registries.setEsm(LIVE_KEY, liveEsm as JestModule);
+      registries.getActiveEsmRegistry().set(LIVE_KEY, liveEsm as JestModule);
 
       const unlinkedEsm = fakeEsm('unlinked');
-      registries.setEsm(UNLINKED_KEY, unlinkedEsm as JestModule);
+      registries
+        .getActiveEsmRegistry()
+        .set(UNLINKED_KEY, unlinkedEsm as JestModule);
 
       const pending = Promise.resolve(fakeEsm()) as unknown as JestModule;
-      registries.setEsm(PENDING_KEY, pending);
+      registries.getActiveEsmRegistry().set(PENDING_KEY, pending);
 
       const cache = registries.getRequireCacheProxy();
 
@@ -268,8 +277,12 @@ describe('ModuleRegistries', () => {
 
     test('hides ESM instances that carry a query or fragment', () => {
       const registries = new ModuleRegistries(module => module.namespace);
-      registries.setEsm(`${LIVE_KEY}?q=1`, fakeEsm('evaluated') as JestModule);
-      registries.setEsm(`${LIVE_KEY}#frag`, fakeEsm('evaluated') as JestModule);
+      registries
+        .getActiveEsmRegistry()
+        .set(`${LIVE_KEY}?q=1`, fakeEsm('evaluated') as JestModule);
+      registries
+        .getActiveEsmRegistry()
+        .set(`${LIVE_KEY}#frag`, fakeEsm('evaluated') as JestModule);
 
       const cache = registries.getRequireCacheProxy();
       expect(Object.keys(cache)).toEqual([]);
@@ -280,7 +293,9 @@ describe('ModuleRegistries', () => {
 
     test('does not address file entries by URL string', () => {
       const registries = new ModuleRegistries(module => module.namespace);
-      registries.setEsm(LIVE_KEY, fakeEsm('evaluated') as JestModule);
+      registries
+        .getActiveEsmRegistry()
+        .set(LIVE_KEY, fakeEsm('evaluated') as JestModule);
 
       const cache = registries.getRequireCacheProxy();
       expect(cache['/live.mjs']).toBeDefined();
@@ -300,25 +315,25 @@ describe('ModuleRegistries', () => {
   describe('clear semantics', () => {
     test('clearForReset drops everything except internal CJS', () => {
       const registries = new ModuleRegistries(module => module.namespace);
-      registries.setCjs('/a.js', fakeCjs('/a.js'));
-      registries.setEsm('/b.mjs', fakeEsm() as JestModule);
+      registries.getActiveCjsRegistry().set('/a.js', fakeCjs('/a.js'));
+      registries.getActiveEsmRegistry().set('/b.mjs', fakeEsm() as JestModule);
       registries.setMock('id', 'mock');
       registries.setModuleMock('mid', fakeEsm() as JestModule);
-      registries.setInternalCjs('/i.js', fakeCjs('/i.js'));
+      registries.getInternalCjsRegistry().set('/i.js', fakeCjs('/i.js'));
 
       registries.clearForReset();
-      expect(registries.hasCjs('/a.js')).toBe(false);
-      expect(registries.hasEsm('/b.mjs')).toBe(false);
+      expect(registries.getActiveCjsRegistry().has('/a.js')).toBe(false);
+      expect(registries.getActiveEsmRegistry().has('/b.mjs')).toBe(false);
       expect(registries.hasMock('id')).toBe(false);
       expect(registries.hasModuleMock('mid')).toBe(false);
-      expect(registries.hasInternalCjs('/i.js')).toBe(true);
+      expect(registries.getInternalCjsRegistry().has('/i.js')).toBe(true);
     });
 
     test('clear drops everything including internal CJS', () => {
       const registries = new ModuleRegistries(module => module.namespace);
-      registries.setInternalCjs('/i.js', fakeCjs('/i.js'));
+      registries.getInternalCjsRegistry().set('/i.js', fakeCjs('/i.js'));
       registries.clear();
-      expect(registries.hasInternalCjs('/i.js')).toBe(false);
+      expect(registries.getInternalCjsRegistry().has('/i.js')).toBe(false);
     });
   });
 });

--- a/packages/jest-runtime/src/internals/__tests__/TestState.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/TestState.test.ts
@@ -11,21 +11,21 @@ describe('TestState', () => {
   test('starts in `loading`: not tornDown, not betweenTests', () => {
     const state = new TestState(jest.fn());
     expect(state.isTornDown()).toBe(false);
-    expect(state.isBetweenTests()).toBe(false);
+    expect(() => state.throwIfBetweenTests('msg')).not.toThrow();
   });
 
   test('enterTestCode does not register as betweenTests or tornDown', () => {
     const state = new TestState(jest.fn());
     state.enterTestCode();
-    expect(state.isBetweenTests()).toBe(false);
+    expect(() => state.throwIfBetweenTests('msg')).not.toThrow();
     expect(state.isTornDown()).toBe(false);
   });
 
-  test('leaveTestCode flips isBetweenTests', () => {
+  test('leaveTestCode enters the betweenTests window', () => {
     const state = new TestState(jest.fn());
     state.enterTestCode();
     state.leaveTestCode();
-    expect(state.isBetweenTests()).toBe(true);
+    expect(() => state.throwIfBetweenTests('msg')).toThrow(ReferenceError);
     expect(state.isTornDown()).toBe(false);
   });
 
@@ -35,7 +35,7 @@ describe('TestState', () => {
     state.leaveTestCode();
     state.teardown();
     expect(state.isTornDown()).toBe(true);
-    expect(state.isBetweenTests()).toBe(false);
+    expect(() => state.throwIfBetweenTests('msg')).not.toThrow();
   });
 
   test('bailIfTornDown returns false and does not log before teardown', () => {

--- a/packages/jest-runtime/src/internals/__tests__/V8CoverageCollector.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/V8CoverageCollector.test.ts
@@ -240,7 +240,7 @@ describe('V8CoverageCollector', () => {
     expect(collector.getResult()).toHaveLength(0);
   });
 
-  test('reset() drops sources and produces an empty result', async () => {
+  test('reset() drops the result, so getResult() reports it was never stopped', async () => {
     mockStopInstrumenting.mockResolvedValue([
       {functions: [], scriptId: '3', url: insideUrl},
     ]);
@@ -249,8 +249,11 @@ describe('V8CoverageCollector', () => {
     const collector = new V8CoverageCollector(v8Options, config, cache);
     await collector.start();
     await collector.stop();
+    expect(collector.getResult()).toHaveLength(1);
 
     collector.reset();
-    expect(collector.getResult()).toEqual([]);
+    expect(() => collector.getResult()).toThrow(
+      'You need to call `stopCollectingV8Coverage` first.',
+    );
   });
 });

--- a/packages/jest-runtime/src/internals/cjsRequire.ts
+++ b/packages/jest-runtime/src/internals/cjsRequire.ts
@@ -16,7 +16,7 @@ import type {ModuleRegistries} from './ModuleRegistries';
 import type {Resolution} from './Resolution';
 import type {TestMainModule} from './TestMainModule';
 import type {TransformOptions} from './TransformCache';
-import type {InitialModule} from './moduleTypes';
+import {type InitialModule, createInitialModule} from './moduleTypes';
 
 export const JEST_RESOLVE_OUTSIDE_VM_OPTION = Symbol.for(
   'jest-resolve-outside-vm-option',
@@ -98,18 +98,7 @@ export class RequireBuilder {
   }
 
   forFilename(filename: string): NodeJS.Require {
-    return this.for(
-      {
-        children: [],
-        exports: {},
-        filename,
-        id: filename,
-        isPreloading: false,
-        loaded: false,
-        path: path.dirname(filename),
-      },
-      undefined,
-    );
+    return this.for(createInitialModule(filename), undefined);
   }
 
   private resolve(

--- a/packages/jest-runtime/src/internals/moduleTypes.ts
+++ b/packages/jest-runtime/src/internals/moduleTypes.ts
@@ -5,6 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+import * as path from 'node:path';
 import type {SyntheticModule, Module as VMModule} from 'node:vm';
 import type {Module} from '@jest/environment';
 
@@ -14,3 +15,17 @@ export type ESModule = VMModule | SyntheticModule;
 export type JestModule = ESModule | Promise<ESModule>;
 export type InitialModule = Omit<Module, 'require' | 'parent' | 'paths'>;
 export type ModuleRegistry = Map<string, InitialModule | Module | JestModule>;
+
+// Registered before evaluation so a cycle reached mid-evaluation resolves to
+// the same object.
+export function createInitialModule(filename: string): InitialModule {
+  return {
+    children: [],
+    exports: {},
+    filename,
+    id: filename,
+    isPreloading: false,
+    loaded: false,
+    path: path.dirname(filename),
+  };
+}


### PR DESCRIPTION
## Summary

Dead code and duplication in `jest-runtime`, plus one latent bug the cleanup exposed. No behaviour change a user can see, except where noted below.

**Accessors nothing called.** `ModuleRegistries` carried ten per-key accessors — `getCjs`/`setCjs`/`hasCjs`/`deleteCjs`, the three `*InternalCjs`, and `getEsm`/`setEsm`/`hasEsm`. Production code reaches for `getActiveCjsRegistry()`, `getInternalCjsRegistry()` or `getActiveEsmRegistry()` and works the map directly; `deleteCjs` had no callers at all, tests included. `isIsolated` is read only by `enterIsolated`, so it is private now. Along with them: `MockState.getEsmModuleId`, `getEsmModuleIdAsync`, `hasCjsFactory`, `hasEsmFactory`, and `TestState.isBetweenTests`.

The `betweenTests` state stays live — `throwIfBetweenTests` reads it — and its tests assert through that instead. The registry tests moved to the active-registry maps, and the two `isIsolated()` assertions became registry-identity assertions, which pin more than the boolean did.

**A duplicated capability gate.** `esmIsAvailable` in `index.ts` tested `SourceTextModule` where `runtimeSupportsVmModules`, imported one line away, tests `SyntheticModule`. Node exposes both only under `--experimental-vm-modules`, so they answer the same question; the local copy is gone.

**Three shapes written more than once.** The sync ESM walker built a `SourceTextModule`, refused top-level await and resolved every static import in two places — inline in `walkGraphSync` and again in `buildSyncDataUriEntry`. That mechanical half was identical in both; everything specific to the module kind lived in `initializeImportMeta`, where a `data:` module gets no `filename` or `dirname`, is never `main`, and resolves only builtins and absolute URLs because its base URL is not hierarchical. Both now call `buildSyncSourceEntry` and pass their own callback.

The seven-field `InitialModule` literal in `CjsLoader`, `cjsRequire` and `index.ts` became `createInitialModule(filename)`. And `decodePossibleOutsideJestVmPath` compiled a fresh `RegExp` per call to strip a constant prefix.

**Two fixes that fall out of the above.**

`decodePossibleOutsideJestVmPath` guarded on the `jest-main:` protocol but stripped `jest-main://`. A specifier written without the authority delimiter entered the branch, missed the pattern, and came back out as a decoded filesystem path — so `jest-main:x.js` resolved to itself rather than being treated as an ordinary specifier. The guard now requires the delimiter. Nothing in Jest emits that shape (`createOutsideJestVmPath` always writes `//`), so this only matters to hand-written input.

`V8CoverageCollector.getResult` guards on `!this.result` to catch being called before `stopCollectingV8Coverage`, but `reset` assigned an empty array, which passes the guard. `getResult` after a reset reported zero coverage entries instead of reporting that nothing was collected. The field is cleared now, so the guard fires.

## Changelog

One **Fixes** entry, for the coverage-collector change:

> `[jest-runtime]` Report that no coverage was collected when `getAllV8CoverageInfoCopy` is called after `teardown`, instead of returning an empty result

`Runtime#teardown` and `Runtime#getAllV8CoverageInfoCopy` are both public, and `reset` runs from the former, so anything driving `jest-runtime` itself can reach the changed behaviour. The runner cannot: `runTest` reads the result before it awaits `tearDownEnv`. Public surface either way, so it gets an entry.

The `jest-main:` guard gets none. `createOutsideJestVmPath` always writes the `//`, so no path Jest produces takes the changed branch, and a hand-written `jest-main:x.js` failed to resolve before this change and still fails after it — only the error text differs.

The rest is deletions and extractions with no observable effect.

## Test plan

```
yarn jest packages/jest-runtime        # 357 passed
yarn jest-runtime-vm-modules           # 505 passed
yarn typecheck:tests                   # 0
yarn lint                              # 0
```

Plus `instrumentation.test.ts` and the five `e2e/__tests__/coverage*` suites, 34 passed, for the coverage-collector change.

Both fixes have a test that fails without them: the new `helpers.test.ts` returns `"jest-main:x.js"` against the old guard, and the reset case is a rewrite of a test that previously asserted the empty-array behaviour, so it reports `Received function did not throw` against the old source.

Deletions were checked for callers across `packages` and `e2e` rather than `jest-runtime` alone. Worth noting for reviewers that `yarn jest packages/jest-runtime` does not include the ESM suite — two of the removed accessors were still called from `runtime_esm_sync_graph.test.ts`, which only `yarn jest-runtime-vm-modules` runs.