### PR TITLE
chore(deps): update glob to v13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,7 +117,7 @@
 - `[docs]` Note deprecation of `react-test-renderer` in React Native tutorial and `pretty-format` README ([#16294](https://github.com/jestjs/jest/pull/16294))
 - `[docs]` Use `@testing-library/react-native` in the React Native tutorial instead of the deprecated `react-test-renderer` ([#16318](https://github.com/jestjs/jest/pull/16318))
 - `[babel-jest, @jest/transform]` Update `babel-plugin-istanbul` to v8 ([#16049](https://github.com/jestjs/jest/pull/16049))
-- `[jest-config, @jest/reporters, jest-runtime]` Update `glob` to v13, so no published package resolves a `minimatch` that depends on a `brace-expansion` affected by [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) ([#16397](https://github.com/jestjs/jest/pull/16397))
+- `[jest-config, @jest/reporters, jest-runtime]` Update `glob` to v13 ([#16397](https://github.com/jestjs/jest/pull/16397))
 - `[jest-haste-map]` Refactor massive class into multiple files ([#16180](https://github.com/jestjs/jest/pull/16180))
 - `[jest-haste-map]` Drop `walker` dependency; replace hand-rolled directory recursion in the JS crawler and watcher startup with `fdir` ([#16187](https://github.com/jestjs/jest/pull/16187))
 - `[jest-haste-map]` Reuse cached metadata for files whose haste name is a known duplicate, instead of re-reading and re-parsing them on every startup ([#16351](https://github.com/jestjs/jest/pull/16351))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@
 - `[docs]` Note deprecation of `react-test-renderer` in React Native tutorial and `pretty-format` README ([#16294](https://github.com/jestjs/jest/pull/16294))
 - `[docs]` Use `@testing-library/react-native` in the React Native tutorial instead of the deprecated `react-test-renderer` ([#16318](https://github.com/jestjs/jest/pull/16318))
 - `[babel-jest, @jest/transform]` Update `babel-plugin-istanbul` to v8 ([#16049](https://github.com/jestjs/jest/pull/16049))
+- `[jest-config, @jest/reporters, jest-runtime]` Update `glob` to v13, so no published package resolves a `minimatch` that depends on a `brace-expansion` affected by [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg) ([#16397](https://github.com/jestjs/jest/pull/16397))
 - `[jest-haste-map]` Refactor massive class into multiple files ([#16180](https://github.com/jestjs/jest/pull/16180))
 - `[jest-haste-map]` Drop `walker` dependency; replace hand-rolled directory recursion in the JS crawler and watcher startup with `fdir` ([#16187](https://github.com/jestjs/jest/pull/16187))
 - `[jest-haste-map]` Reuse cached metadata for files whose haste name is a known duplicate, instead of re-reading and re-parsing them on every startup ([#16351](https://github.com/jestjs/jest/pull/16351))

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint-plugin-unicorn": "^64.0.0",
     "execa": "^5.1.1",
     "find-process": "^2.0.0",
-    "glob": "^10.5.0",
+    "glob": "^13.0.6",
     "globals": "^17.0.0",
     "graceful-fs": "^4.2.11",
     "isbinaryfile": "^6.0.0",

--- a/packages/jest-config/package.json
+++ b/packages/jest-config/package.json
@@ -44,7 +44,7 @@
     "chalk": "^4.1.2",
     "ci-info": "^4.2.0",
     "deepmerge": "^4.3.1",
-    "glob": "^10.5.0",
+    "glob": "^13.0.6",
     "graceful-fs": "^4.2.11",
     "jest-circus": "workspace:*",
     "jest-docblock": "workspace:*",

--- a/packages/jest-reporters/package.json
+++ b/packages/jest-reporters/package.json
@@ -24,7 +24,7 @@
     "chalk": "^4.1.2",
     "collect-v8-coverage": "^1.0.2",
     "exit-x": "^0.2.2",
-    "glob": "^10.5.0",
+    "glob": "^13.0.6",
     "graceful-fs": "^4.2.11",
     "istanbul-lib-coverage": "^3.0.0",
     "istanbul-lib-instrument": "^6.0.0",

--- a/packages/jest-runtime/package.json
+++ b/packages/jest-runtime/package.json
@@ -31,7 +31,7 @@
     "cjs-module-lexer": "^2.2.0",
     "collect-v8-coverage": "^1.0.2",
     "es-module-lexer": "^2.1.0",
-    "glob": "^10.5.0",
+    "glob": "^13.0.6",
     "graceful-fs": "^4.2.11",
     "jest-haste-map": "workspace:*",
     "jest-message-util": "workspace:*",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4431,7 +4431,7 @@ __metadata:
     eslint-plugin-unicorn: "npm:^64.0.0"
     execa: "npm:^5.1.1"
     find-process: "npm:^2.0.0"
-    glob: "npm:^10.5.0"
+    glob: "npm:^13.0.6"
     globals: "npm:^17.0.0"
     graceful-fs: "npm:^4.2.11"
     isbinaryfile: "npm:^6.0.0"
@@ -4525,7 +4525,7 @@ __metadata:
     chalk: "npm:^4.1.2"
     collect-v8-coverage: "npm:^1.0.2"
     exit-x: "npm:^0.2.2"
-    glob: "npm:^10.5.0"
+    glob: "npm:^13.0.6"
     graceful-fs: "npm:^4.2.11"
     istanbul-lib-coverage: "npm:^3.0.0"
     istanbul-lib-instrument: "npm:^6.0.0"
@@ -12904,7 +12904,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^10.3.7, glob@npm:^10.4.1, glob@npm:^10.5.0":
+"glob@npm:^10.3.7, glob@npm:^10.4.1":
   version: 10.5.0
   resolution: "glob@npm:10.5.0"
   dependencies:
@@ -12936,7 +12936,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^13.0.0":
+"glob@npm:^13.0.0, glob@npm:^13.0.6":
   version: 13.0.6
   resolution: "glob@npm:13.0.6"
   dependencies:
@@ -14687,7 +14687,7 @@ __metadata:
     deepmerge: "npm:^4.3.1"
     esbuild: "npm:^0.28.0"
     esbuild-register: "npm:^3.6.0"
-    glob: "npm:^10.5.0"
+    glob: "npm:^13.0.6"
     graceful-fs: "npm:^4.2.11"
     jest-circus: "workspace:*"
     jest-docblock: "workspace:*"
@@ -15027,7 +15027,7 @@ __metadata:
     cjs-module-lexer: "npm:^2.2.0"
     collect-v8-coverage: "npm:^1.0.2"
     es-module-lexer: "npm:^2.1.0"
-    glob: "npm:^10.5.0"
+    glob: "npm:^13.0.6"
     graceful-fs: "npm:^4.2.11"
     jest-environment-node: "workspace:*"
     jest-haste-map: "workspace:*"


### PR DESCRIPTION
## Summary

Fixes #16291.

`jest-config`, `@jest/reporters` and `jest-runtime` all sit on `glob@^10.5.0`, which brings in `minimatch@9` and through it `brace-expansion@2.1.2` — the range flagged by [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg). So installing Jest puts the advisory in your audit output even though nothing here calls the affected code path.

Moving to `glob@^13.0.6` resolves `minimatch@10.2.6` → `brace-expansion@5.0.9`, which is past the fix.

Two things that seemed worth checking before doing it:

**Why `^13.0.6` specifically.** glob 13.0.0 through 13.0.5 declare `"node": "20 || >=22"`, which doesn't fit Jest's `^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0`. 13.0.6 put Node 18 back (`"18 || 20 || >=22"`), so it's the first v13 that's usable here without touching supported engines. That went out in February, I think it just went unnoticed — it's the only reason this bump wasn't already possible.

**Nothing changed in the API.** Everything between v10 and v13 is CLI-side: v11 dropped old Node, v12 removed the unsafe `--shell` flag, v13 moved the CLI out to a separate `glob-bin` package. The programmatic surface is untouched, and the call sites here only use `glob()` / `glob.sync()` with `windowsPathsNoEscape`, `cwd`, `absolute` and `ignore`, all of which behave the same.

I bumped the root devDependency too, so the repo builds against one glob rather than two. After this, `yarn why glob` shows glob 10 only under `rimraf@5` and `test-exclude@7` (via `babel-plugin-istanbul`) — both dev-only, so no published Jest package reaches it any more.

The lockfile barely moves, incidentally: `glob@13.0.6` was already in the tree for `@npmcli/*` and `cacache`, so this just points our own deps at a copy that was already being installed.

## Test plan

There's no behaviour change to write a test for, so this is about proving the existing glob-dependent paths still work. All six call sites in the repo are covered:

`packages/jest-config/src/normalize.ts`, `packages/jest-reporters/src/CoverageReporter.ts`, `packages/jest-runtime/src/helpers.ts`:

```
yarn jest packages/jest-config/src/__tests__/normalize.test.ts \
  packages/jest-reporters/src/__tests__/CoverageReporter.test.js \
  packages/jest-runtime/src/__tests__/
→ Test Suites: 1 skipped, 26 passed, 26 of 27 total
  Tests: 179 skipped, 330 passed, 509 total
  Snapshots: 38 passed
```

Plus the e2e that actually exercises coverage threshold globs and project globs end to end:

```
yarn jest e2e/__tests__/coverageThreshold.test.ts e2e/__tests__/multiProjectRunner.test.ts \
  e2e/__tests__/selectProjects.test.ts e2e/__tests__/coverageReport.test.ts
→ Test Suites: 4 passed
  Tests: 2 skipped, 74 passed, 76 total
  Snapshots: 33 passed
```

`scripts/buildTs.mjs`, `scripts/bundleTs.mjs`, `scripts/cleanE2e.mjs` via `yarn build:js && yarn build:ts && yarn bundle:ts`, all successful, and `node scripts/cleanE2e.mjs` exits 0 with its `ignore` list respected.

And the chain itself:

```
glob 13.0.6 engines {"node":"18 || 20 || >=22"}
minimatch 10.2.6
brace-expansion 5.0.9
```
