### PR TITLE
docs: explain `globalsCleanup` and point the JEST-01 warning at it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Chore & Maintenance
 
+- `[jest-util]` Name the `testEnvironmentOptions.globalsCleanup` option and link the docs from the `JEST-01` deprecation warning, and document the option's modes ([#16404](https://github.com/jestjs/jest/pull/16404))
+
 ## 30.5.0
 
 ### Features

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -2122,8 +2122,33 @@ Test environment options that will be passed to the `testEnvironment`. The relev
 
 When using the `node` environment, you can configure various options that are passed to `runInContext`. These options include:
 
-- **`globalsCleanup`** (**'on'** | **'soft'** | **'off'**): Controls cleanup of global variables between tests. Default: `'soft'`.
+- **`globalsCleanup`** (**'on'** | **'soft'** | **'off'**): Controls cleanup of global variables between test files. Default: `'soft'`. See [Cleaning up globals](#cleaning-up-globals) below.
 - All the options listed in the [vm.runInContext](https://nodejs.org/api/vm.html#scriptrunincontextcontextifiedobject-options) documentation
+
+##### Cleaning up globals
+
+When a test file finishes, Jest deletes the properties of the objects that the file put on the global scope. This releases memory that a worker would otherwise hold until it exits.
+
+The `globalsCleanup` option controls that deletion:
+
+- `'on'`: the properties are deleted. Code that reads such a property after its test file finished gets `undefined`.
+- `'soft'` (default): the properties are kept, but reading or writing one emits a `JEST-01` deprecation warning. Nothing breaks, so this is a migration path towards `'on'`.
+- `'off'`: no cleanup and no warning.
+
+If you see a `JEST-01` warning, some code holds on to a global past the end of the test file that created it. Either release that reference, or turn the cleanup off:
+
+```js
+const {defineConfig} = require('jest');
+
+module.exports = defineConfig({
+  testEnvironment: 'node',
+  testEnvironmentOptions: {
+    globalsCleanup: 'off',
+  },
+});
+```
+
+The mode is set once per worker process, by the first test environment that worker creates. A per-file `@jest-environment-options` docblock therefore only takes effect if that file is the first one the worker runs.
 
 #### JSDOM Environment Options
 

--- a/packages/jest-environment-node/CLAUDE.md
+++ b/packages/jest-environment-node/CLAUDE.md
@@ -19,7 +19,7 @@ Key members every environment must provide:
 
 **`GlobalProxy`**: The `global` object is a `Proxy`. Before `envSetupCompleted()` (end of constructor), property writes are not tracked. After it, newly assigned globals are tracked and deleted at teardown. This is how `jest-runtime`'s own globals survive while user-created globals are cleaned up.
 
-**`globalsCleanup`**: `testEnvironmentOptions.globalsCleanup: 'soft' | 'aggressive'`. `'soft'` (default) deletes only post-setup properties. `'aggressive'` also clears pre-setup properties.
+**`globalsCleanup`**: `testEnvironmentOptions.globalsCleanup: 'on' | 'soft' | 'off'`. `'on'` deletes the properties of tracked globals at teardown, `'soft'` (default) instead wraps them in accessors that emit a `JEST-01` deprecation warning, `'off'` disables cleanup. The mode lives on the worker's `globalThis` under `Symbol.for('$$jest-deletion-mode')` and is initialized once — the first environment created in a worker wins, and a conflicting later value only logs a warning.
 
 **Storage globals** (`localStorage`/`sessionStorage`): Installed as passthrough getters on Node 25+ to avoid warnings and prevent tracking by `GlobalProxy`.
 

--- a/packages/jest-util/src/garbage-collection-utils.ts
+++ b/packages/jest-util/src/garbage-collection-utils.ts
@@ -205,7 +205,9 @@ function emitAccessWarning(obj: object, key: string | symbol): void {
         'Jest deletes objects that were set on the global scope between test files to reduce memory leaks.',
         'Currently it only "soft" deletes them and emits this warning if those objects were accessed after their deletion.',
         'In future versions of Jest, this behavior will change to "on", which will likely fail tests.',
-        'You can change the behavior in your test configuration now to reduce memory usage.',
+        'Set `testEnvironmentOptions.globalsCleanup` to "on" to delete them now and reduce memory usage,',
+        'or to "off" to disable the cleanup and this warning.',
+        'See https://jestjs.io/docs/configuration#testenvironmentoptions-object',
       ]
         .map(s => `  ${s}`)
         .join('\n'),

--- a/website/versioned_docs/version-29.7/Configuration.md
+++ b/website/versioned_docs/version-29.7/Configuration.md
@@ -2029,7 +2029,6 @@ Test environment options that will be passed to the `testEnvironment`. The relev
 
 When using the `node` environment, you can configure various options that are passed to `runInContext`. These options include:
 
-- **`globalsCleanupMode`** (**'on'** | **'soft'** | **'off'**): Controls cleanup of global variables between tests. Default: `'soft'`.
 - All the options listed in the [vm.runInContext](https://nodejs.org/api/vm.html#scriptrunincontextcontextifiedobject-options) documentation
 
 #### JSDOM Environment Options

--- a/website/versioned_docs/version-30.0/Configuration.md
+++ b/website/versioned_docs/version-30.0/Configuration.md
@@ -2055,8 +2055,29 @@ Test environment options that will be passed to the `testEnvironment`. The relev
 
 When using the `node` environment, you can configure various options that are passed to `runInContext`. These options include:
 
-- **`globalsCleanup`** (**'on'** | **'soft'** | **'off'**): Controls cleanup of global variables between tests. Default: `'soft'`.
+- **`globalsCleanup`** (**'on'** | **'soft'** | **'off'**): Controls cleanup of global variables between test files. Default: `'soft'`. See [Cleaning up globals](#cleaning-up-globals) below.
 - All the options listed in the [vm.runInContext](https://nodejs.org/api/vm.html#scriptrunincontextcontextifiedobject-options) documentation
+
+##### Cleaning up globals
+
+When a test file finishes, Jest deletes the properties of the objects that the file put on the global scope. This releases memory that a worker would otherwise hold until it exits.
+
+The `globalsCleanup` option controls that deletion:
+
+- `'on'`: the properties are deleted. Code that reads such a property after its test file finished gets `undefined`.
+- `'soft'` (default): the properties are kept, but reading or writing one emits a `JEST-01` deprecation warning. Nothing breaks, so this is a migration path towards `'on'`.
+- `'off'`: no cleanup and no warning.
+
+If you see a `JEST-01` warning, some code holds on to a global past the end of the test file that created it. Either release that reference, or turn the cleanup off:
+
+```js
+module.exports = {
+  testEnvironment: 'node',
+  testEnvironmentOptions: {
+    globalsCleanup: 'off',
+  },
+};
+```
 
 #### JSDOM Environment Options
 

--- a/website/versioned_docs/version-30.4/Configuration.md
+++ b/website/versioned_docs/version-30.4/Configuration.md
@@ -2109,8 +2109,33 @@ Test environment options that will be passed to the `testEnvironment`. The relev
 
 When using the `node` environment, you can configure various options that are passed to `runInContext`. These options include:
 
-- **`globalsCleanup`** (**'on'** | **'soft'** | **'off'**): Controls cleanup of global variables between tests. Default: `'soft'`.
+- **`globalsCleanup`** (**'on'** | **'soft'** | **'off'**): Controls cleanup of global variables between test files. Default: `'soft'`. See [Cleaning up globals](#cleaning-up-globals) below.
 - All the options listed in the [vm.runInContext](https://nodejs.org/api/vm.html#scriptrunincontextcontextifiedobject-options) documentation
+
+##### Cleaning up globals
+
+When a test file finishes, Jest deletes the properties of the objects that the file put on the global scope. This releases memory that a worker would otherwise hold until it exits.
+
+The `globalsCleanup` option controls that deletion:
+
+- `'on'`: the properties are deleted. Code that reads such a property after its test file finished gets `undefined`.
+- `'soft'` (default): the properties are kept, but reading or writing one emits a `JEST-01` deprecation warning. Nothing breaks, so this is a migration path towards `'on'`.
+- `'off'`: no cleanup and no warning.
+
+If you see a `JEST-01` warning, some code holds on to a global past the end of the test file that created it. Either release that reference, or turn the cleanup off:
+
+```js
+const {defineConfig} = require('jest');
+
+module.exports = defineConfig({
+  testEnvironment: 'node',
+  testEnvironmentOptions: {
+    globalsCleanup: 'off',
+  },
+});
+```
+
+The mode is set once per worker process, by the first test environment that worker creates. A per-file `@jest-environment-options` docblock therefore only takes effect if that file is the first one the worker runs.
 
 #### JSDOM Environment Options
 

--- a/website/versioned_docs/version-30.5/Configuration.md
+++ b/website/versioned_docs/version-30.5/Configuration.md
@@ -2122,8 +2122,33 @@ Test environment options that will be passed to the `testEnvironment`. The relev
 
 When using the `node` environment, you can configure various options that are passed to `runInContext`. These options include:
 
-- **`globalsCleanup`** (**'on'** | **'soft'** | **'off'**): Controls cleanup of global variables between tests. Default: `'soft'`.
+- **`globalsCleanup`** (**'on'** | **'soft'** | **'off'**): Controls cleanup of global variables between test files. Default: `'soft'`. See [Cleaning up globals](#cleaning-up-globals) below.
 - All the options listed in the [vm.runInContext](https://nodejs.org/api/vm.html#scriptrunincontextcontextifiedobject-options) documentation
+
+##### Cleaning up globals
+
+When a test file finishes, Jest deletes the properties of the objects that the file put on the global scope. This releases memory that a worker would otherwise hold until it exits.
+
+The `globalsCleanup` option controls that deletion:
+
+- `'on'`: the properties are deleted. Code that reads such a property after its test file finished gets `undefined`.
+- `'soft'` (default): the properties are kept, but reading or writing one emits a `JEST-01` deprecation warning. Nothing breaks, so this is a migration path towards `'on'`.
+- `'off'`: no cleanup and no warning.
+
+If you see a `JEST-01` warning, some code holds on to a global past the end of the test file that created it. Either release that reference, or turn the cleanup off:
+
+```js
+const {defineConfig} = require('jest');
+
+module.exports = defineConfig({
+  testEnvironment: 'node',
+  testEnvironmentOptions: {
+    globalsCleanup: 'off',
+  },
+});
+```
+
+The mode is set once per worker process, by the first test environment that worker creates. A per-file `@jest-environment-options` docblock therefore only takes effect if that file is the first one the worker runs.
 
 #### JSDOM Environment Options
 


### PR DESCRIPTION
## Summary

Closes #16403.

The `JEST-01` deprecation warning ends with "You can change the behavior in your test configuration now to reduce memory usage" without saying which option to change, and `testEnvironmentOptions.globalsCleanup` had exactly one bullet in the docs. Searching the docs for `JEST-01` found nothing at all.

- The warning now names the option, says what each of `'on'` and `'off'` does, and links to the config docs.
- `docs/Configuration.md` gets a "Cleaning up globals" section under the node environment options: what the cleanup does, the three modes, and a config snippet for turning it off. It mentions `JEST-01` so the warning is searchable. It also notes that the mode is set once per worker process by the first environment created there, so a per-file `@jest-environment-options` docblock only wins if that file runs first.
- The same section is added to the `30.0`, `30.4` and `30.5` versioned docs. The `30.0` copy drops the docblock note - the mode became a global symbol in #15684, first released in 30.0.1 - and uses a plain `module.exports` since `defineConfig` does not exist in that snapshot.
- The `29.7` versioned docs listed a `globalsCleanupMode` option. The feature landed in 30, and carried that name only before the 30.0.0 release, so it never existed in 29 under either name. Removed.
- Corrected the stale `'soft' | 'aggressive'` values in `packages/jest-environment-node/CLAUDE.md`.

One thing this does not fix: `globalsCleanup` is only read by `jest-environment-node`. `jest-environment-jsdom` never initializes the garbage collection utils and never deletes globals at teardown, so a jsdom user who somehow hits `JEST-01` has nothing to set. I could not construct such a case - the reported `[Window]` is consistent with a JSDOM instance stored on a node environment global - so I left it alone pending a repro.

## Test plan

`yarn jest packages/jest-util/src/__tests__/garbage-collection-utils.test.ts` passes (7/7). No behavior changes, only the warning's `detail` string and markdown.

`yarn lint` and `yarn check-changelog` are clean.