### PR TITLE
fix(jest-resolve): keep the `node:` prefix through async resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@
 - `[jest-mock]` Remove the leftover own accessor descriptor when restoring a `spyOn` of an inherited getter or setter, so the instance keeps reflecting the prototype ([#16226](https://github.com/jestjs/jest/pull/16226))
 - `[jest-resolve]` Include `extensionsToTreatAsEsm` in the `shouldLoadAsEsm` cache key, so projects with different extension lists don't read each other's answers ([#16369](https://github.com/jestjs/jest/pull/16369))
 - `[jest-resolve]` Make `getModuleIDAsync` build and cache `data:` URI module IDs the same way as `getModuleID` ([#16370](https://github.com/jestjs/jest/pull/16370))
+- `[jest-resolve]` Keep the `node:` prefix when resolving a core module asynchronously, so a builtin that only exists prefixed (`node:sea`, `node:sqlite`, `node:test`, `node:test/reporters`) resolves instead of failing as a missing bare package ([#16388](https://github.com/jestjs/jest/pull/16388))
+- `[jest-resolve]` Look up manual mocks for `node:` protocol specifiers under the unprefixed name they are stored as ([#16388](https://github.com/jestjs/jest/pull/16388))
 - `[jest-resolve]` Keep virtual and ordinary mock module IDs isolated across test files ([#16296](https://github.com/jestjs/jest/pull/16296))
 - `[jest-resolve]` Guard missing `require.resolve.paths` ([#16052](https://github.com/jestjs/jest/pull/16052))
 - `[jest-resolve, jest-config, jest-runner]` Support a user resolver written as an ES module ([#16332](https://github.com/jestjs/jest/pull/16332))

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -32,7 +32,7 @@ Time:        <<REPLACED>>
 Ran all test suites matching native-esm-import-attributes.test.js."
 `;
 
-exports[`on node >=22.5.0 supports importing a builtin that only exists prefixed 1`] = `
+exports[`on node >=22.13.0 <23.0.0 || >=23.4.0 supports importing a builtin that only exists prefixed 1`] = `
 "Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total
 Snapshots:   0 total

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -32,6 +32,14 @@ Time:        <<REPLACED>>
 Ran all test suites matching native-esm-import-attributes.test.js."
 `;
 
+exports[`on node >=22.5.0 supports importing a builtin that only exists prefixed 1`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching native-esm-prefixed-builtin.test.js."
+`;
+
 exports[`properly handle re-exported native modules in ESM via CJS 1`] = `
 "Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total

--- a/e2e/__tests__/nativeEsm.test.ts
+++ b/e2e/__tests__/nativeEsm.test.ts
@@ -118,6 +118,24 @@ test('support re-exports from CJS of core module', () => {
   expect(exitCode).toBe(0);
 });
 
+// `node:sqlite` is the first builtin without a bare counterpart that is stable
+// enough to import here.
+onNodeVersions('>=22.5.0', () => {
+  test('supports importing a builtin that only exists prefixed', () => {
+    const {exitCode, stderr, stdout} = runJest(
+      DIR,
+      ['native-esm-prefixed-builtin.test.js'],
+      {nodeOptions: '--experimental-vm-modules --no-warnings'},
+    );
+
+    const {summary} = extractSummary(stderr);
+
+    expect(summary).toMatchSnapshot();
+    expect(stdout).toBe('');
+    expect(exitCode).toBe(0);
+  });
+});
+
 test('runs WebAssembly (Wasm) test with native ESM', () => {
   const {exitCode, stderr, stdout} = runJest(DIR, ['native-esm-wasm.test.js'], {
     nodeOptions: '--experimental-vm-modules --no-warnings',

--- a/e2e/__tests__/nativeEsm.test.ts
+++ b/e2e/__tests__/nativeEsm.test.ts
@@ -119,8 +119,10 @@ test('support re-exports from CJS of core module', () => {
 });
 
 // `node:sqlite` is the first builtin without a bare counterpart that is stable
-// enough to import here.
-onNodeVersions('>=22.5.0', () => {
+// enough to import here. The range is where it no longer needs
+// `--experimental-sqlite`, so the fixture exercises resolution rather than the
+// flag.
+onNodeVersions('>=22.13.0 <23.0.0 || >=23.4.0', () => {
   test('supports importing a builtin that only exists prefixed', () => {
     const {exitCode, stderr, stdout} = runJest(
       DIR,

--- a/e2e/native-esm/__tests__/native-esm-prefixed-builtin.test.js
+++ b/e2e/native-esm/__tests__/native-esm-prefixed-builtin.test.js
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+test('imports a builtin that only exists behind the node: prefix', async () => {
+  const sqlite = await import('node:sqlite');
+
+  expect(typeof sqlite.DatabaseSync).toBe('function');
+});

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -788,7 +788,7 @@ describe('core module specifiers', () => {
   });
 
   it.each(['fs', 'node:fs'])(
-    'resolves %s to the prefixed specifier Node itself reports',
+    'resolves %s to the incoming specifier, sync and async alike',
     async specifier => {
       expect(resolver.resolveModule(src, specifier)).toBe(specifier);
       await expect(resolver.resolveModuleAsync(src, specifier)).resolves.toBe(

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -776,6 +776,47 @@ describe('resolveModuleAsync', () => {
   });
 });
 
+describe('core module specifiers', () => {
+  let resolver: Resolver;
+  const src = require.resolve('../');
+
+  beforeEach(() => {
+    resolver = new Resolver(ModuleMap.create('/'), {
+      extensions: ['.js'],
+      hasCoreModules: true,
+    } as ResolverConfig);
+  });
+
+  it.each(['fs', 'node:fs'])(
+    'resolves %s to the prefixed specifier Node itself reports',
+    async specifier => {
+      expect(resolver.resolveModule(src, specifier)).toBe(specifier);
+      await expect(resolver.resolveModuleAsync(src, specifier)).resolves.toBe(
+        specifier,
+      );
+    },
+  );
+
+  // `node:test` has no bare counterpart, so stripping the prefix leaves a bare
+  // specifier that resolves to nothing - or to a userland package by that name.
+  it('keeps the prefix on a builtin that only exists prefixed', async () => {
+    expect(resolver.resolveModule(src, 'node:test')).toBe('node:test');
+    await expect(resolver.resolveModuleAsync(src, 'node:test')).resolves.toBe(
+      'node:test',
+    );
+  });
+
+  it.each(['fs', 'node:fs'])(
+    'reports no stub module for %s without a moduleNameMapper entry',
+    async specifier => {
+      expect(resolver.resolveStubModuleName(src, specifier)).toBeNull();
+      await expect(
+        resolver.resolveStubModuleNameAsync(src, specifier),
+      ).resolves.toBeNull();
+    },
+  );
+});
+
 describe('getMockModule', () => {
   it('is possible to use custom resolver to resolve deps inside mock modules with moduleNameMapper', () => {
     mockUserResolver.mockImplementation(() => 'module');
@@ -801,6 +842,25 @@ describe('getMockModule', () => {
       path.dirname(src),
     );
   });
+
+  it.each(['fs', 'node:fs'])(
+    'finds the manual mock stored under the unprefixed name for %s',
+    specifier => {
+      const mockPath = path.join('/root', '__mocks__', 'fs.js');
+      const moduleMap = ModuleMap.create('/');
+      jest
+        .spyOn(moduleMap, 'getMockModule')
+        .mockImplementation(name => (name === 'fs' ? mockPath : undefined));
+      const resolver = new Resolver(moduleMap, {
+        extensions: ['.js'],
+        hasCoreModules: true,
+      } as ResolverConfig);
+
+      expect(resolver.getMockModule(require.resolve('../'), specifier)).toBe(
+        mockPath,
+      );
+    },
+  );
 });
 
 describe('getMockModuleAsync', () => {
@@ -837,6 +897,25 @@ describe('getMockModuleAsync', () => {
       ['browser'],
     );
   });
+
+  it.each(['fs', 'node:fs'])(
+    'finds the manual mock stored under the unprefixed name for %s',
+    async specifier => {
+      const mockPath = path.join('/root', '__mocks__', 'fs.js');
+      const moduleMap = ModuleMap.create('/');
+      jest
+        .spyOn(moduleMap, 'getMockModule')
+        .mockImplementation(name => (name === 'fs' ? mockPath : undefined));
+      const resolver = new Resolver(moduleMap, {
+        extensions: ['.js'],
+        hasCoreModules: true,
+      } as ResolverConfig);
+
+      await expect(
+        resolver.getMockModuleAsync(require.resolve('../'), specifier, {}),
+      ).resolves.toBe(mockPath);
+    },
+  );
 });
 
 describe('getModuleID', () => {

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -565,16 +565,36 @@ export default class Resolver {
     name: string,
     options?: Pick<ResolveModuleConfig, 'conditions'>,
   ): string | null {
+    const mock = this._lookupManualMock(name);
+    if (mock) {
+      return mock;
+    }
+
+    const resolvedName = this.resolveStubModuleName(from, name, options);
+    if (resolvedName) {
+      return this._lookupManualMock(resolvedName);
+    }
+    return null;
+  }
+
+  // A colon is not a legal filename character on Windows, so a manual mock for
+  // `node:fs` lives at `__mocks__/fs`. Both specifier forms have to find it.
+  private _lookupManualMock(name: string): string | null {
     const mock = this._moduleMap.getMockModule(name);
     if (mock) {
       return mock;
-    } else {
-      const resolvedName = this.resolveStubModuleName(from, name, options);
-      if (resolvedName) {
-        return this._moduleMap.getMockModule(resolvedName) ?? null;
-      }
     }
-    return null;
+
+    if (!this.isCoreModule(name)) {
+      return null;
+    }
+
+    const normalized = this.normalizeCoreModuleSpecifier(name);
+    if (normalized === name) {
+      return null;
+    }
+
+    return this._moduleMap.getMockModule(normalized) ?? null;
   }
 
   async getMockModuleAsync(
@@ -582,18 +602,18 @@ export default class Resolver {
     name: string,
     options: Pick<ResolveModuleConfig, 'conditions'>,
   ): Promise<string | null> {
-    const mock = this._moduleMap.getMockModule(name);
+    const mock = this._lookupManualMock(name);
     if (mock) {
       return mock;
-    } else {
-      const resolvedName = await this.resolveStubModuleNameAsync(
-        from,
-        name,
-        options,
-      );
-      if (resolvedName) {
-        return this._moduleMap.getMockModule(resolvedName) ?? null;
-      }
+    }
+
+    const resolvedName = await this.resolveStubModuleNameAsync(
+      from,
+      name,
+      options,
+    );
+    if (resolvedName) {
+      return this._lookupManualMock(resolvedName);
     }
     return null;
   }
@@ -900,11 +920,6 @@ export default class Resolver {
     moduleName: string,
     options?: Pick<ResolveModuleConfig, 'conditions'>,
   ): Promise<string | null> {
-    // Strip node URL scheme from core modules imported using it
-    if (this.isCoreModule(moduleName)) {
-      return this.normalizeCoreModuleSpecifier(moduleName);
-    }
-
     const moduleNameMapper = this._options.moduleNameMapper;
     if (moduleNameMapper == null || moduleNameMapper.length === 0) {
       return null;


### PR DESCRIPTION
## Summary

Closes #16339 - adapted from @arronKler's work there, with the direction I settled on in review. The mock-lookup half of the diff and its tests are theirs, credited as co-author on the commit; the resolution fix below is the amended part.

`resolveStubModuleNameAsync` stripped the `node:` prefix off every core specifier before anything else ran, so the two `resolveModule` variants disagreed:

```js
resolver.resolveModule(from, "node:fs"); // 'node:fs'
await resolver.resolveModuleAsync(from, "node:fs"); // 'fs'
```

Four builtins have no bare counterpart:

```
> require('node:module').builtinModules.filter(m => m.startsWith('node:'))
[ 'node:sea', 'node:sqlite', 'node:test', 'node:test/reporters' ]
```

For those, stripping the prefix does not produce a builtin - it produces a bare specifier that resolves to nothing, or to a userland package of that name. On `main`:

```js
await import("node:sqlite");
// Cannot find module 'sqlite' from 'sqlite.test.js'
```

Node's own answer is the prefixed form (`import.meta.resolve('fs')` and `require.resolve('node:fs')` both report `node:fs`), so the sync side was already right and the async normalization goes. A builtin with no `moduleNameMapper` entry now returns `null` from both `resolveStubModuleName` variants, which is what they are for. `getModuleID` keeps stripping - a module ID is an opaque key and never gets resolved or required.

Manual mocks are a separate concern. A colon is not a legal filename character on Windows, so a mock for `node:fs` lives at `__mocks__/fs` and both specifier forms have to find it. `getMockModule` and `getMockModuleAsync` now normalize for that lookup alone, via a shared `_lookupManualMock`. That closes the resolver-level hole #16339 was opened for: after #14297, `Runtime` normalized before asking, but `Resolver.getMockModule(from, 'node:fs')` still missed a mock stored as `fs`.

## Test plan

The e2e fixture is the reported failure, gated on `>=22.5.0` for `node:sqlite`. Same fixture, before and after:

```
main         Cannot find module 'sqlite' from 'sqlite.test.js'   1 failed
this branch                                                      1 passed
```

Unit coverage in `resolve.test.ts` pins both variants together: `fs` and `node:fs` resolve to themselves, `node:test` keeps its prefix (chosen over `node:sqlite` so it runs on Node 18), both stub variants answer `null` for a builtin with no mapper entry, and both mock lookups find `__mocks__/fs` from either specifier form.

`packages/jest-resolve`, `packages/jest-runtime`, `jest-runtime-vm-modules` and the `nativeEsm` e2e suite are green locally.