### PR TITLE
fix: do not inline the package version when bundling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- `[jest-core, jest-haste-map, jest-transform]` Keep `require('../package.json')` external when bundling, so `jest --version` and the transform and haste-map cache keys report the released version instead of the previous one ([#16422](https://github.com/jestjs/jest/pull/16422))
 - `[jest-each]` Escape a table row's keys before building the `$variable` interpolation `RegExp`, so a column name such as `count(*)` no longer fails the whole table with `Invalid regular expression`, and a `.` or `|` in a column name is matched literally ([#16345](https://github.com/jestjs/jest/pull/16345))
 
 ### Chore & Maintenance

--- a/scripts/buildUtils.mjs
+++ b/scripts/buildUtils.mjs
@@ -264,7 +264,18 @@ export function createBuildConfigs() {
           ...separateChunks,
           ...extraEntryPoints,
         },
-        externals: nodeExternals(),
+        externals: [
+          nodeExternals(),
+          // Publishing bumps `package.json` after the build, so an inlined
+          // version would be one release behind. The bundle is emitted to
+          // `<packageDir>/build`, hence the relative path.
+          ({context, request}, callback) =>
+            request != null &&
+            path.resolve(context, request) ===
+              path.join(packageDir, 'package.json')
+              ? callback(null, 'commonjs ../package.json')
+              : callback(),
+        ],
         mode: 'production',
         module: {
           rules: [


### PR DESCRIPTION
## Summary

Fixes #16420.

Webpack inlines `require('../package.json')` into each bundle. A release builds first and lets Lerna bump every `package.json` afterwards, so the published bundles carry the version from before the bump — `@jest/core@30.5.1` ships `"version":"30.5.0"` in its `build/index.js`, and `30.2.0` ships `30.1.3`. `jest --version` and `--debug` print that stale value. `jest-haste-map` and `@jest/transform` read the same constant into their cache keys, so those are labelled one release behind too.

29.7.0 was unaffected: that build emitted one file per module with a real runtime `require`. It regressed in #12348, which moved the build to webpack.

Marking the request external restores the runtime `require`. `webpackIgnore` is not an option — webpack honours it on `import()` and `new URL()`, not on CommonJS `require`; with the magic comment in place the output still reads `__webpack_require__(/* webpackIgnore: true */"./package.json")` and the JSON is still emitted as a module.

The external path is relative to the bundle rather than to the importing source file, so `logDebugMessages.ts` asking for `../../package.json` from `src/lib` lands in the same place as `version.ts` asking for `../package.json`. No source changes needed.

## Test plan

After `yarn build:js`, no `"version":"30.x.y"` literal is left in the `jest-core`, `jest-transform` or `jest-haste-map` bundles, and each contains `module.exports = require("../package.json")`.

Editing `packages/jest-core/package.json` to `99.9.9` *after* building, then running `node packages/jest-cli/bin/jest.js --version`, prints `99.9.9-dev` — the built output reads the file at run time.

`grep -rln 'require("../package.json")' packages/*/build/` matches only the three flat `build/index.js` files. The external assumes a chunk at `build/*.js`; the one nested entry in the build, `jest-jasmine2`'s `jasmine/jasmineLight.js`, does not touch `package.json`.