### PR TITLE
feat(jest-config)!: read the global config from the cwd for multi-project runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[jest-config]` [**BREAKING**] Read the global config from the current working directory when several projects are passed without `--config`, instead of taking it from the first project ([#16412](https://github.com/jestjs/jest/pull/16412))
+
 ### Fixes
 
 - `[jest-config]` Don't warn about global-only options in the config that supplies the global config - the root config a project resolves to, or the first entry of `--projects` when no root config is passed ([#16411](https://github.com/jestjs/jest/pull/16411))

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -342,6 +342,12 @@ If configuration files are found in the specified paths, _all_ projects specifie
 
 :::
 
+:::note
+
+When more than one path is given, the root (global) configuration is read from `--config` if it is passed, and from the current working directory otherwise. Global-only options set in the projects themselves are ignored — see [`projects`](configuration#projects-arraystring--projectconfig) for the list.
+
+:::
+
 ### `--randomize`
 
 Shuffle the order of the tests within a file. The shuffling is based on the seed. See [`--seed=<num>`](#--seednum) for more info.

--- a/e2e/__tests__/multiProjectRunner.test.ts
+++ b/e2e/__tests__/multiProjectRunner.test.ts
@@ -687,7 +687,7 @@ test('does not warn about global options in the root config a project resolves t
   );
 });
 
-test('only warns about global options in projects that do not supply the global config', () => {
+test('warns about global options in every project when none supplies the global config', () => {
   writeFiles(DIR, {
     'p1/jest.config.js': 'module.exports = {testFailureExitCode: 7};',
     'p1/some.test.js': "test('a', () => expect(1).toBe(2));",
@@ -703,11 +703,49 @@ test('only warns about global options in projects that do not supply the global 
     'p2',
   ]);
 
-  // the first project doubles as the global config, so its options do apply
-  expect(exitCode).toBe(7);
+  // the global config comes from the cwd, so neither project's copy applies
+  expect(exitCode).toBe(1);
   expect(
     stderr.match(/Option "testFailureExitCode" is not supported/g),
-  ).toHaveLength(1);
+  ).toHaveLength(2);
+});
+
+test('reads the global config from the cwd when several projects are passed', () => {
+  writeFiles(DIR, {
+    'jest.config.js': 'module.exports = {testFailureExitCode: 7};',
+    'p1/jest.config.js': "module.exports = {displayName: 'p1'};",
+    'p1/some.test.js': "test('a', () => expect(1).toBe(2));",
+    'p2/jest.config.js': "module.exports = {displayName: 'p2'};",
+    'p2/other.test.js': "test('b', () => expect(1).toBe(1));",
+    'package.json': '{}',
+  });
+
+  const {stderr, exitCode} = runJest(DIR, [
+    '--no-watchman',
+    '--projects',
+    'p1',
+    'p2',
+  ]);
+
+  expect(exitCode).toBe(7);
+  expect(stderr).not.toContain(
+    'is not supported in an individual project configuration',
+  );
+});
+
+test('runs several projects without any config in the cwd', () => {
+  writeFiles(DIR, {
+    'p1/jest.config.js': "module.exports = {displayName: 'p1'};",
+    'p1/some.test.js': "test('a', () => expect(1).toBe(1));",
+    'p2/jest.config.js': "module.exports = {displayName: 'p2'};",
+    'p2/other.test.js': "test('b', () => expect(1).toBe(1));",
+  });
+
+  const {exitCode} = runJest(DIR, ['--no-watchman', '--projects', 'p1', 'p2'], {
+    skipPkgJsonCheck: true,
+  });
+
+  expect(exitCode).toBe(0);
 });
 
 test('warns about global options in a project that lives next to the global config', () => {

--- a/packages/jest-config/src/index.ts
+++ b/packages/jest-config/src/index.ts
@@ -14,7 +14,7 @@ import {tryRealpath} from 'jest-util';
 import * as constants from './constants';
 import normalize from './normalize';
 import readConfigFileAndSetRootDir from './readConfigFileAndSetRootDir';
-import resolveConfigPath from './resolveConfigPath';
+import resolveConfigPath, {findConfigPath} from './resolveConfigPath';
 import {isJSONString, replaceRootDirInPath} from './utils';
 
 export {isJSONString} from './utils';
@@ -419,10 +419,17 @@ export async function readConfigs(
       // and its config has `projects` settings, use that value instead.
       projects = globalConfig.projects;
     }
-  } else if (projectPaths.length > 1 && argv.config) {
+  } else if (projectPaths.length > 1) {
     // Every per-project read below sets `skipArgvConfigOption`, so this is the
-    // only place `--config` is read for the global scope.
-    const parsedConfig = await readConfig(argv, process.cwd());
+    // only place the global config is read - from `--config` when it is passed,
+    // and from `process.cwd()` otherwise. Without a config file to read it
+    // from, the global config is made of the defaults alone.
+    const cwd = process.cwd();
+    const globalConfigRoot =
+      argv.config == null && findConfigPath(cwd, cwd, true) == null
+        ? {rootDir: cwd}
+        : cwd;
+    const parsedConfig = await readConfig(argv, globalConfigRoot, false, cwd);
     configPath = parsedConfig.configPath;
     hasDeprecationWarnings = parsedConfig.hasDeprecationWarnings;
     globalConfig = parsedConfig.globalConfig;
@@ -460,10 +467,9 @@ export async function readConfigs(
           // The config that supplies the global config must not be validated
           // as a project config - its global options are in the right place.
           const suppliesGlobalConfig =
-            (globalConfig == null && projectIndex === 0) ||
-            (configPath != null &&
-              typeof root === 'string' &&
-              resolveConfigPath(root, cwd, projectIsCwd) === configPath);
+            configPath != null &&
+            typeof root === 'string' &&
+            resolveConfigPath(root, cwd, projectIsCwd) === configPath;
 
           return readConfig(
             argv,
@@ -484,15 +490,6 @@ export async function readConfigs(
       hasDeprecationWarnings = parsedConfigs.some(
         ({hasDeprecationWarnings}) => !!hasDeprecationWarnings,
       );
-    }
-    // If no config was passed initially, use the one from the first project
-    // TODO: In the next major, read the global config from `process.cwd()` when
-    // several projects are passed without `--config`, the way the `argv.config`
-    // branch above does, and drop this fallback. Today the first project
-    // doubles as the root config, so its global options apply to the whole run
-    // while the same options in the other projects are ignored.
-    if (!globalConfig) {
-      globalConfig = parsedConfigs[0].globalConfig;
     }
   }
 

--- a/packages/jest-config/src/resolveConfigPath.ts
+++ b/packages/jest-config/src/resolveConfigPath.ts
@@ -27,6 +27,24 @@ export default function resolveConfigPath(
   cwd: string,
   skipMultipleConfigError = false,
 ): string {
+  const configPath = findConfigPath(
+    pathToResolve,
+    cwd,
+    skipMultipleConfigError,
+  );
+
+  if (configPath == null) {
+    throw new Error(makeResolutionErrorMessage(pathToResolve, cwd));
+  }
+
+  return configPath;
+}
+
+export function findConfigPath(
+  pathToResolve: string,
+  cwd: string,
+  skipMultipleConfigError = false,
+): string | undefined {
   if (!path.isAbsolute(cwd)) {
     throw new Error(`"cwd" must be an absolute path. cwd: ${cwd}`);
   }
@@ -56,20 +74,13 @@ export default function resolveConfigPath(
     );
   }
 
-  return resolveConfigPathByTraversing(
-    absolutePath,
-    pathToResolve,
-    cwd,
-    skipMultipleConfigError,
-  );
+  return resolveConfigPathByTraversing(absolutePath, skipMultipleConfigError);
 }
 
 const resolveConfigPathByTraversing = (
   pathToResolve: string,
-  initialPath: string,
-  cwd: string,
   skipMultipleConfigError: boolean,
-): string => {
+): string | undefined => {
   const configFiles = JEST_CONFIG_EXT_ORDER.map(ext =>
     path.resolve(pathToResolve, getConfigFilename(ext)),
   ).filter(isFile);
@@ -115,14 +126,12 @@ const resolveConfigPathByTraversing = (
   // This is the system root.
   // We tried everything, config is nowhere to be found ¯\_(ツ)_/¯
   if (pathToResolve === path.dirname(pathToResolve)) {
-    throw new Error(makeResolutionErrorMessage(initialPath, cwd));
+    return undefined;
   }
 
   // go up a level and try it again
   return resolveConfigPathByTraversing(
     path.dirname(pathToResolve),
-    initialPath,
-    cwd,
     skipMultipleConfigError,
   );
 };


### PR DESCRIPTION
## Summary

Holding for the next major.

`jest --projects p1 p2` without `--config` has no root config, so `readConfigs` falls back to the first project's global config. That project's `bail`, `testFailureExitCode`, `passWithNoTests` and the rest silently drive the whole run, while the same options in every other project are dropped. #16411 made the warning consistent with that fallback — it stopped warning about the first project — but the underlying asymmetry stays: which project happens to be listed first decides the run's global options.

This reads the global config from the current working directory instead, the way it already works when `--config` is passed. Every entry of `--projects` is now purely a project, and global-only options in any of them warn and are ignored. The `parsedConfigs[0].globalConfig` fallback and the `TODO` #16411 left behind are gone.

`readConfig(argv, process.cwd())` resolves a config file by traversing up from the cwd and throws when it reaches the system root without finding one, which would break `--projects` in a directory with no `package.json` above it — something that works today. So `resolveConfigPath` is split: `findConfigPath` returns `undefined` at the root, and the default export keeps throwing on top of it. `readConfigs` uses the predicate and builds the global config from `{rootDir: cwd}` when nothing resolves.

Behaviour change, for `--projects` with more than one path and no `--config`:

|                                         | before                         | after              |
| --------------------------------------- | ------------------------------ | ------------------ |
| global-only option in the first project | applies to the run, no warning | ignored, warns     |
| global-only option in any other project | ignored, warns                 | ignored, warns     |
| global-only option in the cwd config    | ignored                        | applies to the run |
| no config resolvable from the cwd       | runs on defaults               | runs on defaults   |

Documented under [`--projects`](https://jestjs.io/docs/cli#--projects-path1--pathn) in `docs/CLI.md`.

## Test plan

`e2e/__tests__/multiProjectRunner.test.ts`:

- the existing "two projects each setting `testFailureExitCode: 7`" case now expects two warnings and exit code 1, where it expected one warning and exit code 7
- new: a `jest.config.js` in the cwd supplies `testFailureExitCode: 7` to a `--projects p1 p2` run — exit code 7, no warnings
- new: `--projects p1 p2` with no config in the cwd at all still runs (`skipPkgJsonCheck`)

```
FORCE_COLOR=1 yarn jest packages/jest-config packages/jest-validate
yarn jest e2e/__tests__/multiProjectRunner e2e/__tests__/multipleConfigs e2e/__tests__/typescriptConfigFile
yarn tsc -p packages/jest-config --noEmit
yarn check-changelog
```