### PR TITLE
feat: strip TypeScript types when no transformer claims the file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Features
 
+- `[@jest/transform]` Strip TypeScript types with Node when no transformer claims a `.ts`, `.mts` or `.cts` file ([#16420](https://github.com/jestjs/jest/pull/16420))
+
 ### Fixes
 
 - `[jest-each]` Escape a table row's keys before building the `$variable` interpolation `RegExp`, so a column name such as `count(*)` no longer fails the whole table with `Invalid regular expression`, and a `.` or `|` in a column name is matched literally ([#16345](https://github.com/jestjs/jest/pull/16345))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- `[@jest/transform]` Strip TypeScript types with Node when no transformer claims a `.ts`, `.mts` or `.cts` file ([#16420](https://github.com/jestjs/jest/pull/16420))
+- `[@jest/transform]` Strip TypeScript types with Node when no transformer claims a `.ts`, `.mts` or `.cts` file ([#16421](https://github.com/jestjs/jest/pull/16421))
 
 ### Fixes
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -2472,6 +2472,8 @@ Jest runs the code of your project as JavaScript, hence a transformer is needed 
 
 See the [Code Transformation](CodeTransformation.md) section for more details and instructions on building your own transformer.
 
+When no transformer matches a `.ts`, `.mts` or `.cts` file, Jest erases its type annotations with [`module.stripTypeScriptTypes()`](https://nodejs.org/api/module.html#modulestriptypescripttypescode-options), the same way Node does. This needs Node.js `^22.13.0` or `>=23.2.0`, and it only erases types — see [Using TypeScript](GettingStarted.md#via-nodes-type-stripping) for the limits. `transformIgnorePatterns` applies, so files under `node_modules` are left alone.
+
 :::tip
 
 Keep in mind that a transformer only runs once per file unless the file has changed.

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -163,6 +163,27 @@ module.exports = {
 
 However, there are some [caveats](https://babeljs.io/docs/en/babel-plugin-transform-typescript#caveats) to using TypeScript with Babel. Because TypeScript support in Babel is purely transpilation, Jest will not type-check your tests as they are run. If you want that, you can use [ts-jest](https://github.com/kulshekhar/ts-jest) instead, or just run the TypeScript compiler [tsc](https://www.typescriptlang.org/docs/handbook/compiler-options.html) separately (or as part of your build process).
 
+#### Via Node's type stripping
+
+Node erases type annotations itself, and Jest uses that whenever no transformer claims a `.ts`, `.mts` or `.cts` file. Set an empty `transform` to take the default `babel-jest` entry out of the way:
+
+```json title="package.json"
+{
+  "jest": {
+    "transform": {}
+  }
+}
+```
+
+Node replaces types with whitespace, so positions line up with your source and no source map is involved. It requires Node.js `^22.13.0` or `>=23.2.0`.
+
+Jest reads the module format the same way it does for JavaScript, so an ESM `.ts` or `.mts` file needs its extension in [`extensionsToTreatAsEsm`](Configuration.md#extensionstotreatasesm-arraystring). Node infers ESM from `.mts` and CommonJS from `.cts` on the extension alone; Jest does not do that yet.
+
+What Node cannot do is compile TypeScript features that emit code. `enum`, `namespace` and parameter properties throw, and so does JSX, which means `.tsx` still needs Babel or `ts-jest`. Two more things to keep in mind:
+
+- `jest.mock()` calls are no longer hoisted above the imports of the module they mock, because `babel-plugin-jest-hoist` is not running. Move them above your `require` calls yourself, or use `jest.unstable_mockModule` with dynamic `import()`.
+- A type imported as a value (`import {SomeType} from 'pkg'`) survives the erasure and fails at link time. Write `import type` for anything that only exists in the type system.
+
 #### Via `ts-jest`
 
 [ts-jest](https://github.com/kulshekhar/ts-jest) is a TypeScript preprocessor with source map support for Jest that lets you use Jest to test projects written in TypeScript.

--- a/e2e/__tests__/nativeTypescriptStrip.test.ts
+++ b/e2e/__tests__/nativeTypescriptStrip.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import {resolve} from 'path';
+import runJest, {json as runWithJson, supportsTypeStripping} from '../runJest';
+
+const describeIfSupported = supportsTypeStripping ? describe : describe.skip;
+
+describeIfSupported('native type stripping', () => {
+  test('strips types when no transformer claims the file', () => {
+    const {exitCode, json} = runWithJson(
+      resolve(__dirname, '../native-typescript-strip'),
+      [],
+      {nodeOptions: '--experimental-vm-modules --no-warnings'},
+    );
+
+    expect(exitCode).toBe(0);
+    expect(json.numTotalTests).toBe(2);
+    expect(json.numPassedTests).toBe(2);
+  });
+
+  test('points at a real transformer for TypeScript that needs code generation', () => {
+    const {exitCode, stderr} = runJest(
+      resolve(__dirname, '../native-typescript-strip-unsupported'),
+      [],
+      {nodeOptions: '--experimental-vm-modules --no-warnings'},
+    );
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain(
+      'TypeScript enum is not supported in strip-only mode',
+    );
+    expect(stderr).toContain('@babel/preset-typescript');
+  });
+});

--- a/e2e/native-typescript-strip-unsupported/__tests__/unsupported.test.ts
+++ b/e2e/native-typescript-strip-unsupported/__tests__/unsupported.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 enum Direction {
   Up,
 }

--- a/e2e/native-typescript-strip-unsupported/__tests__/unsupported.test.ts
+++ b/e2e/native-typescript-strip-unsupported/__tests__/unsupported.test.ts
@@ -1,0 +1,7 @@
+enum Direction {
+  Up,
+}
+
+test('never runs', () => {
+  expect(Direction.Up).toBe(0);
+});

--- a/e2e/native-typescript-strip-unsupported/package.json
+++ b/e2e/native-typescript-strip-unsupported/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "native-typescript-strip-unsupported",
+  "version": "1.0.0",
+  "jest": {
+    "transform": {},
+    "extensionsToTreatAsEsm": [
+      ".ts",
+      ".mts"
+    ],
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/__tests__/**/*.{ts,mts,cts}"
+    ]
+  }
+}

--- a/e2e/native-typescript-strip/__tests__/cjs.test.cts
+++ b/e2e/native-typescript-strip/__tests__/cjs.test.cts
@@ -1,0 +1,8 @@
+const {expect, test} =
+  require('@jest/globals') as typeof import('@jest/globals');
+const {triple} = require('../triple.cts') as typeof import('../triple.cts');
+
+test('strips types from a CJS test file', () => {
+  const value: number = triple(14);
+  expect(value).toBe(42);
+});

--- a/e2e/native-typescript-strip/__tests__/cjs.test.cts
+++ b/e2e/native-typescript-strip/__tests__/cjs.test.cts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 const {expect, test} =
   require('@jest/globals') as typeof import('@jest/globals');
 const {triple} = require('../triple.cts') as typeof import('../triple.cts');

--- a/e2e/native-typescript-strip/__tests__/esm.test.ts
+++ b/e2e/native-typescript-strip/__tests__/esm.test.ts
@@ -1,0 +1,7 @@
+import {expect, test} from '@jest/globals';
+import {double} from '../double.mts';
+
+test('strips types from an ESM test file', () => {
+  const value: number = double(21);
+  expect(value).toBe(42);
+});

--- a/e2e/native-typescript-strip/__tests__/esm.test.ts
+++ b/e2e/native-typescript-strip/__tests__/esm.test.ts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 import {expect, test} from '@jest/globals';
 import {double} from '../double.mts';
 

--- a/e2e/native-typescript-strip/double.mts
+++ b/e2e/native-typescript-strip/double.mts
@@ -1,0 +1,3 @@
+export function double(value: number): number {
+  return value * 2;
+}

--- a/e2e/native-typescript-strip/double.mts
+++ b/e2e/native-typescript-strip/double.mts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 export function double(value: number): number {
   return value * 2;
 }

--- a/e2e/native-typescript-strip/package.json
+++ b/e2e/native-typescript-strip/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "native-typescript-strip",
+  "version": "1.0.0",
+  "jest": {
+    "transform": {},
+    "extensionsToTreatAsEsm": [
+      ".ts",
+      ".mts"
+    ],
+    "testEnvironment": "node",
+    "testMatch": [
+      "**/__tests__/**/*.{ts,mts,cts}"
+    ]
+  }
+}

--- a/e2e/native-typescript-strip/triple.cts
+++ b/e2e/native-typescript-strip/triple.cts
@@ -1,0 +1,5 @@
+type Multiplier = (value: number) => number;
+
+const triple: Multiplier = value => value * 3;
+
+module.exports = {triple};

--- a/e2e/native-typescript-strip/triple.cts
+++ b/e2e/native-typescript-strip/triple.cts
@@ -1,3 +1,10 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
 type Multiplier = (value: number) => number;
 
 const triple: Multiplier = value => value * 3;

--- a/e2e/runJest.ts
+++ b/e2e/runJest.ts
@@ -6,6 +6,7 @@
  *
  */
 
+import * as nodeModule from 'node:module';
 import * as path from 'node:path';
 import {Writable} from 'node:stream';
 import {stripVTControlCharacters as stripAnsi} from 'node:util';
@@ -20,6 +21,13 @@ import {ErrorWithStack} from 'jest-util';
 
 // @ts-expect-error: Type assertion can be removed once @types/node is updated to 23 https://nodejs.org/api/process.html#processfeaturestypescript
 export const useNativeTypeScript = Boolean(process.features.typescript);
+
+// `module.stripTypeScriptTypes` landed in Node 22.13/23.2 and works regardless
+// of `--no-experimental-strip-types`, so it is a wider gate than
+// `process.features.typescript`.
+export const supportsTypeStripping =
+  // @ts-expect-error: not yet typed in @types/node@18
+  typeof nodeModule.stripTypeScriptTypes === 'function';
 
 const JEST_PATH = path.resolve(__dirname, '../packages/jest-cli/bin/jest.js');
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -358,7 +358,10 @@ const config = defineConfig(
     },
   ]
     .flat()
-    .map(config => ({...config, files: ['**/*.ts', '**/*.tsx']})),
+    .map(config => ({
+      ...config,
+      files: ['**/*.ts', '**/*.tsx', '**/*.mts', '**/*.cts'],
+    })),
 
   {
     files: [

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -143,9 +143,10 @@ class ScriptTransformer {
         .update('\0', 'utf8')
         .update(filename)
         .update('\0', 'utf8')
-        // A cache directory can be shared by Node versions that disagree
-        // about whether they can strip types at all.
-        .update(willStripTypes ? 'strip-types' : '')
+        // Node makes no stability promise about stripped output across
+        // versions, and which syntax it rejects moves too. Same reasoning as
+        // babel-jest's own cache key.
+        .update(willStripTypes ? process.version : '')
         .update('\0', 'utf8')
         .update(CACHE_VERSION)
         .digest('hex')

--- a/packages/jest-transform/src/ScriptTransformer.ts
+++ b/packages/jest-transform/src/ScriptTransformer.ts
@@ -33,6 +33,7 @@ import {
   makeInvalidTransformerError,
 } from './runtimeErrorsAndWarnings';
 import shouldInstrument from './shouldInstrument';
+import {canStripTypes, stripTypes} from './stripTypeScriptTypes';
 import type {
   CallerTransformOptions,
   FixedRawSourceMap,
@@ -117,6 +118,7 @@ class ScriptTransformer {
     filename: string,
     transformOptions: TransformOptions,
     transformerCacheKey: string | undefined,
+    willStripTypes: boolean,
   ): string {
     if (transformerCacheKey != null) {
       return createHash('sha1')
@@ -129,20 +131,26 @@ class ScriptTransformer {
         .slice(0, 32);
     }
 
-    return createHash('sha1')
-      .update(fileData)
-      .update('\0', 'utf8')
-      .update(transformOptions.configString)
-      .update('\0', 'utf8')
-      .update(transformOptions.instrument ? 'instrument' : '')
-      .update('\0', 'utf8')
-      .update(callerSupport(transformOptions))
-      .update('\0', 'utf8')
-      .update(filename)
-      .update('\0', 'utf8')
-      .update(CACHE_VERSION)
-      .digest('hex')
-      .slice(0, 32);
+    return (
+      createHash('sha1')
+        .update(fileData)
+        .update('\0', 'utf8')
+        .update(transformOptions.configString)
+        .update('\0', 'utf8')
+        .update(transformOptions.instrument ? 'instrument' : '')
+        .update('\0', 'utf8')
+        .update(callerSupport(transformOptions))
+        .update('\0', 'utf8')
+        .update(filename)
+        .update('\0', 'utf8')
+        // A cache directory can be shared by Node versions that disagree
+        // about whether they can strip types at all.
+        .update(willStripTypes ? 'strip-types' : '')
+        .update('\0', 'utf8')
+        .update(CACHE_VERSION)
+        .digest('hex')
+        .slice(0, 32)
+    );
   }
 
   private _buildTransformCacheKey(pattern: string, filepath: string) {
@@ -180,6 +188,7 @@ class ScriptTransformer {
       filename,
       transformOptions,
       transformerCacheKey,
+      transformer == null && this._shouldStripTypes(filename),
     );
   }
 
@@ -219,6 +228,7 @@ class ScriptTransformer {
       filename,
       transformOptions,
       transformerCacheKey,
+      transformer == null && this._shouldStripTypes(filename),
     );
   }
 
@@ -416,6 +426,10 @@ class ScriptTransformer {
         invariant(transformPath);
         throw new Error(makeInvalidReturnValueError(transformPath));
       }
+    } else if (this._shouldStripTypes(filename)) {
+      // Strip-only replaces types with whitespace, so positions are preserved
+      // and no source map is needed.
+      transformed = {code: stripTypes(content, filename), map: null};
     }
 
     if (transformed.map == null || transformed.map === '') {
@@ -628,7 +642,9 @@ class ScriptTransformer {
 
     const willTransform =
       isInternalModule !== true &&
-      (transformOptions.instrument || this.shouldTransform(filename));
+      (transformOptions.instrument ||
+        this.shouldTransform(filename) ||
+        this._shouldStripTypes(filename));
 
     try {
       if (willTransform) {
@@ -674,7 +690,9 @@ class ScriptTransformer {
 
     const willTransform =
       isInternalModule !== true &&
-      (transformOptions.instrument || this.shouldTransform(filename));
+      (transformOptions.instrument ||
+        this.shouldTransform(filename) ||
+        this._shouldStripTypes(filename));
 
     try {
       if (willTransform) {
@@ -852,6 +870,18 @@ class ScriptTransformer {
     const isIgnored = ignoreRegexp ? ignoreRegexp.test(filename) : false;
 
     return this._config.transform.length > 0 && !isIgnored;
+  }
+
+  // Mirrors what Node does for files no other transform claimed: erase the
+  // types so `vm` gets JavaScript. `transformIgnorePatterns` still applies,
+  // which reproduces Node's refusal to strip anything under `node_modules`.
+  private _shouldStripTypes(filename: string): boolean {
+    if (!canStripTypes(filename)) {
+      return false;
+    }
+    const ignoreRegexp = this._cache.ignorePatternsRegExp;
+
+    return ignoreRegexp ? !ignoreRegexp.test(filename) : true;
   }
 
   canTransformSync(filename: string): boolean {

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -19,6 +19,7 @@ import type {
   Transformer,
   TransformerFactory,
 } from '../types';
+import {supportsTypeStripping} from '../stripTypeScriptTypes';
 
 jest
   .mock('graceful-fs', () => ({
@@ -2185,6 +2186,142 @@ describe('ScriptTransformer', () => {
         .mock.calls.map(([filePath]) => filePath);
 
       expect(new Set(written).size).toBe(2);
+    });
+  });
+
+  (supportsTypeStripping ? describe : describe.skip)('type stripping', () => {
+    beforeEach(() => {
+      mockFs['/fruits/durian.ts'] =
+        'const weight: number = 3;\nmodule.exports = weight;';
+      mockFs['/fruits/durian.tsx'] = 'const node = <div />;';
+      mockFs['/fruits/lychee.ts'] =
+        'enum Size { Small }\nmodule.exports = Size;';
+      mockFs['/node_modules/papaya.ts'] = 'const weight: number = 4;';
+    });
+
+    it('erases types when no transformer claims the file', async () => {
+      const scriptTransformer = await createScriptTransformer({
+        ...config,
+        transform: [],
+      });
+
+      expect(
+        scriptTransformer.transform('/fruits/durian.ts', getCoverageOptions())
+          .code,
+      ).toBe('const weight         = 3;\nmodule.exports = weight;');
+    });
+
+    it('preserves positions rather than emitting a source map', async () => {
+      const scriptTransformer = await createScriptTransformer({
+        ...config,
+        transform: [],
+      });
+
+      const result = scriptTransformer.transform(
+        '/fruits/durian.ts',
+        getCoverageOptions(),
+      );
+
+      expect(result.sourceMapPath).toBeNull();
+      expect(result.code.split('\n')[0]).toHaveLength(
+        mockFs['/fruits/durian.ts'].split('\n')[0].length,
+      );
+    });
+
+    it('leaves `.tsx` alone, since strip-only cannot parse JSX', async () => {
+      const scriptTransformer = await createScriptTransformer({
+        ...config,
+        transform: [],
+      });
+
+      expect(
+        scriptTransformer.transform('/fruits/durian.tsx', getCoverageOptions())
+          .code,
+      ).toBe(mockFs['/fruits/durian.tsx']);
+    });
+
+    it('leaves the file alone when a transformer claims it', async () => {
+      const scriptTransformer = await createScriptTransformer({
+        ...config,
+        transform: [['\\.ts$', 'passthrough-preprocessor', {}]],
+      });
+      jest
+        .mocked(
+          (require('passthrough-preprocessor') as SyncTransformer).process,
+        )
+        .mockImplementation(sourceText => ({code: sourceText}));
+
+      expect(
+        scriptTransformer.transform('/fruits/durian.ts', getCoverageOptions())
+          .code,
+      ).toBe(mockFs['/fruits/durian.ts']);
+    });
+
+    it('honours `transformIgnorePatterns`, like Node refusing `node_modules`', async () => {
+      const scriptTransformer = await createScriptTransformer({
+        ...config,
+        transform: [],
+      });
+
+      expect(
+        scriptTransformer.transform(
+          '/node_modules/papaya.ts',
+          getCoverageOptions(),
+        ).code,
+      ).toBe(mockFs['/node_modules/papaya.ts']);
+    });
+
+    it('points at a real transformer for TypeScript that needs code generation', async () => {
+      const scriptTransformer = await createScriptTransformer({
+        ...config,
+        transform: [],
+      });
+
+      expect(() =>
+        scriptTransformer.transform('/fruits/lychee.ts', getCoverageOptions()),
+      ).toThrow('@babel/preset-typescript');
+    });
+
+    it('keys the cache on whether types were stripped', async () => {
+      const content = mockFs['/fruits/durian.ts'];
+      const options = getTransformOptions(false);
+
+      const stripping = await createScriptTransformer({
+        ...config,
+        transform: [],
+      });
+      stripping.transformSource('/fruits/durian.ts', content, options);
+      const [[strippedPath]] = jest.mocked(writeFileAtomic.sync).mock.calls;
+
+      // Stand in for a Node version too old to strip types, which may well be
+      // reading the same cache directory.
+      jest.resetModules();
+      jest.doMock('../stripTypeScriptTypes', () => ({
+        ...jest.requireActual<typeof import('../stripTypeScriptTypes')>(
+          '../stripTypeScriptTypes',
+        ),
+        canStripTypes: () => false,
+      }));
+
+      try {
+        const passingThrough = await (
+          require('../ScriptTransformer') as typeof import('../ScriptTransformer')
+        ).createScriptTransformer({...config, transform: []});
+        passingThrough.transformSource('/fruits/durian.ts', content, options);
+
+        const written = jest
+          .mocked(
+            (require('write-file-atomic') as typeof import('write-file-atomic'))
+              .sync,
+          )
+          .mock.calls.map(([filePath]) => filePath);
+
+        // An empty list would mean it read the stripped file back out of the cache.
+        expect(written).toHaveLength(1);
+        expect(written[0]).not.toBe(strippedPath);
+      } finally {
+        jest.dontMock('../stripTypeScriptTypes');
+      }
     });
   });
 });

--- a/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
+++ b/packages/jest-transform/src/__tests__/ScriptTransformer.test.ts
@@ -2282,6 +2282,42 @@ describe('ScriptTransformer', () => {
       ).toThrow('@babel/preset-typescript');
     });
 
+    it('keys the cache on the Node version, whose output is not stable', async () => {
+      const scriptTransformer = await createScriptTransformer({
+        ...config,
+        transform: [],
+      });
+      const content = mockFs['/fruits/durian.ts'];
+      const options = getTransformOptions(false);
+
+      scriptTransformer.transformSource('/fruits/durian.ts', content, options);
+
+      const realVersion = process.version;
+      // `process.version` is read-only, so `jest.replaceProperty` cannot restore it.
+      Object.defineProperty(process, 'version', {
+        configurable: true,
+        value: 'v99.0.0',
+      });
+      try {
+        scriptTransformer.transformSource(
+          '/fruits/durian.ts',
+          content,
+          options,
+        );
+      } finally {
+        Object.defineProperty(process, 'version', {
+          configurable: true,
+          value: realVersion,
+        });
+      }
+
+      const written = jest
+        .mocked(writeFileAtomic.sync)
+        .mock.calls.map(([filePath]) => filePath);
+
+      expect(new Set(written).size).toBe(2);
+    });
+
     it('keys the cache on whether types were stripped', async () => {
       const content = mockFs['/fruits/durian.ts'];
       const options = getTransformOptions(false);

--- a/packages/jest-transform/src/stripTypeScriptTypes.ts
+++ b/packages/jest-transform/src/stripTypeScriptTypes.ts
@@ -34,7 +34,7 @@ function burnExperimentalWarning(
 ) {
   warningBurnt = true;
 
-  const {emitWarning} = process;
+  const emitWarning = process.emitWarning.bind(process);
   process.emitWarning = () => undefined;
   try {
     strip('', {mode: 'strip'});

--- a/packages/jest-transform/src/stripTypeScriptTypes.ts
+++ b/packages/jest-transform/src/stripTypeScriptTypes.ts
@@ -34,12 +34,14 @@ function burnExperimentalWarning(
 ) {
   warningBurnt = true;
 
-  const emitWarning = process.emitWarning.bind(process);
+  // Restored through its descriptor so `process` gets the same function object
+  // back, rather than a bound copy.
+  const emitWarning = Object.getOwnPropertyDescriptor(process, 'emitWarning')!;
   process.emitWarning = () => undefined;
   try {
     strip('', {mode: 'strip'});
   } finally {
-    process.emitWarning = emitWarning;
+    Object.defineProperty(process, 'emitWarning', emitWarning);
   }
 }
 

--- a/packages/jest-transform/src/stripTypeScriptTypes.ts
+++ b/packages/jest-transform/src/stripTypeScriptTypes.ts
@@ -1,0 +1,70 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+import * as nodeModule from 'node:module';
+import * as path from 'node:path';
+import {invariant, isError} from 'jest-util';
+
+const nodeStripTypeScriptTypes = (
+  nodeModule as {
+    // `stripTypeScriptTypes` is in Node v22.13+/v23.2+, not yet typed in @types/node@18
+    stripTypeScriptTypes?: (code: string, options: {mode: 'strip'}) => string;
+  }
+).stripTypeScriptTypes;
+
+export const supportsTypeStripping =
+  typeof nodeStripTypeScriptTypes === 'function';
+
+// `.tsx` is absent on purpose - Node's strip-only mode cannot parse JSX.
+const TYPESCRIPT_EXTENSIONS = new Set(['.ts', '.mts', '.cts']);
+
+let warningBurnt = false;
+
+// Node emits a one-off `ExperimentalWarning` the first time the API is called.
+// Jest owns the decision to call it, so burn the warning on a throwaway input
+// rather than printing it out of every worker on every run. Loading the
+// TypeScript parser costs around 20ms, so this waits for a real caller instead
+// of running when the module is imported.
+function burnExperimentalWarning(
+  strip: (code: string, options: {mode: 'strip'}) => string,
+) {
+  warningBurnt = true;
+
+  const {emitWarning} = process;
+  process.emitWarning = () => undefined;
+  try {
+    strip('', {mode: 'strip'});
+  } finally {
+    process.emitWarning = emitWarning;
+  }
+}
+
+export function canStripTypes(filename: string): boolean {
+  return (
+    supportsTypeStripping && TYPESCRIPT_EXTENSIONS.has(path.extname(filename))
+  );
+}
+
+export function stripTypes(code: string, filename: string): string {
+  invariant(nodeStripTypeScriptTypes, 'Node.js cannot strip TypeScript types');
+
+  if (!warningBurnt) {
+    burnExperimentalWarning(nodeStripTypeScriptTypes);
+  }
+
+  try {
+    return nodeStripTypeScriptTypes(code, {mode: 'strip'});
+  } catch (error) {
+    const reason = isError(error) ? error.message : String(error);
+
+    throw new Error(
+      `jest: failed to strip TypeScript types from ${filename}\n\n${reason}\n\n` +
+        'Node.js only erases type annotations - it cannot compile TypeScript features that emit code, such as `enum`, `namespace` and parameter properties. Configure a `transform` using `@babel/preset-typescript` or `ts-jest` to handle this file.',
+      {cause: error},
+    );
+  }
+}


### PR DESCRIPTION
## Summary

Closes #15443.

`node:vm` parses JavaScript only, and there is no option for it — Node's docs point at running the source through `module.stripTypeScriptTypes()` first. `ScriptTransformer` now does that when no transformer claimed a `.ts`, `.mts` or `.cts` file:

```jsonc
{
  "transform": {} // or any config that leaves .ts unclaimed
}
```

Follows Node: keyed on extension, applied on both the CommonJS and ESM paths, and `transformIgnorePatterns` still applies, which reproduces Node's refusal to strip under `node_modules`. Strip-only replaces types with whitespace, so positions survive and no source map is involved. The cache key records whether stripping happened, since one cache directory can be shared by a Node that strips and a Node that cannot.

`.tsx` is left alone. `enum`, `namespace` and parameter properties throw, naming the file and pointing at `@babel/preset-typescript` or `ts-jest`. Needs Node `^22.13.0` or `>=23.2.0`; older versions behave as before.

`stripTypeScriptTypes.ts` burns Node's one-off `ExperimentalWarning` on a throwaway input, on first use rather than at import — the parser costs ~18ms per process and a project with no TypeScript should not pay it.

Out of scope: `transform` still defaults to `babel-jest`, so a config without a `transform` key is unaffected; `.mts`/`.cts` still do not imply a module format, so the fixtures list `.mts` in `extensionsToTreatAsEsm`. Both belong in 31. And without `babel-plugin-jest-hoist`, `jest.mock()` is no longer hoisted above the imports it mocks — documented in `docs/GettingStarted.md`, unsolved.

`eslint.config.mjs` applies the TypeScript configs to `**/*.mts` and `**/*.cts`, which were falling through to espree.

## Test plan

New `describe` in `ScriptTransformer.test.ts` covers erasure, position preservation, `.tsx` and claimed files, `transformIgnorePatterns`, the `enum` error and the cache key. E2E fixtures run a `.ts` ESM suite, a `.cts` CommonJS suite and the `enum` failure, gated on `supportsTypeStripping`.

```
$ yarn jest packages/jest-transform
Tests:       99 passed, 99 total

$ yarn jest e2e/__tests__/nativeTypescriptStrip e2e/__tests__/transform e2e/__tests__/coverage
Tests:       58 passed, 58 total
```

Not asserted in the suite, checked by hand: coverage over stripped sources reports 100% with correct line attribution, and `require('@jest/transform')` stays at ~4.7ms (23ms when the warning was burnt at import).