### PR TITLE
fix(jest-resolve): apply `moduleNameMapper` to both spellings of core modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@
 - `[jest-resolve]` Make `getModuleIDAsync` build and cache `data:` URI module IDs the same way as `getModuleID` ([#16370](https://github.com/jestjs/jest/pull/16370))
 - `[jest-resolve]` Keep the `node:` prefix when resolving a core module asynchronously, so a builtin that only exists prefixed (`node:sea`, `node:sqlite`, `node:test`, `node:test/reporters`) resolves instead of failing as a missing bare package ([#16388](https://github.com/jestjs/jest/pull/16388))
 - `[jest-resolve]` Look up manual mocks for `node:` protocol specifiers under the unprefixed name they are stored as ([#16388](https://github.com/jestjs/jest/pull/16388))
+- `[jest-resolve]` Apply `moduleNameMapper` consistently to both spellings of core module specifiers (`fs` vs `node:fs`) ([#16390](https://github.com/jestjs/jest/pull/16390))
 - `[jest-resolve]` Keep virtual and ordinary mock module IDs isolated across test files ([#16296](https://github.com/jestjs/jest/pull/16296))
 - `[jest-resolve]` Guard missing `require.resolve.paths` ([#16052](https://github.com/jestjs/jest/pull/16052))
 - `[jest-resolve, jest-config, jest-runner]` Support a user resolver written as an ES module ([#16332](https://github.com/jestjs/jest/pull/16332))

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -866,6 +866,17 @@ describe('core module specifiers', () => {
         mappingResolver.resolveModuleAsync(src, 'node:test'),
       ).resolves.toBe('node:test');
     });
+
+    it('does not map a double prefixed specifier from a pattern targeting `node:fs`', async () => {
+      const mappingResolver = createMappingResolver(/^node:fs$/);
+
+      expect(
+        mappingResolver.resolveStubModuleName(src, 'node:node:fs'),
+      ).toBeNull();
+      await expect(
+        mappingResolver.resolveStubModuleNameAsync(src, 'node:node:fs'),
+      ).resolves.toBeNull();
+    });
   });
 });
 

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -815,6 +815,58 @@ describe('core module specifiers', () => {
       ).resolves.toBeNull();
     },
   );
+
+  describe('moduleNameMapper', () => {
+    const mappedModule = require.resolve('../__mocks__/mockJsDependency.js');
+
+    function createMappingResolver(regex: RegExp) {
+      return new Resolver(ModuleMap.create('/'), {
+        extensions: ['.js'],
+        hasCoreModules: true,
+        moduleNameMapper: [{moduleName: './__mocks__/mockJsDependency', regex}],
+      } as ResolverConfig);
+    }
+
+    it.each(['fs', 'node:fs'])(
+      'maps %s when the pattern targets the bare specifier',
+      async specifier => {
+        const mappingResolver = createMappingResolver(/^fs$/);
+
+        expect(mappingResolver.isCoreModule(specifier)).toBe(false);
+        expect(mappingResolver.resolveModule(src, specifier)).toBe(
+          mappedModule,
+        );
+        await expect(
+          mappingResolver.resolveModuleAsync(src, specifier),
+        ).resolves.toBe(mappedModule);
+      },
+    );
+
+    it.each(['fs', 'node:fs'])(
+      'maps %s when the pattern targets the prefixed specifier',
+      async specifier => {
+        const mappingResolver = createMappingResolver(/^node:fs$/);
+
+        expect(mappingResolver.isCoreModule(specifier)).toBe(false);
+        expect(mappingResolver.resolveModule(src, specifier)).toBe(
+          mappedModule,
+        );
+        await expect(
+          mappingResolver.resolveModuleAsync(src, specifier),
+        ).resolves.toBe(mappedModule);
+      },
+    );
+
+    it('does not map `node:test` from a pattern targeting bare `test`', async () => {
+      const mappingResolver = createMappingResolver(/^test$/);
+
+      expect(mappingResolver.isCoreModule('node:test')).toBe(true);
+      expect(mappingResolver.resolveModule(src, 'node:test')).toBe('node:test');
+      await expect(
+        mappingResolver.resolveModuleAsync(src, 'node:test'),
+      ).resolves.toBe('node:test');
+    });
+  });
 });
 
 describe('getMockModule', () => {

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -530,6 +530,10 @@ export default class Resolver {
   // (`node:test`, `node:sqlite`) have no bare spelling to test, and a bare
   // pattern like `^test$` must keep matching the userland package instead.
   private _specifierSpellings(specifier: string): Array<string> {
+    if (!isBuiltin(specifier)) {
+      return [specifier];
+    }
+
     if (specifier.startsWith('node:')) {
       const bareSpecifier = specifier.slice(5);
       return isBuiltin(bareSpecifier)
@@ -537,9 +541,7 @@ export default class Resolver {
         : [specifier];
     }
 
-    return isBuiltin(specifier)
-      ? [specifier, `node:${specifier}`]
-      : [specifier];
+    return [specifier, `node:${specifier}`];
   }
 
   private _matchModuleNameMapper(

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -518,7 +518,42 @@ export default class Resolver {
       return false;
     }
 
-    return moduleNameMapper.some(({regex}) => regex.test(moduleName));
+    const spellings = this._specifierSpellings(moduleName);
+
+    return moduleNameMapper.some(({regex}) =>
+      spellings.some(specifier => regex.test(specifier)),
+    );
+  }
+
+  // Node treats `fs` and `node:fs` as the same module, so a pattern written
+  // for either spelling has to catch both. Builtins that only exist prefixed
+  // (`node:test`, `node:sqlite`) have no bare spelling to test, and a bare
+  // pattern like `^test$` must keep matching the userland package instead.
+  private _specifierSpellings(specifier: string): Array<string> {
+    if (specifier.startsWith('node:')) {
+      const bareSpecifier = specifier.slice(5);
+      return isBuiltin(bareSpecifier)
+        ? [specifier, bareSpecifier]
+        : [specifier];
+    }
+
+    return isBuiltin(specifier)
+      ? [specifier, `node:${specifier}`]
+      : [specifier];
+  }
+
+  private _matchModuleNameMapper(
+    regex: RegExp,
+    moduleName: string,
+  ): RegExpMatchArray | null {
+    for (const specifier of this._specifierSpellings(moduleName)) {
+      const matches = specifier.match(regex);
+      if (matches) {
+        return matches;
+      }
+    }
+
+    return null;
   }
 
   isCoreModule(moduleName: string): boolean {
@@ -872,7 +907,7 @@ export default class Resolver {
     const resolver = this._options.resolver;
 
     for (const {moduleName: mappedModuleName, regex} of moduleNameMapper) {
-      const matches = moduleName.match(regex);
+      const matches = this._matchModuleNameMapper(regex, moduleName);
       if (matches) {
         // Note: once a moduleNameMapper matches the name, it must result
         // in a module, or else an error is thrown.
@@ -934,7 +969,7 @@ export default class Resolver {
     const resolver = this._options.resolver;
 
     for (const {moduleName: mappedModuleName, regex} of moduleNameMapper) {
-      const matches = moduleName.match(regex);
+      const matches = this._matchModuleNameMapper(regex, moduleName);
       if (matches) {
         // Note: once a moduleNameMapper matches the name, it must result
         // in a module, or else an error is thrown.


### PR DESCRIPTION
## Summary

Node treats `fs` and `node:fs` as one module, but `moduleNameMapper` did not. With

```json
{"moduleNameMapper": {"^fs$": "<rootDir>/fake-fs.js"}}
```

`require('fs')` returned the mapped module while `require('node:fs')` returned the real builtin. `import` behaved the same way, since it goes through the same `isCoreModule` path. Mapping `^node:fs$` had the mirror problem.

Two places in `jest-resolve` tested the mapper patterns against the raw specifier only:

- `isCoreModule` reported `node:fs` as a core module, so resolution short-circuited to the builtin before any mapper ran.
- `resolveStubModuleName` applies the mapping, and `^fs$` does not match the string `node:fs` there either.

Both now test the alternate spelling as well. A prefixed specifier only gains its bare form when that bare form is itself a builtin, so `node:test`, `node:sqlite` and `node:sea` keep matching prefixed patterns only, and a user who maps `^test$` still targets the npm package of that name.

## Test plan

New cases in `packages/jest-resolve/src/__tests__/resolve.test.ts`, sync and async, for both `resolveModule` and `isCoreModule`:

- a `^fs$` pattern catches `fs` and `node:fs`
- a `^node:fs$` pattern catches `fs` and `node:fs`
- a `^test$` pattern catches neither spelling of `node:test`

The first two fail on `main`; the third passes before and after and guards the prefix-only builtins.

```
yarn jest packages/jest-resolve   # 139 passed
yarn jest packages/jest-runtime   # 363 passed
yarn jest-runtime-vm-modules      # 524 passed
yarn typecheck:tests && yarn lint && yarn check-changelog
```

Also ran a fixture by hand — both mapper directions against both spellings, in CJS through `require` and in ESM through `import`, all resolve to the mock.

One thing worth knowing, unchanged by this PR: in an ESM project, mapping `fs` itself now also reaches the `graceful-fs` that Jest's own modules load inside the sandbox, and that crashes on the frozen module namespace. `main` fails the same way when the pattern is `^fs$`, so the hazard predates this change — it just becomes reachable from the second spelling too.