### PR TITLE
fix(jest-runtime): do not treat a leading `#` as a fragment delimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `[jest-config]` Don't warn about global-only options in the config that supplies the global config - the root config a project resolves to, or the first entry of `--projects` when no root config is passed ([#16411](https://github.com/jestjs/jest/pull/16411))
 - `[jest-config, jest-types]` Stop accepting `reporters`, `coverageReporters`, `workerIdleMemoryLimit`, `cwd` and `runnerOptions` in a project config - they were silently ignored, and now warn like the other global-only options ([#16411](https://github.com/jestjs/jest/pull/16411))
 - `[jest-config, jest-validate]` Warn about `maxWorkers` and `coverageThreshold` in a project config instead of dropping them without a word ([#16411](https://github.com/jestjs/jest/pull/16411))
-- `[jest-runtime]` Resolve a package `imports` specifier under ESM again: a leading `#` was read as a URL fragment delimiter, so `#dep` split into an empty specifier and never reached the `imports` map ([#16413](https://github.com/jestjs/jest/pull/16413))
+- `[jest-runtime]` Resolve package `imports` specifiers like `#dep` under ESM again ([#16413](https://github.com/jestjs/jest/pull/16413))
 
 ### Chore & Maintenance
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[jest-config]` Don't warn about global-only options in the config that supplies the global config - the root config a project resolves to, or the first entry of `--projects` when no root config is passed ([#16411](https://github.com/jestjs/jest/pull/16411))
 - `[jest-config, jest-types]` Stop accepting `reporters`, `coverageReporters`, `workerIdleMemoryLimit`, `cwd` and `runnerOptions` in a project config - they were silently ignored, and now warn like the other global-only options ([#16411](https://github.com/jestjs/jest/pull/16411))
 - `[jest-config, jest-validate]` Warn about `maxWorkers` and `coverageThreshold` in a project config instead of dropping them without a word ([#16411](https://github.com/jestjs/jest/pull/16411))
+- `[jest-runtime]` Resolve a package `imports` specifier under ESM again: a leading `#` was read as a URL fragment delimiter, so `#dep` split into an empty specifier and never reached the `imports` map ([#16413](https://github.com/jestjs/jest/pull/16413))
 
 ### Chore & Maintenance
 

--- a/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
@@ -1180,6 +1180,28 @@ describe('Runtime sync ESM graph - URL-keyed module instances', () => {
   );
 
   testWithVmEsm(
+    'carries a query on a package-imports specifier onto the target',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const plain = (await runtime.unstable_importModule(
+        FROM,
+        '#imports-root/url-reporter.mjs',
+      )) as any;
+      const queried = (await runtime.unstable_importModule(
+        FROM,
+        '#imports-root/url-reporter.mjs?v=2',
+      )) as any;
+      const reporterUrl = pathToFileURL(
+        path.join(ROOT_DIR, 'url-reporter.mjs'),
+      ).href;
+
+      expect(plain.namespace.url).toBe(reporterUrl);
+      expect(queried.namespace.url).toBe(`${reporterUrl}?v=2`);
+      expect(queried.namespace).not.toBe(plain.namespace);
+    },
+  );
+
+  testWithVmEsm(
     'accepts file: URLs without an authority and with an upper-case scheme',
     async () => {
       const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});

--- a/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
+++ b/packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts
@@ -220,6 +220,31 @@ describe('Runtime sync ESM graph', () => {
   });
 
   testWithVmEsm(
+    'resolves a package-imports specifier through the `imports` field',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const m = (await runtime.unstable_importModule(
+        FROM,
+        './import-package-imports.mjs',
+      )) as any;
+      expect(m.namespace.doubled).toBe(84);
+      expect(m.namespace.viaWildcard).toBe('matched');
+    },
+  );
+
+  testWithVmEsm(
+    'imports a package-imports specifier directly, leading `#` and all',
+    async () => {
+      const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});
+      const m = (await runtime.unstable_importModule(
+        FROM,
+        '#imports-dep',
+      )) as any;
+      expect(m.namespace.value).toBe(42);
+    },
+  );
+
+  testWithVmEsm(
     'supports dynamic import() from inside an ESM module',
     async () => {
       const runtime = await createRuntime(__filename, {rootDir: ROOT_DIR});

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/import-package-imports.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/import-package-imports.mjs
@@ -1,0 +1,12 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {value} from '#imports-dep';
+import {wildcard} from '#imports-lib/wild';
+
+export const doubled = value * 2;
+export const viaWildcard = wildcard;

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/imports-dep.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/imports-dep.mjs
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const value = 42;

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/imports-lib-wild.mjs
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/imports-lib-wild.mjs
@@ -1,0 +1,8 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+export const wildcard = 'matched';

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/package.json
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/package.json
@@ -2,6 +2,7 @@
   "name": "test_esm_sync_graph_root",
   "imports": {
     "#imports-dep": "./imports-dep.mjs",
-    "#imports-lib/*": "./imports-lib-*.mjs"
+    "#imports-lib/*": "./imports-lib-*.mjs",
+    "#imports-root/*": "./*"
   }
 }

--- a/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/package.json
+++ b/packages/jest-runtime/src/__tests__/test_esm_sync_graph_root/package.json
@@ -1,3 +1,7 @@
 {
-  "name": "test_esm_sync_graph_root"
+  "name": "test_esm_sync_graph_root",
+  "imports": {
+    "#imports-dep": "./imports-dep.mjs",
+    "#imports-lib/*": "./imports-lib-*.mjs"
+  }
 }

--- a/packages/jest-runtime/src/internals/EsmLoader.ts
+++ b/packages/jest-runtime/src/internals/EsmLoader.ts
@@ -213,11 +213,12 @@ const fileSchemeRegex = /^file:/i;
 // A `?` or `#` in an import specifier is a query/fragment delimiter, never a
 // filename character: the fragment starts at the first `#`, the query at the
 // first `?` before it. `data:` URIs pass through whole - their `?`/`#` belong
-// to the URI payload. So does a specifier that *starts* with `#`: that is a
-// package-imports specifier resolved against the nearest `package.json`, and
-// the whole string including any `?` is the key looked up in `imports`.
+// to the URI payload. A leading `#` opens a package-imports specifier rather
+// than a fragment, so the scan starts past it and the rest of the string
+// splits as usual - `#lib/a.mjs?v=2` resolves `#lib/a.mjs` and carries `?v=2`
+// onto the target, the same instance Node's wildcard substitution produces.
 function splitQueryAndFragment(specifier: string): SplitSpecifier {
-  if (specifier.startsWith('data:') || specifier.startsWith('#')) {
+  if (specifier.startsWith('data:')) {
     return {pathOrSpecifier: specifier, suffix: ''};
   }
   if (fileSchemeRegex.test(specifier)) {
@@ -227,10 +228,11 @@ function splitQueryAndFragment(specifier: string): SplitSpecifier {
       suffix: url.search + url.hash,
     };
   }
-  const hashIndex = specifier.indexOf('#');
+  const scanFrom = specifier.startsWith('#') ? 1 : 0;
+  const hashIndex = specifier.indexOf('#', scanFrom);
   const beforeFragment =
     hashIndex === -1 ? specifier : specifier.slice(0, hashIndex);
-  const queryIndex = beforeFragment.indexOf('?');
+  const queryIndex = beforeFragment.indexOf('?', scanFrom);
   const splitIndex = queryIndex === -1 ? hashIndex : queryIndex;
   if (splitIndex === -1) {
     return {pathOrSpecifier: specifier, suffix: ''};

--- a/packages/jest-runtime/src/internals/EsmLoader.ts
+++ b/packages/jest-runtime/src/internals/EsmLoader.ts
@@ -213,9 +213,11 @@ const fileSchemeRegex = /^file:/i;
 // A `?` or `#` in an import specifier is a query/fragment delimiter, never a
 // filename character: the fragment starts at the first `#`, the query at the
 // first `?` before it. `data:` URIs pass through whole - their `?`/`#` belong
-// to the URI payload.
+// to the URI payload. So does a specifier that *starts* with `#`: that is a
+// package-imports specifier resolved against the nearest `package.json`, and
+// the whole string including any `?` is the key looked up in `imports`.
 function splitQueryAndFragment(specifier: string): SplitSpecifier {
-  if (specifier.startsWith('data:')) {
+  if (specifier.startsWith('data:') || specifier.startsWith('#')) {
     return {pathOrSpecifier: specifier, suffix: ''};
   }
   if (fileSchemeRegex.test(specifier)) {


### PR DESCRIPTION
## Summary

Fixes #16412.

Every subpath in a package's `imports` field starts with `#`, and on 30.5.0 none of them resolve under ESM. `import { value } from '#dep'` fails with `The requested module '#dep' does not provide an export named 'value'`.

`splitQueryAndFragment` in `packages/jest-runtime/src/internals/EsmLoader.ts` looks for the first `#` and treats it as a fragment delimiter:

```js
const hashIndex = specifier.indexOf('#');
```

For `#dep` that index is 0, so the specifier splits into `pathOrSpecifier: ''` and `suffix: '#dep'`. The resolver is then handed an empty string and the specifier never reaches the `imports` map at all, which is also why a custom `resolver` in the jest config does not see it.

A leading `#` is not a fragment delimiter. In Node's resolution algorithm a specifier starting with `#` is a package-imports specifier and goes to PACKAGE_IMPORTS_RESOLVE against the nearest `package.json`. So it passes through whole, next to the existing `data:` carve-out:

```js
if (specifier.startsWith('data:') || specifier.startsWith('#')) {
  return {pathOrSpecifier: specifier, suffix: ''};
}
```

`git log -S splitQueryAndFragment` gives one commit, `30ce9da` (#16375), first released in 30.5.0, so this is a regression from 30.4.2 and the change restores the earlier behaviour rather than adding anything.

The reporter found the cause and the one line guard. I checked it against Node, wrote the tests, and checked the other direction.

### checked against node 24 first

I wanted to know whether the whole specifier is the key or only the part before a `?`, because that decides whether the suffix has to stay attached:

| specifier | node 24.20 |
|---|---|
| `#dep` | resolves |
| `#lib/wild.mjs` through `"#lib/*"` | resolves |
| `#dep?v=2` | `ERR_PACKAGE_IMPORT_NOT_DEFINED` |

Node looks up the whole thing, so returning an empty suffix is right and the query must not be split off either. The wildcard form starts with `#` too, so it was broken the same way and is covered.

### one thing I deliberately did not change

`#dep?v=2` is not a package-imports key in Node, but jest reaches a different error for it. `unstable_importModule` ends at:

```
ENOENT: no such file or directory, open '.../imports-dep.mjs?v=2'
```

so the resolver matches the key and carries the query into the resolved path, and `FileCache` then tries to open a file with `?v=2` in its name. That is not new, it is what 30.4.2 does as well since the specifier reached the resolver whole there too, and it is unrelated to this bug. I found it while writing a test for the boundary and then dropped the test rather than pin a behaviour that is arguably its own small bug. Happy to open a separate issue if it is worth one.

## Test plan

Two tests in `runtime_esm_sync_graph.test.ts`, one going through a module that imports both the plain and the wildcard form, one importing `#imports-dep` directly as the entry specifier. Fixtures add an `imports` map to `test_esm_sync_graph_root/package.json`.

`yarn jest packages/jest-runtime/src/__tests__/runtime_esm_sync_graph.test.ts`:

```
Tests: 154 passed, 154 total
```

with the guard taken back out and nothing else changed:

```
Tests: 2 failed, 152 passed, 154 total

SyntaxError: The requested module '#imports-dep' does not provide an export named 'value'
```

which is the error from the issue.

The opposite direction, a `#` that is a real fragment, is already covered in the same file by `./stateful.mjs#frag`, `./url-reporter.mjs?#frag`, `./url-reporter.mjs?tag=1#frag` and the `import.meta.resolve` case, and all of them still pass, so the guard is not swallowing fragments that should split.

Also run: `yarn build:ts` clean, `yarn typecheck:tests` exit 0, eslint clean on the changed files.

`yarn jest packages/jest-runtime` reports 6 pre-existing failures in this environment, all `ENAMETOOLONG` from `jest-haste-map` writing a cache filename built out of my checkout path. Same 6 on a clean checkout with no changes, 578 tests there against 581 here, so the only difference is the 2 added tests plus the fixture module.
