### PR TITLE
revert(jest-resolve): match `moduleNameMapper` against the specifier as written

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `[jest-config]` Don't warn about global-only options in the config that supplies the global config - the root config a project resolves to, or the first entry of `--projects` when no root config is passed ([#16411](https://github.com/jestjs/jest/pull/16411))
 - `[jest-config, jest-types]` Stop accepting `reporters`, `coverageReporters`, `workerIdleMemoryLimit`, `cwd` and `runnerOptions` in a project config - they were silently ignored, and now warn like the other global-only options ([#16411](https://github.com/jestjs/jest/pull/16411))
 - `[jest-config, jest-validate]` Warn about `maxWorkers` and `coverageThreshold` in a project config instead of dropping them without a word ([#16411](https://github.com/jestjs/jest/pull/16411))
+- `[jest-resolve]` Match `moduleNameMapper` patterns against the specifier as written again (reverting [#16390](https://github.com/jestjs/jest/pull/16390)) ([#16417](https://github.com/jestjs/jest/pull/16417))
 - `[jest-runtime]` Resolve package `imports` specifiers like `#dep` under ESM again ([#16413](https://github.com/jestjs/jest/pull/16413))
 
 ### Chore & Maintenance
@@ -80,6 +81,7 @@
 - `[jest-resolve]` Make `getModuleIDAsync` build and cache `data:` URI module IDs the same way as `getModuleID` ([#16370](https://github.com/jestjs/jest/pull/16370))
 - `[jest-resolve]` Keep the `node:` prefix when resolving a core module asynchronously, so a builtin that only exists prefixed (`node:sea`, `node:sqlite`, `node:test`, `node:test/reporters`) resolves instead of failing as a missing bare package ([#16388](https://github.com/jestjs/jest/pull/16388))
 - `[jest-resolve]` Look up manual mocks for `node:` protocol specifiers under the unprefixed name they are stored as ([#16388](https://github.com/jestjs/jest/pull/16388))
+- `[jest-resolve]` Apply `moduleNameMapper` consistently to both spellings of core module specifiers (`fs` vs `node:fs`) ([#16390](https://github.com/jestjs/jest/pull/16390))
 - `[jest-resolve]` Keep virtual and ordinary mock module IDs isolated across test files ([#16296](https://github.com/jestjs/jest/pull/16296))
 - `[jest-resolve]` Guard missing `require.resolve.paths` ([#16052](https://github.com/jestjs/jest/pull/16052))
 - `[jest-resolve, jest-config, jest-runner]` Support a user resolver written as an ES module ([#16332](https://github.com/jestjs/jest/pull/16332))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,6 @@
 - `[jest-resolve]` Make `getModuleIDAsync` build and cache `data:` URI module IDs the same way as `getModuleID` ([#16370](https://github.com/jestjs/jest/pull/16370))
 - `[jest-resolve]` Keep the `node:` prefix when resolving a core module asynchronously, so a builtin that only exists prefixed (`node:sea`, `node:sqlite`, `node:test`, `node:test/reporters`) resolves instead of failing as a missing bare package ([#16388](https://github.com/jestjs/jest/pull/16388))
 - `[jest-resolve]` Look up manual mocks for `node:` protocol specifiers under the unprefixed name they are stored as ([#16388](https://github.com/jestjs/jest/pull/16388))
-- `[jest-resolve]` Apply `moduleNameMapper` consistently to both spellings of core module specifiers (`fs` vs `node:fs`) ([#16390](https://github.com/jestjs/jest/pull/16390))
 - `[jest-resolve]` Keep virtual and ordinary mock module IDs isolated across test files ([#16296](https://github.com/jestjs/jest/pull/16296))
 - `[jest-resolve]` Guard missing `require.resolve.paths` ([#16052](https://github.com/jestjs/jest/pull/16052))
 - `[jest-resolve, jest-config, jest-runner]` Support a user resolver written as an ES module ([#16332](https://github.com/jestjs/jest/pull/16332))

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -815,6 +815,76 @@ describe('core module specifiers', () => {
       ).resolves.toBeNull();
     },
   );
+
+  describe('moduleNameMapper', () => {
+    const mappedModule = require.resolve('../__mocks__/mockJsDependency.js');
+
+    function createMappingResolver(regex: RegExp) {
+      return new Resolver(ModuleMap.create('/'), {
+        extensions: ['.js'],
+        hasCoreModules: true,
+        moduleNameMapper: [{moduleName: './__mocks__/mockJsDependency', regex}],
+      } as ResolverConfig);
+    }
+
+    async function expectMapped(
+      mappingResolver: Resolver,
+      specifier: string,
+    ): Promise<void> {
+      expect(mappingResolver.isCoreModule(specifier)).toBe(false);
+      expect(mappingResolver.resolveModule(src, specifier)).toBe(mappedModule);
+      await expect(
+        mappingResolver.resolveModuleAsync(src, specifier),
+      ).resolves.toBe(mappedModule);
+    }
+
+    async function expectCore(
+      mappingResolver: Resolver,
+      specifier: string,
+    ): Promise<void> {
+      expect(mappingResolver.isCoreModule(specifier)).toBe(true);
+      expect(mappingResolver.resolveModule(src, specifier)).toBe(specifier);
+      await expect(
+        mappingResolver.resolveModuleAsync(src, specifier),
+      ).resolves.toBe(specifier);
+    }
+
+    it('maps only the bare specifier when the pattern targets it', async () => {
+      const mappingResolver = createMappingResolver(/^fs$/);
+
+      await expectMapped(mappingResolver, 'fs');
+      await expectCore(mappingResolver, 'node:fs');
+    });
+
+    it('maps only the prefixed specifier when the pattern targets it', async () => {
+      const mappingResolver = createMappingResolver(/^node:fs$/);
+
+      await expectMapped(mappingResolver, 'node:fs');
+      await expectCore(mappingResolver, 'fs');
+    });
+
+    it('maps both spellings when the pattern makes the prefix optional', async () => {
+      const mappingResolver = createMappingResolver(/^(node:)?fs$/);
+
+      await expectMapped(mappingResolver, 'fs');
+      await expectMapped(mappingResolver, 'node:fs');
+    });
+
+    it('does not map `node:test` from a pattern targeting bare `test`', async () => {
+      await expectCore(createMappingResolver(/^test$/), 'node:test');
+    });
+
+    it('does not map a double prefixed specifier from a pattern targeting `node:fs`', async () => {
+      const mappingResolver = createMappingResolver(/^node:fs$/);
+
+      expect(
+        mappingResolver.resolveStubModuleName(src, 'node:node:fs'),
+      ).toBeNull();
+      await expect(
+        mappingResolver.resolveStubModuleNameAsync(src, 'node:node:fs'),
+      ).resolves.toBeNull();
+    });
+  });
 });
 
 describe('getMockModule', () => {
@@ -1072,7 +1142,8 @@ describe('nodeModulesPaths', () => {
 
   it('does not throw when require.resolve.paths is unavailable', () => {
     const originalResolvePaths = require.resolve.paths;
-    require.resolve.paths = undefined as typeof require.resolve.paths;
+    require.resolve.paths =
+      undefined as unknown as typeof require.resolve.paths;
 
     try {
       const src = require.resolve('../');

--- a/packages/jest-resolve/src/__tests__/resolve.test.ts
+++ b/packages/jest-resolve/src/__tests__/resolve.test.ts
@@ -815,69 +815,6 @@ describe('core module specifiers', () => {
       ).resolves.toBeNull();
     },
   );
-
-  describe('moduleNameMapper', () => {
-    const mappedModule = require.resolve('../__mocks__/mockJsDependency.js');
-
-    function createMappingResolver(regex: RegExp) {
-      return new Resolver(ModuleMap.create('/'), {
-        extensions: ['.js'],
-        hasCoreModules: true,
-        moduleNameMapper: [{moduleName: './__mocks__/mockJsDependency', regex}],
-      } as ResolverConfig);
-    }
-
-    it.each(['fs', 'node:fs'])(
-      'maps %s when the pattern targets the bare specifier',
-      async specifier => {
-        const mappingResolver = createMappingResolver(/^fs$/);
-
-        expect(mappingResolver.isCoreModule(specifier)).toBe(false);
-        expect(mappingResolver.resolveModule(src, specifier)).toBe(
-          mappedModule,
-        );
-        await expect(
-          mappingResolver.resolveModuleAsync(src, specifier),
-        ).resolves.toBe(mappedModule);
-      },
-    );
-
-    it.each(['fs', 'node:fs'])(
-      'maps %s when the pattern targets the prefixed specifier',
-      async specifier => {
-        const mappingResolver = createMappingResolver(/^node:fs$/);
-
-        expect(mappingResolver.isCoreModule(specifier)).toBe(false);
-        expect(mappingResolver.resolveModule(src, specifier)).toBe(
-          mappedModule,
-        );
-        await expect(
-          mappingResolver.resolveModuleAsync(src, specifier),
-        ).resolves.toBe(mappedModule);
-      },
-    );
-
-    it('does not map `node:test` from a pattern targeting bare `test`', async () => {
-      const mappingResolver = createMappingResolver(/^test$/);
-
-      expect(mappingResolver.isCoreModule('node:test')).toBe(true);
-      expect(mappingResolver.resolveModule(src, 'node:test')).toBe('node:test');
-      await expect(
-        mappingResolver.resolveModuleAsync(src, 'node:test'),
-      ).resolves.toBe('node:test');
-    });
-
-    it('does not map a double prefixed specifier from a pattern targeting `node:fs`', async () => {
-      const mappingResolver = createMappingResolver(/^node:fs$/);
-
-      expect(
-        mappingResolver.resolveStubModuleName(src, 'node:node:fs'),
-      ).toBeNull();
-      await expect(
-        mappingResolver.resolveStubModuleNameAsync(src, 'node:node:fs'),
-      ).resolves.toBeNull();
-    });
-  });
 });
 
 describe('getMockModule', () => {

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -541,44 +541,7 @@ export default class Resolver {
       return false;
     }
 
-    const spellings = this._specifierSpellings(moduleName);
-
-    return moduleNameMapper.some(({regex}) =>
-      spellings.some(specifier => regex.test(specifier)),
-    );
-  }
-
-  // Node treats `fs` and `node:fs` as the same module, so a pattern written
-  // for either spelling has to catch both. Builtins that only exist prefixed
-  // (`node:test`, `node:sqlite`) have no bare spelling to test, and a bare
-  // pattern like `^test$` must keep matching the userland package instead.
-  private _specifierSpellings(specifier: string): Array<string> {
-    if (!isBuiltin(specifier)) {
-      return [specifier];
-    }
-
-    if (specifier.startsWith('node:')) {
-      const bareSpecifier = specifier.slice(5);
-      return isBuiltin(bareSpecifier)
-        ? [specifier, bareSpecifier]
-        : [specifier];
-    }
-
-    return [specifier, `node:${specifier}`];
-  }
-
-  private _matchModuleNameMapper(
-    regex: RegExp,
-    moduleName: string,
-  ): RegExpMatchArray | null {
-    for (const specifier of this._specifierSpellings(moduleName)) {
-      const matches = specifier.match(regex);
-      if (matches) {
-        return matches;
-      }
-    }
-
-    return null;
+    return moduleNameMapper.some(({regex}) => regex.test(moduleName));
   }
 
   isCoreModule(moduleName: string): boolean {
@@ -932,7 +895,7 @@ export default class Resolver {
     const resolver = this._options.resolver;
 
     for (const {moduleName: mappedModuleName, regex} of moduleNameMapper) {
-      const matches = this._matchModuleNameMapper(regex, moduleName);
+      const matches = moduleName.match(regex);
       if (matches) {
         // Note: once a moduleNameMapper matches the name, it must result
         // in a module, or else an error is thrown.
@@ -994,7 +957,7 @@ export default class Resolver {
     const resolver = this._options.resolver;
 
     for (const {moduleName: mappedModuleName, regex} of moduleNameMapper) {
-      const matches = this._matchModuleNameMapper(regex, moduleName);
+      const matches = moduleName.match(regex);
       if (matches) {
         // Note: once a moduleNameMapper matches the name, it must result
         // in a module, or else an error is thrown.

--- a/packages/jest-resolve/src/resolver.ts
+++ b/packages/jest-resolve/src/resolver.ts
@@ -535,6 +535,8 @@ export default class Resolver {
       : (moduleName: string) => moduleName;
   }
 
+  // Matched against the specifier as written, so `fs` and `node:fs` are
+  // separately targetable. A pattern for both is `^(node:)?fs$`.
   private _isAliasModule(moduleName: string): boolean {
     const moduleNameMapper = this._options.moduleNameMapper;
     if (!moduleNameMapper) {


### PR DESCRIPTION
## Summary

Reverts #16390, which shipped in 30.5.0 and regressed `moduleNameMapper` for core modules (fixes #16415).

That PR expanded a specifier to both spellings before testing the patterns: `fs` became `['fs', 'node:fs']`, `node:fs` became `['node:fs', 'fs']`. Same set either way, so a pattern matching one spelling matched both. `^buffer$` captured `node:buffer`, and no pattern could say otherwise — the expansion runs before the regex.

| intent | before #16390 | after |
| --- | --- | --- |
| `buffer` only | `^buffer$` | not expressible |
| `node:buffer` only | `^node:buffer$` | not expressible |
| both | `^(node:)?buffer$` | any of the three |

The invariant it protected, `require('buffer') === require('node:buffer')`, was already available as `^(node:)?buffer$`, and still holds through the mock path — `jest.mock('node:buffer', …)` covers both spellings.

#16415 also had no escape hatch: `require`, `createRequire` and `jest.requireActual` all returned the shim, so a polyfill could not re-export from the builtin.

#16388 and #16391 are untouched — they sit behind the `isCoreModule` gate and never see a mapped specifier.

## Test plan

Five cases replace #16390's, each asserting `isCoreModule`, `resolveModule` and `resolveModuleAsync`:

- `^fs$` maps `fs`, leaves `node:fs` core
- `^node:fs$` maps `node:fs`, leaves `fs` core
- `^(node:)?fs$` maps both
- `^test$` leaves `node:test` core
- `^node:fs$` does not match `node:node:fs`

Reintroducing the expansion in `_isAliasModule` fails the first, second and fourth.

```
yarn jest packages/jest-resolve packages/jest-runtime   # 507 passed, 214 skipped
yarn typecheck:tests                                    # exit 0
```

The #16415 repro passes against this branch's build.