### PR TITLE
fix(jest-diff): do not crash diffing a Set or Map that contains a symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - `[jest-each]` Escape a table row's keys before building the `$variable` interpolation `RegExp`, so a column name such as `count(*)` no longer fails the whole table with `Invalid regular expression`, and a `.` or `|` in a column name is matched literally ([#16345](https://github.com/jestjs/jest/pull/16345))
+- `[jest-diff]` Print the diff for a `Set` or `Map` that contains a symbol, instead of failing the assertion with `TypeError: Cannot convert a Symbol value to a string` ([#16418](https://github.com/jestjs/jest/pull/16418))
 
 ### Chore & Maintenance
 

--- a/packages/jest-diff/src/__tests__/diff.test.ts
+++ b/packages/jest-diff/src/__tests__/diff.test.ts
@@ -117,6 +117,51 @@ describe('no visual difference', () => {
   });
 });
 
+describe('values which cannot be coerced to a string', () => {
+  test('Set containing a symbol', () => {
+    const difference = stripped(
+      new Set([Symbol('a'), 1]),
+      new Set([Symbol('a'), 2]),
+    );
+
+    expect(difference).toContain('Symbol(a),');
+    expect(difference).toContain('-   1,');
+    expect(difference).toContain('+   2,');
+  });
+
+  test('Map with a symbol key', () => {
+    const difference = stripped(
+      new Map<unknown, unknown>([
+        [Symbol('a'), 1],
+        ['b', 2],
+      ]),
+      new Map<unknown, unknown>([
+        [Symbol('a'), 1],
+        ['b', 3],
+      ]),
+    );
+
+    expect(difference).toContain('Symbol(a) => 1,');
+    expect(difference).toContain('-   "b" => 2,');
+    expect(difference).toContain('+   "b" => 3,');
+  });
+
+  test('Set containing an object with a throwing toString', () => {
+    const throwing = {
+      toString() {
+        throw new Error('toString should not be called');
+      },
+    };
+    const difference = stripped(
+      new Set<unknown>([throwing, 1]),
+      new Set<unknown>([throwing, 2]),
+    );
+
+    expect(difference).toContain('-   1,');
+    expect(difference).toContain('+   2,');
+  });
+});
+
 test('oneline strings', () => {
   expect(diff('ab', 'aa', optionsCounts)).toMatchSnapshot();
   expect(diff('123456789', '234567890', optionsCounts)).toMatchSnapshot();

--- a/packages/jest-diff/src/index.ts
+++ b/packages/jest-diff/src/index.ts
@@ -126,12 +126,24 @@ function comparePrimitive(
     : diffLinesUnified(aFormat.split('\n'), bFormat.split('\n'), options);
 }
 
+// The default comparator coerces every element with implicit `ToString`, which
+// throws a `TypeError` for symbols and for objects with a throwing `toString`.
+// Sorting only makes insertion order irrelevant, so keeping that order is a far
+// better outcome than replacing the whole diff with the coercion error.
+function sortForDiff<T>(values: Array<T>): Array<T> {
+  try {
+    return [...values].sort();
+  } catch {
+    return values;
+  }
+}
+
 function sortMap(map: Map<unknown, unknown>) {
-  return new Map([...map].sort());
+  return new Map(sortForDiff([...map]));
 }
 
 function sortSet(set: Set<unknown>) {
-  return new Set([...set].sort());
+  return new Set(sortForDiff([...set]));
 }
 
 function compareObjects(


### PR DESCRIPTION
## Summary

A failing assertion on a `Set` or `Map` containing a symbol reports a `TypeError` instead of the diff. On jest 30.5.1:

```js
test('set with symbol', () => {
  const A = Symbol('A');
  expect(new Set([A, 1])).toEqual(new Set([A, 2]));
});
```

```
    TypeError: Cannot convert a Symbol value to a string

    > 3 |   expect(new Set([A, 1])).toEqual(new Set([A, 2]));
        |                           ^
```

`sortMap`/`sortSet` call `[...collection].sort()` with no comparator, and the default comparator coerces every element with implicit `ToString`, which throws for symbols — and for objects with a throwing `toString`. It needs two or more entries, since a one-element sort never calls the comparator. The sort runs before the `try`/`catch` in `compareObjects`, so the error escapes and replaces the whole assertion message.

The sort only exists to make insertion order irrelevant, so this falls back to insertion order when the values cannot be compared. Ordering of every currently-working diff is unchanged. After:

```
  Set {
    Symbol(A),
-   2,
+   1,
  }
```

`sortMap`/`sortSet` and their two tests came in together in `df1a6bcc` (2016) — both tests compare equal collections of numbers, so nothing exercised a value the default comparator cannot coerce.

## Test plan

`FORCE_COLOR=1 yarn jest packages/jest-diff packages/expect packages/jest-matcher-utils packages/jest-snapshot packages/pretty-format` — 1942 pass. `yarn typecheck:tests`, `yarn lint:prettier:ci`, `yarn check-changelog`, `yarn check-copyright-headers`, `yarn constraints` all clean.

Three new cases in `diff.test.ts`: Set with a symbol, Map with a symbol key, Set with a throwing `toString`. Revert `sortForDiff` to `[...x].sort()` and all three fail while the other 161 pass; drop the sort entirely and the two existing "order should be irrelevant" tests fail while the three new ones pass.
