### PR TITLE
perf(jest-snapshot): load babel, semver and synckit lazily

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,7 @@
 - `[jest-resolve]` Store the per-directory package-type lookup in the cache it reads, so it actually memoizes ([#16369](https://github.com/jestjs/jest/pull/16369))
 - `[jest-resolve, jest-runtime]` Cut repeated work on the resolution hot path: hoist the platform-extension list to construction, memoize `isCoreModule` and the options cache-key serialization, skip mapper preparation when no `moduleNameMapper` is configured, run each mapper regex once, and stop re-parsing `NODE_OPTIONS` on every default-resolver call ([#16371](https://github.com/jestjs/jest/pull/16371))
 - `[jest-runner, @jest/source-map]` Replace `source-map-support` with an implementation in `@jest/source-map` ([#16327](https://github.com/jestjs/jest/pull/16327))
+- `[jest-snapshot]` Load babel, semver and synckit lazily, so requiring the package (which every test process does through `@jest/expect`) no longer loads ~200 modules that only writing inline snapshots needs ([#16387](https://github.com/jestjs/jest/pull/16387))
 - `[jest-runtime]` Reduce per-require overhead: skip module ID resolution when no mock can apply, answer core modules before probing for a manual mock, share one `require.cache` proxy across modules, and cache empty files ([#16376](https://github.com/jestjs/jest/pull/16376))
 - `[@jest/source-map]` Deprecate `getCallsite` in favour of `SourceMapSupport#getCallsite` ([#16327](https://github.com/jestjs/jest/pull/16327))
 - `[jest-runtime]` Avoid magical `null` value in ESM loader ([#16160](https://github.com/jestjs/jest/pull/16160))

--- a/packages/jest-snapshot/src/InlineSnapshots.ts
+++ b/packages/jest-snapshot/src/InlineSnapshots.ts
@@ -11,8 +11,6 @@ import type {
   CustomParser as PrettierCustomParser,
   BuiltInParserName as PrettierParserName,
 } from 'prettier-v2';
-import * as semver from 'semver';
-import {createSyncFn} from 'synckit';
 import {isError} from 'jest-util';
 import type {InlineSnapshot} from './types';
 import {
@@ -30,6 +28,19 @@ type WorkerFn = (
 ) => string;
 
 const cachedPrettier = new Map<string, Prettier | WorkerFn>();
+
+// Required on demand: this module loads in every test process, but semver and
+// synckit are only needed when inline snapshots are written with prettier.
+// Resolving outside the VM keeps the require native, which also exempts it
+// from the runtime's between-tests require gate at snapshot-save time.
+function semverGte(version: string, other: string): boolean {
+  const semver = require(
+    require.resolve('semver', {
+      [Symbol.for('jest-resolve-outside-vm-option')]: true,
+    }),
+  ) as typeof import('semver');
+  return semver.gte(version, other);
+}
 
 export function saveInlineSnapshots(
   snapshots: Array<InlineSnapshot>,
@@ -52,7 +63,12 @@ export function saveInlineSnapshots(
 
       cachedPrettier.set(`module|${prettierPath}`, prettier);
 
-      if (semver.gte(prettier.version, '3.0.0')) {
+      if (semverGte(prettier.version, '3.0.0')) {
+        const {createSyncFn} = require(
+          require.resolve('synckit', {
+            [Symbol.for('jest-resolve-outside-vm-option')]: true,
+          }),
+        ) as typeof import('synckit');
         workerFn = createSyncFn(
           require.resolve(/*webpackIgnore: true*/ './worker'),
         ) as WorkerFn;
@@ -88,7 +104,7 @@ export function saveInlineSnapshots(
         sourceFileWithSnapshots,
         snapshotMatcherNames,
       );
-    } else if (prettier && semver.gte(prettier.version, '1.5.0')) {
+    } else if (prettier && semverGte(prettier.version, '1.5.0')) {
       newSourceFile = runPrettier(
         prettier,
         sourceFilePath,

--- a/packages/jest-snapshot/src/__tests__/utils.test.ts
+++ b/packages/jest-snapshot/src/__tests__/utils.test.ts
@@ -11,6 +11,7 @@ jest.mock('graceful-fs', () => ({
 }));
 
 import {strict as assert} from 'assert';
+import {spawnSync} from 'child_process';
 import {
   addExtraLineBreaks,
   deepMerge,
@@ -339,4 +340,36 @@ describe('DeepMerge with property matchers', () => {
     // Ensure original target is not modified
     expect(target).toStrictEqual(originalTarget);
   });
+});
+
+test('requiring the package does not load babel, semver or synckit', () => {
+  const {status, stdout, stderr} = spawnSync(
+    process.execPath,
+    [
+      '-e',
+      `
+        require(process.argv[1]);
+        const loaded = Object.keys(require.cache).map(key =>
+          key.replaceAll('\\\\', '/'),
+        );
+        console.log(
+          JSON.stringify(
+            loaded.filter(
+              key =>
+                key.includes('@babel/core') ||
+                key.includes('@babel/generator') ||
+                key.includes('/semver/') ||
+                key.includes('synckit'),
+            ),
+          ),
+        );
+      `,
+      require.resolve('jest-snapshot'),
+    ],
+    {encoding: 'utf8'},
+  );
+
+  expect(stderr).toBe('');
+  expect(status).toBe(0);
+  expect(JSON.parse(stdout)).toEqual([]);
 });

--- a/packages/jest-snapshot/src/utils.ts
+++ b/packages/jest-snapshot/src/utils.ts
@@ -169,27 +169,48 @@ const indent = (
     .join('\n');
 };
 
-const generate = (
-  require(
-    require.resolve('@babel/generator', {
+// Loading babel costs well over a hundred modules, and only writing inline
+// snapshots needs it, so defer it until the first snapshot is processed.
+function loadBabel() {
+  const generate = (
+    require(
+      require.resolve('@babel/generator', {
+        [Symbol.for('jest-resolve-outside-vm-option')]: true,
+      }),
+    ) as typeof import('@babel/generator')
+  ).default;
+
+  const {parseSync, types} = require(
+    require.resolve('@babel/core', {
       [Symbol.for('jest-resolve-outside-vm-option')]: true,
     }),
-  ) as typeof import('@babel/generator')
-).default;
+  ) as typeof import('@babel/core');
 
-const {parseSync, types} = require(
-  require.resolve('@babel/core', {
-    [Symbol.for('jest-resolve-outside-vm-option')]: true,
-  }),
-) as typeof import('@babel/core');
+  const {
+    isAwaitExpression,
+    templateElement,
+    templateLiteral,
+    traverseFast,
+    traverse,
+  } = types;
 
-const {
-  isAwaitExpression,
-  templateElement,
-  templateLiteral,
-  traverseFast,
-  traverse,
-} = types;
+  return {
+    generate,
+    isAwaitExpression,
+    parseSync,
+    templateElement,
+    templateLiteral,
+    traverse,
+    traverseFast,
+  };
+}
+
+let babel: ReturnType<typeof loadBabel> | undefined;
+
+function getBabel() {
+  babel ??= loadBabel();
+  return babel;
+}
 
 export const processInlineSnapshotsWithBabel = (
   snapshots: Array<InlineSnapshot>,
@@ -200,6 +221,7 @@ export const processInlineSnapshotsWithBabel = (
   sourceFile: string;
   sourceFileWithSnapshots: string;
 } => {
+  const {generate, parseSync} = getBabel();
   const sourceFile = fs.readFileSync(sourceFilePath, 'utf8');
 
   // TypeScript projects may not have a babel config; make sure they can be parsed anyway.
@@ -291,6 +313,8 @@ export const processPrettierAst = (
   snapshotMatcherNames: Array<string>,
   keepNode?: boolean,
 ): void => {
+  const {isAwaitExpression, templateElement, templateLiteral, traverse} =
+    getBabel();
   traverse(ast, (node: Node, ancestors: TraversalAncestors) => {
     if (node.type !== 'CallExpression') return;
 
@@ -377,6 +401,7 @@ const traverseAst = (
   ast: File | Program,
   snapshotMatcherNames: Array<string>,
 ) => {
+  const {templateElement, templateLiteral, traverseFast} = getBabel();
   const groupedSnapshots = groupSnapshotsByFrame(snapshots);
   const remainingSnapshots = new Set(snapshots.map(({snapshot}) => snapshot));
 


### PR DESCRIPTION
## Summary

`jest-snapshot` requires `@babel/generator` and `@babel/core` at module scope, so requiring the package loads 162 `@babel/*` modules. The package is in every test process's entry chain via `@jest/expect`, and `jest-runtime` imports it only for the `EXTENSION` string constant — so a user on `@swc/jest` or `ts-jest` with zero snapshots in the suite still pays for babel in every worker. The babel machinery is only needed when an inline snapshot is written.

The build's lazy-import transform never covered this. `jest-snapshot` is on `INLINE_REQUIRE_EXCLUDE_LIST` in `scripts/buildUtils.mjs`, and those packages get `babel-plugin-jest-native-globals` instead of the `@babel/plugin-transform-modules-commonjs` `lazy: true` option. Even with `lazy` on, the transform only defers ESM imports, and the babel block is a hand-written `require` that webpack's `IgnoreDynamicRequire` leaves verbatim. So every top-level runtime import in this package is eager.

This moves the two requires into a memoized `getBabel()` called by the three functions that use them (`processInlineSnapshotsWithBabel`, `processPrettierAst`, `traverseAst`), keeping the `require(require.resolve(..., {[Symbol.for('jest-resolve-outside-vm-option')]: true}))` shape verbatim so the modules still resolve outside the test VM. `semver` and `synckit` in `InlineSnapshots.ts` get the same treatment; they are only needed when inline snapshots are written through prettier.

Those two also gain the outside-vm marker, which the deferral makes load-bearing rather than cosmetic. Inline snapshots are saved between tests (`jestAdapter._addSnapshotData` → `SnapshotState.save`), and there `CjsLoader` refuses to execute a module — `throwIfBetweenTests`, "You are trying to `require` a file outside of the scope of the test code". Only paths marked for outside-vm resolution take the native-require bypass in `Runtime.requireInternalModule`. A plain `require('semver')` at that point fails every inline-snapshot write; this is the same mechanism the already-lazy prettier require in this file has always depended on.

Measured with a bare `node -e "require('jest-snapshot')"` against `build/`:

|  | modules loaded | require time |
| --- | --- | --- |
| `main` | 254 | ~90–160ms |
| this PR | 44 | ~50ms |

Zero `@babel/core`, `@babel/generator`, `semver` or `synckit` modules remain on that path. The four `@babel/code-frame` modules still loaded come from `jest-message-util`'s own import, which is out of scope here.

No behaviour change, and no change needed in `jest-runtime` — its `EXTENSION` import simply gets cheap.

## Test plan

A new test in `packages/jest-snapshot/src/__tests__/utils.test.ts` spawns a bare node process, requires the built package, and asserts that nothing matching `@babel/core`, `@babel/generator`, `semver` or `synckit` landed in `require.cache`.

`yarn jest packages/jest-snapshot` (184 tests) is green, as are all seven inline-snapshot e2e suites — `customInlineSnapshotMatchers`, `toMatchInlineSnapshot`, `toMatchInlineSnapshotCrlf`, `toMatchInlineSnapshotWithJSX`, `toMatchInlineSnapshotWithPretttier3`, `toMatchInlineSnapshotWithRetries`, `toThrowErrorMatchingInlineSnapshot` — plus `e2e/__tests__/snapshot.test.ts`. `yarn typecheck:tests` and `yarn lint` exit 0.

The between-tests gate above is what those e2e suites catch: with a plain lazy `require`, all 24 inline-snapshot tests fail with the scope `ReferenceError`. I also confirmed it on a standalone fixture outside the repo, where a fresh `toMatchInlineSnapshot()` is written and prettier-formatted, exercising the deferred `semver` and `synckit` path end to end.