### PR TITLE
fix(jest-runtime): link a top-level-await graph in the sync walk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,7 @@
 - `[jest-runtime]` Key ES modules by full URL, so query and fragment suffixes create the same module instances as Node and show up in `import.meta.url` ([#16375](https://github.com/jestjs/jest/pull/16375))
 - `[jest-runtime]` Share modules between overlapping graphs when a CommonJS module `require()`s an ES module mid-load, instead of evaluating shared dependencies twice ([#16375](https://github.com/jestjs/jest/pull/16375))
 - `[jest-runtime]` Throw `ERR_REQUIRE_CYCLE_MODULE` like Node when a CommonJS module `require()`s an ES module that is still being loaded, instead of evaluating the module a second time ([#16366](https://github.com/jestjs/jest/pull/16366))
+- `[jest-runtime]` Build, link and instantiate a graph containing top-level await in the synchronous walk, deferring only its evaluation, so two concurrent `import()`s of modules that share a dependency no longer fail with `request for '<dep>' can not be resolved on module '<importer>' that is not linked` ([#16394](https://github.com/jestjs/jest/pull/16394))
 - `[jest-runtime]` Key builtin modules in the ESM registry by one canonical specifier ([#16341](https://github.com/jestjs/jest/pull/16341))
 - `[jest-runtime]` `import.meta.resolve()` for a builtin uses its `node:` specifier ([#16341](https://github.com/jestjs/jest/pull/16341))
 - `[jest-runtime]` Fall back to native ESM when a `.js` file contains ESM syntax but has no `"type":"module"` marker ([#16152](https://github.com/jestjs/jest/pull/16152))

--- a/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
+++ b/e2e/__tests__/__snapshots__/nativeEsm.test.ts.snap
@@ -40,6 +40,14 @@ Time:        <<REPLACED>>
 Ran all test suites matching native-esm-prefixed-builtin.test.js."
 `;
 
+exports[`on node >=24.9.0 supports concurrent imports sharing a top-level await dependency 1`] = `
+"Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        <<REPLACED>>
+Ran all test suites matching native-esm-tla-concurrent.test.js."
+`;
+
 exports[`properly handle re-exported native modules in ESM via CJS 1`] = `
 "Test Suites: 1 passed, 1 total
 Tests:       1 passed, 1 total

--- a/e2e/__tests__/nativeEsm.test.ts
+++ b/e2e/__tests__/nativeEsm.test.ts
@@ -87,6 +87,29 @@ test('supports top-level await', () => {
   expect(exitCode).toBe(0);
 });
 
+// v24.9 is where `SourceTextModule.prototype.hasAsyncGraph` lands, and with it
+// the sync walk this fix is in. Older versions take the legacy async path,
+// where each concurrent `import()` drives `link()` over the shared dependency
+// itself and the second one still fails to instantiate. A version range rather
+// than the `hasSyncEsm` probe: `--experimental-vm-modules` is passed to the
+// child, so `SourceTextModule` is undefined out here and the probe would read
+// false on every version.
+onNodeVersions('>=24.9.0', () => {
+  test('supports concurrent imports sharing a top-level await dependency', () => {
+    const {exitCode, stderr, stdout} = runJest(
+      DIR,
+      ['native-esm-tla-concurrent.test.js'],
+      {nodeOptions: '--experimental-vm-modules --no-warnings'},
+    );
+
+    const {summary} = extractSummary(stderr);
+
+    expect(summary).toMatchSnapshot();
+    expect(stdout).toBe('');
+    expect(exitCode).toBe(0);
+  });
+});
+
 // minimum version supported by discord.js is 16.9, but they use syntax from 16.11
 onNodeVersions('>=16.11.0', () => {
   test('support re-exports from CJS of dual packages', () => {

--- a/e2e/native-esm/__tests__/native-esm-tla-concurrent.test.js
+++ b/e2e/native-esm/__tests__/native-esm-tla-concurrent.test.js
@@ -1,0 +1,18 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+test('imports modules sharing a top-level-await dependency concurrently', async () => {
+  const [a, b] = await Promise.all([
+    import('../tlaImporterA.js'),
+    import('../tlaImporterB.js'),
+  ]);
+
+  expect(a.fromA).toBe('a');
+  expect(b.fromB).toBe('b');
+  expect(a.value).toBe('tla-value');
+  expect(b.value).toBe('tla-value');
+});

--- a/e2e/native-esm/tlaImporterA.js
+++ b/e2e/native-esm/tlaImporterA.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export {value} from './tlaReexport.js';
+export const fromA = 'a';

--- a/e2e/native-esm/tlaImporterB.js
+++ b/e2e/native-esm/tlaImporterB.js
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export {value} from './tlaReexport.js';
+export const fromB = 'b';

--- a/e2e/native-esm/tlaReexport.js
+++ b/e2e/native-esm/tlaReexport.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export {value} from './tlaValue.js';

--- a/e2e/native-esm/tlaValue.js
+++ b/e2e/native-esm/tlaValue.js
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const value = await Promise.resolve('tla-value');

--- a/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
@@ -75,6 +75,25 @@ describe('Runtime sync ESM graph', () => {
     },
   );
 
+  // `testWithSyncEsm`, not `testWithVmEsm`: the fix is in the sync walk, and
+  // Node only exposes that from v24.9. Older versions take the legacy async
+  // path, where each concurrent `import()` drives `link()` over the shared
+  // dependency itself and the second one still fails to instantiate.
+  testWithSyncEsm(
+    'links a shared top-level-await dependency once across concurrent imports',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const [a, b] = (await Promise.all([
+        runtime.unstable_importModule(FROM, './concurrent-tla-a.mjs'),
+        runtime.unstable_importModule(FROM, './concurrent-tla-b.mjs'),
+      ])) as Array<any>;
+      expect(a.namespace.fromA).toBe('a');
+      expect(b.namespace.fromB).toBe('b');
+      expect(a.namespace.value).toBe('tla-value');
+      expect(b.namespace.value).toBe('tla-value');
+    },
+  );
+
   testWithVmEsm('resolves data: URI specifiers in the sync graph', async () => {
     const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
     const m = (await runtime.unstable_importModule(

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/concurrent-tla-a.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/concurrent-tla-a.mjs
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export {value} from './import-tla.mjs';
+export const fromA = 'a';

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/concurrent-tla-b.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/concurrent-tla-b.mjs
@@ -1,0 +1,9 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export {value} from './import-tla.mjs';
+export const fromB = 'b';

--- a/packages/jest-runtime/src/internals/EsmLoader.ts
+++ b/packages/jest-runtime/src/internals/EsmLoader.ts
@@ -960,16 +960,17 @@ export class EsmLoader {
               : `a dependency uses top-level await (${culprit})`,
           );
         }
+        // Only `evaluate()` is async here - the graph is already built, linked
+        // and instantiated. Commit it before handing the caller back to the
+        // async path so that path evaluates these modules, rather than
+        // rebuilding an unlinked copy of the graph that a concurrent
+        // `import()` sharing a dependency would race to `link()`.
+        this.commitScratchEntries(scratch, registry);
         return LOAD_ASYNC;
       }
     }
 
-    for (const entry of scratch.values()) {
-      if (entry.kind === 'prelinked' && entry.excludeFromRegistry) continue;
-      if (!registry.has(entry.cacheKey)) {
-        registry.set(entry.cacheKey, entry.module);
-      }
-    }
+    this.commitScratchEntries(scratch, registry);
 
     rootModule.evaluate().catch(noop);
 
@@ -995,6 +996,18 @@ export class EsmLoader {
     return hasEsmSyntax(
       this.transformCache.transform(pending.modulePath, undefined),
     );
+  }
+
+  private commitScratchEntries(
+    scratch: Map<string, ScratchEntry>,
+    registry: Map<string, JestModule>,
+  ): void {
+    for (const entry of scratch.values()) {
+      if (entry.kind === 'prelinked' && entry.excludeFromRegistry) continue;
+      if (!registry.has(entry.cacheKey)) {
+        registry.set(entry.cacheKey, entry.module);
+      }
+    }
   }
 
   // A module sits in the registry linked-but-unevaluated when an earlier walk
@@ -1720,14 +1733,21 @@ export class EsmLoader {
       initializeImportMeta,
     }) as VMModuleWithAsyncGraph;
 
+    // Only `require()` has to stop for top-level await. A `sync-preferred`
+    // walk keeps going: building, linking and instantiating a top-level-await
+    // graph are all synchronous, and only `evaluate()` has to be awaited - the
+    // `moduleHasAsyncGraph` check after `instantiate()` is where that walk
+    // hands the caller a `'linked'` module. Bailing here instead would send
+    // the graph down the legacy async path, where two concurrent `import()`s
+    // of modules that share a dependency both drive `link()` over it and the
+    // second one throws `can not be resolved on module ... that is not
+    // linked`.
     if (
+      mode === 'sync-required' &&
       typeof module.hasTopLevelAwait === 'function' &&
       module.hasTopLevelAwait()
     ) {
-      if (mode === 'sync-required') {
-        throw makeRequireAsyncError(identifier, 'top-level await');
-      }
-      return LOAD_ASYNC;
+      throw makeRequireAsyncError(identifier, 'top-level await');
     }
 
     // If we got here without `moduleRequests`, the capability gate is lying.

--- a/packages/jest-runtime/src/internals/__tests__/EsmLoader.test.ts
+++ b/packages/jest-runtime/src/internals/__tests__/EsmLoader.test.ts
@@ -211,6 +211,31 @@ describe('EsmLoader.tryLoadGraphSync', () => {
     },
   );
 
+  testWithSyncEsm(
+    'sync-required mode throws ERR_REQUIRE_ASYNC_MODULE for a linked TLA graph',
+    () => {
+      // Committing a top-level-await graph opened this branch up: the registry
+      // can now hold such a graph `'linked'`, which is where it sits between
+      // the `'sync-preferred'` walk that linked it and the async path
+      // evaluating it. A `require()` landing in that window reaches
+      // `evaluateLinkedModule`, whose async-graph check throws - not the throw
+      // in the walk that the other require-of-TLA tests reach.
+      const {esmRegistry, loader, stubs} = makeLoader();
+      stubs.transformCache.transform.mockReturnValue(
+        'export const x = await Promise.resolve(1);',
+      );
+
+      expect(loader.tryLoadGraphSync('/m.mjs', '', 'sync-preferred')).toBe(
+        LOAD_ASYNC,
+      );
+      expect(esmRegistry.get(M_KEY)).toMatchObject({status: 'linked'});
+
+      expect(() =>
+        loader.tryLoadGraphSync('/m.mjs', '', 'sync-required'),
+      ).toThrow(expect.objectContaining({code: 'ERR_REQUIRE_ASYNC_MODULE'}));
+    },
+  );
+
   testWithLinkedSyntheticModule(
     'rethrows when tryCommitSynthetic finds an errored entry (CJS-as-ESM)',
     async () => {


### PR DESCRIPTION
## Summary

Fixes #16393. Two concurrent `import()`s of modules that share a dependency throw
`request for '<dep>' can not be resolved on module '<importer>' that is not linked` when anything in
the shared graph uses top-level await. Without the top-level await the same graph imports fine, so
the trigger is the async graph rather than the concurrency alone.

`buildSyncSourceEntry` bailed to `LOAD_ASYNC` as soon as a module reported `hasTopLevelAwait()`,
before the walk resolved that module's dependencies — so the walk built nothing, committed nothing,
and every root fell through to the legacy async path. There each concurrent `import()` gets its own
unlinked `SourceTextModule` and calls `module.link()`. Node's `[kLink]` only awaits a dependency
that is `'unlinked'`, so the second walk sees the shared dependency at `'linking'`, does not wait,
and hands V8 a `ModuleWrap` with no resolved requests.

Only `evaluate()` actually has to be async for a top-level-await graph. Building, linking and
instantiating it are all synchronous, and `walkGraphSync` already does exactly that before its
`moduleHasAsyncGraph` check. So this:

- drops the early bail, leaving `require()`'s `ERR_REQUIRE_ASYNC_MODULE` throw in place — a
  `sync-preferred` walk now runs to completion and links the whole graph in one turn;
- commits the scratch entries on the `moduleHasAsyncGraph` branch, so the caller's async path
  evaluates the modules the walk just linked instead of rebuilding an unlinked copy of the graph.

Concurrency is then no longer observable: the linking happens inside one synchronous walk, and every
later root either adopts the committed `'linked'` modules or finds them in the registry.

The trade-off is that a top-level-await graph is now built synchronously, like every other graph.
That blocks the event loop for the duration of the walk where the previous path did not — the same
cost the sync core already pays for graphs without top-level await.

This is the failure #11434 reported. #16063 fixed the underlying concurrency by moving linking into
the sync core; graphs with top-level await were the ones still routed around it.

## Test plan

`runtime_esm_sync_graph.test.ts` gets a case importing two modules that share a top-level-await
dependency concurrently, and `e2e/native-esm` gets the same shape driven through a real dynamic
`import()`. Both fail on `main` with the reported error and pass here:

```console
$ yarn jest packages/jest-runtime/src/__tests__/runtime_esm_sync_graph
  ● Runtime sync ESM graph › links a shared top-level-await dependency once across concurrent imports
    request for './with-tla.mjs' can not be resolved on module '…/import-tla.mjs' that is not linked
  Tests: 1 failed, 107 passed, 108 total          # before
  Tests: 108 passed, 108 total                    # after
```

Full suite, `yarn jest --config jest.config.ci.mjs`, before and after on the same machine:

```
Test Suites: 36 failed, 2 skipped, 514 passed, 550 of 552 total
Tests:       1003 failed, 69 skipped, 5381 passed, 6453 total
Snapshots:   1155 failed, 701 passed, 1856 total
```

Identical in both runs, to the test. (Those failures are a local baseline — `jest.config.ci.mjs` run
off CI on macOS — not something this change moves.)

Also checked against the codebase this was found in: 30 Mongoose models sharing one config module
with a top-level `await`, loaded with `Promise.all` under `--experimental-vm-modules`. Throws on
30.4.2, passes with this patch applied to the published build.

> 🤖 _Investigated and patched with Claude Code (Anthropic's CLI)._
