### PR TITLE
fix(expect): print the arguments of the only call in negative spy matcher messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- `[expect]` Print the arguments of the received call, not its index, in the failure message of a negated `toHaveBeenCalledWith`, `toHaveBeenLastCalledWith` or `toHaveBeenNthCalledWith` on a mock that was called once ([#16426](https://github.com/jestjs/jest/pull/16426))
 - `[jest-core, jest-haste-map, jest-transform]` Keep `require('../package.json')` external when bundling, so `jest --version` and the transform and haste-map cache keys report the released version instead of the previous one ([#16422](https://github.com/jestjs/jest/pull/16422))
 - `[jest-each]` Escape a table row's keys before building the `$variable` interpolation `RegExp`, so a column name such as `count(*)` no longer fails the whole table with `Invalid regular expression`, and a `.` or `|` in a column name is matched literally ([#16345](https://github.com/jestjs/jest/pull/16345))
 

--- a/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.ts.snap
+++ b/packages/expect/src/__tests__/__snapshots__/spyMatchers.test.ts.snap
@@ -334,7 +334,7 @@ exports[`toHaveBeenCalledWith works with arguments that match with matchers 1`] 
 <d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
 Expected: not <g>Any<String></>, <g>Any<String></>
-Received:     <r>0</>, <r>["foo", "bar"]</>
+Received:     <d>"foo"</>, <d>"bar"</>
 
 Number of calls: <r>1</>
 `;
@@ -414,7 +414,7 @@ exports[`toHaveBeenCalledWith works with trailing undefined arguments when expli
 <d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenCalledWith<d>(</><g>...expected</><d>)</>
 
 Expected: not <g>"foo"</>, <g>optionalFn<></>
-Received:     <r>0</>, <r>["foo", undefined]</>
+Received:     <d>"foo"</>, <d>undefined</>
 
 Number of calls: <r>1</>
 `;
@@ -557,7 +557,7 @@ exports[`toHaveBeenLastCalledWith works with arguments that match with matchers 
 <d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
 Expected: not <g>Any<String></>, <g>Any<String></>
-Received:     <r>0</>, <r>["foo", "bar"]</>
+Received:     <d>"foo"</>, <d>"bar"</>
 
 Number of calls: <r>1</>
 `;
@@ -627,7 +627,7 @@ exports[`toHaveBeenLastCalledWith works with trailing undefined arguments when e
 <d>expect(</><r>jest.fn()</><d>).</>not<d>.</>toHaveBeenLastCalledWith<d>(</><g>...expected</><d>)</>
 
 Expected: not <g>"foo"</>, <g>optionalFn<></>
-Received:     <r>0</>, <r>["foo", undefined]</>
+Received:     <d>"foo"</>, <d>undefined</>
 
 Number of calls: <r>1</>
 `;
@@ -811,7 +811,7 @@ exports[`toHaveBeenNthCalledWith works with arguments that match with matchers 1
 
 n: 1
 Expected: not <g>Any<String></>, <g>Any<String></>
-Received:     <r>0</>, <r>["foo", "bar"]</>
+Received:     <d>"foo"</>, <d>"bar"</>
 
 Number of calls: <r>1</>
 `;
@@ -888,7 +888,7 @@ exports[`toHaveBeenNthCalledWith works with trailing undefined arguments when ex
 
 n: 1
 Expected: not <g>"foo"</>, <g>optionalFn<></>
-Received:     <r>0</>, <r>["foo", undefined]</>
+Received:     <d>"foo"</>, <d>undefined</>
 
 Number of calls: <r>1</>
 `;

--- a/packages/expect/src/spyMatchers.ts
+++ b/packages/expect/src/spyMatchers.ts
@@ -120,7 +120,7 @@ const printReceivedCallsNegative = (
 
   const label = 'Received:     ';
   if (isOnlyCall) {
-    return `${label + printReceivedArgs(indexedCalls[0], expected)}\n`;
+    return `${label + printReceivedArgs(indexedCalls[0][1], expected)}\n`;
   }
 
   const printAligned = getRightAlignedPrinter(label);


### PR DESCRIPTION
## Summary

`printReceivedCallsNegative` in `packages/expect/src/spyMatchers.ts` builds its input as `Array<IndexedCall>`, where `IndexedCall = [number, Array<unknown>]`. The multi-call branch destructures that tuple, but the single-call branch passes the whole tuple to `printReceivedArgs`:

```ts
const label = 'Received:     ';
if (isOnlyCall) {
  return `${label + printReceivedArgs(indexedCalls[0], expected)}\n`;   // [i, args]
}

const printAligned = getRightAlignedPrinter(label);

return `Received\n${indexedCalls.reduce(
  (printed: string, [i, args]: IndexedCall) => ...                      // args
```

`printReceivedArgs` maps over its first argument, so it renders the call index as the first "argument" and the entire argument array as the second. `printExpectedReceivedCallsPositive`, 30 lines below, already reads `indexedCalls[0][1]`, and so does `printExpectedReceivedCallsRest` for results.

The branch is reached whenever a negated call matcher fails on a mock that was called exactly once and the expectation is not literally equal to the call, which in practice means an asymmetric matcher in the expectation:

```js
const fn = jest.fn();
fn('foo', 'bar');
expect(fn).not.toHaveBeenCalledWith(expect.any(String), expect.any(String));
```

Before:

```
expect(jest.fn()).not.toHaveBeenCalledWith(...expected)

Expected: not Any<String>, Any<String>
Received:     0, ["foo", "bar"]

Number of calls: 1
```

After:

```
expect(jest.fn()).not.toHaveBeenCalledWith(...expected)

Expected: not Any<String>, Any<String>
Received:     "foo", "bar"

Number of calls: 1
```

Two things are fixed by the same character. The arguments are printed as arguments, and the dim "this argument matched the expectation" highlighting works again: `printReceivedArgs` compares each element against `expected[i]`, and the call index never equals `expect.any(String)`, so every argument used to be printed in received red. That is the reverse of what the positive path does for the same values.

All three call sites are affected: `toHaveBeenCalledWith`, `toHaveBeenLastCalledWith` and `toHaveBeenNthCalledWith`. Behaviour of the matchers themselves is unchanged, only the failure message.

Six committed snapshots in `packages/expect/src/__tests__/__snapshots__/spyMatchers.test.ts.snap` had recorded the old output and are updated here. They are the whole snapshot diff; nothing else in the repository records this shape.

## Test plan

Reverting only `packages/expect/src/spyMatchers.ts` and keeping the updated snapshots fails exactly the six affected tests, for the expected reason:

```
● toHaveBeenLastCalledWith › works with arguments that match with matchers

  - Snapshot  - 1
  + Received  + 1

    Expected: not <g>Any<String></>, <g>Any<String></>
  - Received:     <d>"foo"</>, <d>"bar"</>
  + Received:     <r>0</>, <r>["foo", "bar"]</>

Tests:       6 failed, 144 passed, 150 total
Snapshots:   6 failed, 179 passed, 185 total
```

Restoring the fix returns 150 passed, 185 snapshots passed, 0 written and 0 obsolete.

Commands run on macOS, Node 24.13.0:

```
yarn build:js
FORCE_COLOR=1 yarn jest packages/expect --ci
FORCE_COLOR=1 yarn jest packages/jest-mock packages/jest-snapshot packages/jest-matcher-utils packages/expect-utils --ci
FORCE_COLOR=1 yarn jest --ci
yarn build:ts && yarn bundle:ts && yarn typecheck:tests
yarn lint && yarn lint:prettier:ci
yarn check-changelog && yarn check-copyright-headers && yarn constraints && yarn dedupe --check
```
