### PR TITLE
fix(pretty-format): print the primitive wrapped by Number, String, Boolean and BigInt objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `[jest-core, jest-haste-map, jest-transform]` Keep `require('../package.json')` external when bundling, so `jest --version` and the transform and haste-map cache keys report the released version instead of the previous one ([#16422](https://github.com/jestjs/jest/pull/16422))
 - `[jest-each]` Escape a table row's keys before building the `$variable` interpolation `RegExp`, so a column name such as `count(*)` no longer fails the whole table with `Invalid regular expression`, and a `.` or `|` in a column name is matched literally ([#16345](https://github.com/jestjs/jest/pull/16345))
+- `[pretty-format]` Print `Number`, `String`, `Boolean` and `BigInt` wrapper objects with the primitive they wrap, so a failing assertion shows `[Number: 1]` instead of `Number {}` ([#16409](https://github.com/jestjs/jest/pull/16409))
 
 ### Chore & Maintenance
 

--- a/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
+++ b/packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap
@@ -2016,10 +2016,10 @@ Expected: <g>{"asymmetricMatch": [Function asymmetricMatch]}</>
 Received: <r>"Eve"</>
 `;
 
-exports[`.toEqual() {pass: false} expect("abc").toEqual({"0": "a", "1": "b", "2": "c"}) 1`] = `
+exports[`.toEqual() {pass: false} expect("abc").toEqual([String: "abc"]) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <g>{"0": "a", "1": "b", "2": "c"}</>
+Expected: <g>[String: "abc"]</>
 Received: <r>"abc"</>
 `;
 
@@ -2157,11 +2157,25 @@ exports[`.toEqual() {pass: false} expect([97, 98, 99]).toEqual([97, 98, 100]) 1`
 <d>  ]</>
 `;
 
-exports[`.toEqual() {pass: false} expect({"0": "a", "1": "b", "2": "c"}).toEqual("abc") 1`] = `
+exports[`.toEqual() {pass: false} expect([Number: 0]).toEqual([Number: 1]) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: <g>[Number: 1]</>
+Received: <r>[Number: 0]</>
+`;
+
+exports[`.toEqual() {pass: false} expect([Number: 0]).toEqual(0) 1`] = `
+<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: <g>0</>
+Received: <r>[Number: 0]</>
+`;
+
+exports[`.toEqual() {pass: false} expect([String: "abc"]).toEqual("abc") 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
 Expected: <g>"abc"</>
-Received: <r>{"0": "a", "1": "b", "2": "c"}</>
+Received: <r>[String: "abc"]</>
 `;
 
 exports[`.toEqual() {pass: false} expect({"a": 1, "b": 2}).toEqual(ObjectContaining {"a": 2}) 1`] = `
@@ -2328,20 +2342,6 @@ exports[`.toEqual() {pass: false} expect({"target": {"nodeType": 1, "value": "a"
 <d>  }</>
 `;
 
-exports[`.toEqual() {pass: false} expect({}).toEqual({}) 1`] = `
-<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
-
-Expected: <g>{}</>
-Received: serializes to the same string
-`;
-
-exports[`.toEqual() {pass: false} expect({}).toEqual(0) 1`] = `
-<d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
-
-Expected: <g>0</>
-Received: <r>{}</>
-`;
-
 exports[`.toEqual() {pass: false} expect({Symbol(foo): 1, Symbol(bar): 2}).toEqual({Symbol(foo): Any<Number>, Symbol(bar): 1}) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
@@ -2355,10 +2355,10 @@ exports[`.toEqual() {pass: false} expect({Symbol(foo): 1, Symbol(bar): 2}).toEqu
 <d>  }</>
 `;
 
-exports[`.toEqual() {pass: false} expect(0).toEqual({}) 1`] = `
+exports[`.toEqual() {pass: false} expect(0).toEqual([Number: 0]) 1`] = `
 <d>expect(</><r>received</><d>).</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
-Expected: <g>{}</>
+Expected: <g>[Number: 0]</>
 Received: <r>0</>
 `;
 
@@ -2836,6 +2836,13 @@ Expected: not <g>Any<Function></>
 Received:     <r>[Function anonymous]</>
 `;
 
+exports[`.toEqual() {pass: true} expect([Number: 0]).not.toEqual([Number: 0]) 1`] = `
+<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
+
+Expected: not <g>[Number: 0]</>
+
+`;
+
 exports[`.toEqual() {pass: true} expect({"a": 1, "b": [Function b], "c": true}).not.toEqual({"a": 1, "b": Any<Function>, "c": Anything}) 1`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
@@ -2907,13 +2914,6 @@ Expected: not <g>{"nodeName": "div", "nodeType": 1}</>
 `;
 
 exports[`.toEqual() {pass: true} expect({}).not.toEqual({}) 1`] = `
-<d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
-
-Expected: not <g>{}</>
-
-`;
-
-exports[`.toEqual() {pass: true} expect({}).not.toEqual({}) 2`] = `
 <d>expect(</><r>received</><d>).</>not<d>.</>toEqual<d>(</><g>expected</><d>) // deep equality</>
 
 Expected: not <g>{}</>

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.ts
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.ts
@@ -314,6 +314,16 @@ describe('prettyFormat()', () => {
   });
   /* eslint-enable no-new-wrappers, unicorn/new-for-builtins */
 
+  it.each(['Number', 'String', 'Boolean', 'BigInt'])(
+    'prints a plain object tagged as %s as an object',
+    tag => {
+      const val = {[Symbol.toStringTag]: tag};
+      expect(prettyFormat(val)).toBe(
+        `Object {\n  Symbol(Symbol.toStringTag): "${tag}",\n}`,
+      );
+    },
+  );
+
   it('prints a date', () => {
     const val = new Date(10e11);
     expect(prettyFormat(val)).toBe('2001-09-09T01:46:40.000Z');

--- a/packages/pretty-format/src/__tests__/prettyFormat.test.ts
+++ b/packages/pretty-format/src/__tests__/prettyFormat.test.ts
@@ -277,6 +277,43 @@ describe('prettyFormat()', () => {
     expect(prettyFormat(val)).toBe('0n');
   });
 
+  /* eslint-disable no-new-wrappers, unicorn/new-for-builtins */
+  it('prints a Number wrapper object', () => {
+    const val = new Number(123);
+    expect(prettyFormat(val)).toBe('[Number: 123]');
+  });
+
+  it('prints a Number wrapper object of negative zero', () => {
+    const val = new Number(-0);
+    expect(prettyFormat(val)).toBe('[Number: -0]');
+  });
+
+  it('prints a String wrapper object', () => {
+    const val = new String('string');
+    expect(prettyFormat(val)).toBe('[String: "string"]');
+  });
+
+  it('prints a String wrapper object with escapes', () => {
+    const val = new String('"-"');
+    expect(prettyFormat(val)).toBe('[String: "\\"-\\""]');
+  });
+
+  it('prints a String wrapper object with {escapeString: false}', () => {
+    const val = new String('"-"');
+    expect(prettyFormat(val, {escapeString: false})).toBe('[String: ""-""]');
+  });
+
+  it('prints a Boolean wrapper object', () => {
+    const val = new Boolean(true);
+    expect(prettyFormat(val)).toBe('[Boolean: true]');
+  });
+
+  it('prints a BigInt wrapper object', () => {
+    const val = Object(BigInt(123));
+    expect(prettyFormat(val)).toBe('[BigInt: 123n]');
+  });
+  /* eslint-enable no-new-wrappers, unicorn/new-for-builtins */
+
   it('prints a date', () => {
     const val = new Date(10e11);
     expect(prettyFormat(val)).toBe('2001-09-09T01:46:40.000Z');

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -111,6 +111,24 @@ function printString(val: string, escapeString: boolean): string {
   return `"${val}"`;
 }
 
+/**
+ * A plain object with a matching `Symbol.toStringTag` reaches the wrapper branches
+ * without being a wrapper, and the intrinsic `valueOf` throws on it.
+ */
+function printBoxedPrimitive<T>(
+  val: unknown,
+  valueOf: (this: unknown) => T,
+  print: (primitive: T) => string,
+): string | null {
+  let primitive: T;
+  try {
+    primitive = valueOf.call(val);
+  } catch {
+    return null;
+  }
+  return print(primitive);
+}
+
 function printFunction(val: Function, printFunctionName: boolean): string {
   if (!printFunctionName) {
     return '[Function]';
@@ -185,16 +203,32 @@ function printBasicValue(
     return printSymbol(val);
   }
   if (toStringed === '[object Number]') {
-    return `[Number: ${printNumber(numberValueOf.call(val))}]`;
+    return printBoxedPrimitive(
+      val,
+      numberValueOf,
+      primitive => `[Number: ${printNumber(primitive)}]`,
+    );
   }
   if (toStringed === '[object BigInt]') {
-    return `[BigInt: ${printBigInt(bigIntValueOf.call(val))}]`;
+    return printBoxedPrimitive(
+      val,
+      bigIntValueOf,
+      primitive => `[BigInt: ${printBigInt(primitive)}]`,
+    );
   }
   if (toStringed === '[object Boolean]') {
-    return `[Boolean: ${booleanValueOf.call(val)}]`;
+    return printBoxedPrimitive(
+      val,
+      booleanValueOf,
+      primitive => `[Boolean: ${primitive}]`,
+    );
   }
   if (toStringed === '[object String]') {
-    return `[String: ${printString(stringValueOf.call(val), escapeString)}]`;
+    return printBoxedPrimitive(
+      val,
+      stringValueOf,
+      primitive => `[String: ${printString(primitive, escapeString)}]`,
+    );
   }
   if (toStringed === '[object Date]') {
     return Number.isNaN(+val) ? 'Date { NaN }' : toISOString.call(val);

--- a/packages/pretty-format/src/index.ts
+++ b/packages/pretty-format/src/index.ts
@@ -50,6 +50,10 @@ const toString = Object.prototype.toString;
 const toISOString = Date.prototype.toISOString;
 const errorToString = Error.prototype.toString;
 const regExpToString = RegExp.prototype.toString;
+const bigIntValueOf = BigInt.prototype.valueOf;
+const booleanValueOf = Boolean.prototype.valueOf;
+const numberValueOf = Number.prototype.valueOf;
+const stringValueOf = String.prototype.valueOf;
 
 /**
  * Explicitly comparing typeof constructor to function avoids undefined as name
@@ -100,6 +104,13 @@ function printBigInt(val: bigint): string {
   return String(`${val}n`);
 }
 
+function printString(val: string, escapeString: boolean): string {
+  if (escapeString) {
+    return `"${val.replaceAll(/"|\\/g, '\\$&')}"`;
+  }
+  return `"${val}"`;
+}
+
 function printFunction(val: Function, printFunctionName: boolean): string {
   if (!printFunctionName) {
     return '[Function]';
@@ -144,10 +155,7 @@ function printBasicValue(
     return printBigInt(val);
   }
   if (typeOf === 'string') {
-    if (escapeString) {
-      return `"${val.replaceAll(/"|\\/g, '\\$&')}"`;
-    }
-    return `"${val}"`;
+    return printString(val, escapeString);
   }
   if (typeOf === 'function') {
     return printFunction(val, printFunctionName);
@@ -175,6 +183,18 @@ function printBasicValue(
   }
   if (toStringed === '[object Symbol]') {
     return printSymbol(val);
+  }
+  if (toStringed === '[object Number]') {
+    return `[Number: ${printNumber(numberValueOf.call(val))}]`;
+  }
+  if (toStringed === '[object BigInt]') {
+    return `[BigInt: ${printBigInt(bigIntValueOf.call(val))}]`;
+  }
+  if (toStringed === '[object Boolean]') {
+    return `[Boolean: ${booleanValueOf.call(val)}]`;
+  }
+  if (toStringed === '[object String]') {
+    return `[String: ${printString(stringValueOf.call(val), escapeString)}]`;
   }
   if (toStringed === '[object Date]') {
     return Number.isNaN(+val) ? 'Date { NaN }' : toISOString.call(val);


### PR DESCRIPTION
## Summary

`pretty-format` unwraps every other primitive-like exotic object in `printBasicValue` (`[object Symbol]`, `[object Date]`, `[object Error]`, `[object RegExp]`) but not the four primitive wrappers. They fall through to `printComplexValue`, which prints the constructor name and the own enumerable properties, so the wrapped value is simply lost:

| value | before | after |
| --- | --- | --- |
| `new Number(123)` | `Number {}` | `[Number: 123]` |
| `new Boolean(true)` | `Boolean {}` | `[Boolean: true]` |
| `Object(123n)` | `BigInt {}` | `[BigInt: 123n]` |
| `new String('abc')` | `String { "0": "a", "1": "b", "2": "c" }` | `[String: "abc"]` |

The effect on assertion output is worse than it looks, because two different wrappers serialize to the same empty object. The repository's own committed snapshot for the existing `[new Number(0), new Number(1)]` case in `packages/expect/src/__tests__/matchers.test.js` read:

    expect(received).toEqual(expected) // deep equality

    Expected: {}
    Received: serializes to the same string

Neither value is named. It now reads:

    expect(received).toEqual(expected) // deep equality

    Expected: [Number: 1]
    Received: [Number: 0]

`expect(new Number(0)).toEqual(0)` had the same problem in a more misleading form: it reported `Received: {}`, which reads as "your value is an empty object" rather than "your value is a boxed 0".

`[Number: 0]` matches what `util.inspect` prints and the bracket form `pretty-format` already uses for `[Function name]` and `[Error: message]`. Equality was never wrong here, only the printing.

Two notes on scope:

- The intrinsic `valueOf` functions are captured at module scope, next to the existing `toISOString` / `regExpToString` / `errorToString` captures, so a user-installed `valueOf` cannot change the output.
- Like the existing `Date`, `RegExp` and `Symbol` branches, this returns early from `printBasicValue`, so extra own properties bolted onto a wrapper (`Object.assign(new Number(1), {a: 2})`) are no longer printed. Before this change the wrapped `1` was the part that got dropped instead. Happy to print both if you would rather not lose that.

Snapshots containing a boxed primitive will change. The only ones in this repository are the five in `packages/expect/src/__tests__/__snapshots__/matchers.test.js.snap` updated here.

## Test plan

Seven cases added to `packages/pretty-format/src/__tests__/prettyFormat.test.ts`, covering `Number`, `Number` of `-0`, `String`, `String` with escapes, `String` under `{escapeString: false}`, `Boolean` and `BigInt`.

Reverting only `packages/pretty-format/src/index.ts` and keeping the tests fails them for the right reason, for example:

    ● prettyFormat() › prints a Number wrapper object
        Expected: "[Number: 123]"
        Received: "Number {}"

    ● .toEqual() › {pass: false} expect({}).toEqual({})
        Received:
        Expected: {}
        Received: serializes to the same string

Commands run on macOS, Node 24.13.0:

    yarn build:js
    FORCE_COLOR=1 yarn jest packages/pretty-format          # 391 passed
    FORCE_COLOR=1 yarn jest packages/expect packages/jest-diff packages/jest-matcher-utils packages/jest-snapshot packages/expect-utils
                                                            # 1946 passed, 0 obsolete
    FORCE_COLOR=1 yarn jest --ci                            # 6241 passed
    yarn test-leak                                          # 862 passed
    yarn build:ts && yarn bundle:ts && yarn typecheck:tests  # clean
    yarn lint && yarn lint:prettier:ci                       # clean
    yarn check-changelog <PR> && yarn check-copyright-headers && yarn constraints && yarn dedupe --check

The full `--ci` run has two failures that are identical before and after this change and are local to my machine, not regressions: `e2e/__tests__/showConfig.test.ts` (the `<<REPLACED_JEST_PACKAGES_DIR>>` path normalisation does not match my checkout path) and `e2e/__tests__/jest.config.ts.test.ts` (Node 24.13 phrases `ERR_INVALID_TYPESCRIPT_SYNTAX` differently than the recorded snapshot).
