### PR TITLE
feat(config): add tsx support for config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-config]` Add support for `tsx` as a config loader via `/* @jest-config-loader tsx */` docblock ([#16406](https://github.com/jestjs/jest/pull/16406))
+
 ### Fixes
 
 ### Chore & Maintenance

--- a/packages/jest-config/src/__tests__/readConfigFileAndSetRootDir.test.ts
+++ b/packages/jest-config/src/__tests__/readConfigFileAndSetRootDir.test.ts
@@ -211,24 +211,57 @@ describe('readConfigFileAndSetRootDir', () => {
       });
     });
   });
-});
+  onNodeVersions('^24', () => {
+    describe('TypeScript file', () => {
+      test('reaches into 2nd loadout by TS loader if specified in docblock', async () => {
+        jest
+          .mocked(requireOrImportModule)
+          .mockRejectedValueOnce(new Error('Module not found'));
+        jest.mocked(fs.readFileSync).mockReturnValue(`
+          /** @jest-config-loader tsx */
+          export { testTimeout: 1_000 }
+        `);
+        const rootDir = path.resolve('some', 'path', 'to');
+        await expect(
+          readConfigFileAndSetRootDir(path.join(rootDir, 'jest.config.ts')),
+        ).rejects.toThrow(
+          /Module not found\n.*'tsx' is not a valid TypeScript configuration loader./,
+        );
+      });
 
-onNodeVersions('^24', () => {
-  describe('TypeScript file', () => {
-    test('reaches into 2nd loadout by TS loader if specified in docblock', async () => {
-      jest
-        .mocked(requireOrImportModule)
-        .mockRejectedValueOnce(new Error('Module not found'));
-      jest.mocked(fs.readFileSync).mockReturnValue(`
-        /** @jest-config-loader tsx */
-        export { testTimeout: 1_000 }
-      `);
-      const rootDir = path.resolve('some', 'path', 'to');
-      await expect(
-        readConfigFileAndSetRootDir(path.join(rootDir, 'jest.config.ts')),
-      ).rejects.toThrow(
-        /Module not found\n.*'tsx' is not a valid TypeScript configuration loader./,
-      );
+      test('loads config using tsx loader when specified in docblock', async () => {
+        jest
+          .mocked(requireOrImportModule)
+          .mockRejectedValueOnce(new Error('Module not found'));
+        jest.mocked(fs.readFileSync).mockReturnValue(`
+          /** @jest-config-loader tsx */
+          export const testTimeout = 1_000;
+        `);
+
+        const rootDir = path.resolve('some', 'path', 'to');
+        const config = await readConfigFileAndSetRootDir(
+          path.join(rootDir, 'jest.config.ts'),
+        );
+
+        expect(config).toEqual({rootDir, testTimeout: 1000});
+      });
+
+      test('rejects when tsx loader is specified but not installed', async () => {
+        jest
+          .mocked(requireOrImportModule)
+          .mockRejectedValueOnce(new Error('Module not found'));
+        jest.mocked(fs.readFileSync).mockReturnValue(`
+          /** @jest-config-loader tsx */
+          export const testTimeout = 1_000;
+        `);
+
+        const rootDir = path.resolve('some', 'path', 'to');
+        await expect(
+          readConfigFileAndSetRootDir(path.join(rootDir, 'jest.config.ts')),
+        ).rejects.toThrow(
+          /'tsx' is not a valid TypeScript configuration loader./,
+        );
+      });
     });
   });
 });

--- a/packages/jest-config/src/readConfigFileAndSetRootDir.ts
+++ b/packages/jest-config/src/readConfigFileAndSetRootDir.ts
@@ -23,7 +23,7 @@ import {
 interface TsLoader {
   enabled: (bool: boolean) => void;
 }
-type TsLoaderModule = 'ts-node' | 'esbuild-register';
+type TsLoaderModule = 'ts-node' | 'esbuild-register' | 'tsx';
 // Read the configuration and set its `rootDir`
 // 1. If it's a `package.json` file, we look into its "jest" property
 // 2. If it's a `jest.config.ts`/`jest.config.cts`/`jest.config.mts` file,
@@ -212,6 +212,23 @@ async function registerTsLoader(loader: TsLoaderModule): Promise<TsLoader> {
       const tsLoader = await import(
         /* webpackIgnore: true */ 'esbuild-register/dist/node'
       );
+
+      let instance: {unregister: () => void} | undefined;
+
+      return {
+        enabled: (bool: boolean) => {
+          if (bool) {
+            instance = tsLoader.register({
+              target: `node${process.version.slice(1)}`,
+              ...extraTSLoaderOptions,
+            });
+          } else {
+            instance?.unregister();
+          }
+        },
+      };
+    } else if (loader === 'tsx') {
+      const tsLoader = await import(/* webpackIgnore: true */ 'tsx');
 
       let instance: {unregister: () => void} | undefined;
 


### PR DESCRIPTION
Adds support for using \	sx\ as a config loader via \@jest-config-loader tsx\ docblock.

**Changes:**
- Add \	sx\ to \TsLoaderModule\ type
- Add \	sx\ registration in \egisterTsLoader\ (mirrors \esbuild-register\)
- Add tests for success + error cases

Closes #13143