### PR TITLE
[docs] Clarify mocking separately installed copies of a module

### DIFF
--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -263,11 +263,7 @@ test('should run example code', () => {
 
 ### `jest.mock(moduleName, factory, options)`
 
-Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional.
-
-`moduleName` is resolved from the file that calls `jest.mock`. If a dependency is installed more than once, the mock applies to the resolved copy. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
-
-For example:
+Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional. For example:
 
 ```js title="banana.js"
 module.exports = () => 'banana';
@@ -280,6 +276,8 @@ const banana = require('../banana'); // banana will be explicitly mocked.
 
 banana(); // will return 'undefined' because the function is auto-mocked.
 ```
+
+`moduleName` is resolved from the calling file, so separately installed copies are mocked independently. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
 
 The second argument can be used to specify an explicit module factory that is being run instead of using Jest's automocking feature:
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -277,7 +277,7 @@ const banana = require('../banana'); // banana will be explicitly mocked.
 banana(); // will return 'undefined' because the function is auto-mocked.
 ```
 
-`moduleName` is resolved from the calling file, so separately installed copies are mocked independently. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
+`moduleName` is resolved from the calling file. Each installed copy is treated as a separate module, so mocking one copy does not affect other copies of the same package. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
 
 The second argument can be used to specify an explicit module factory that is being run instead of using Jest's automocking feature:
 

--- a/docs/JestObjectAPI.md
+++ b/docs/JestObjectAPI.md
@@ -263,7 +263,11 @@ test('should run example code', () => {
 
 ### `jest.mock(moduleName, factory, options)`
 
-Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional. For example:
+Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional.
+
+`moduleName` is resolved from the file that calls `jest.mock`. If a dependency is installed more than once, the mock applies to the resolved copy. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
+
+For example:
 
 ```js title="banana.js"
 module.exports = () => 'banana';

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -37,9 +37,9 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 `jest.mock('config')` resolves `config` from the calling file. Each installed copy is a separate module, so mocking one copy does not mock other copies of the same package.
 
-For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or with nested dependencies in a regular installation.
+For example, a test helper with its own `node_modules/config` can mock that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or when dependencies are nested in a normal installation.
 
-Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both use the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
+Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both resolve to the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
 
 ## Examples
 

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -35,11 +35,11 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 ## Mocking multiple copies of a module
 
-`jest.mock('config')` resolves `config` from the file that calls `jest.mock`. If a package is installed in more than one location, each resolved copy is a different module. Mocking one copy does not mock the others, even when they have the same package name.
+`jest.mock('config')` resolves `config` from the calling file. Each installed copy is a separate module, so mocking one copy does not mock other copies of the same package.
 
-For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link`, or with a physically installed helper that has a nested dependency.
+For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or with nested dependencies in a regular installation.
 
-Register the mock from a test file that resolves the same copy as the code under test. If the helper and the code under test should share one copy, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to make both resolve it. For example, mapping `^config$` to `<rootDir>/node_modules/config` makes both use the project's copy. Only combine the resolutions when both should use the same dependency; different installed versions can legitimately be separate modules.
+Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both use the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
 
 ## Examples
 

--- a/docs/ManualMocks.md
+++ b/docs/ManualMocks.md
@@ -33,6 +33,14 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 :::
 
+## Mocking multiple copies of a module
+
+`jest.mock('config')` resolves `config` from the file that calls `jest.mock`. If a package is installed in more than one location, each resolved copy is a different module. Mocking one copy does not mock the others, even when they have the same package name.
+
+For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link`, or with a physically installed helper that has a nested dependency.
+
+Register the mock from a test file that resolves the same copy as the code under test. If the helper and the code under test should share one copy, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to make both resolve it. For example, mapping `^config$` to `<rootDir>/node_modules/config` makes both use the project's copy. Only combine the resolutions when both should use the same dependency; different installed versions can legitimately be separate modules.
+
 ## Examples
 
 ```bash

--- a/website/versioned_docs/version-29.7/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.7/JestObjectAPI.md
@@ -263,11 +263,7 @@ test('should run example code', () => {
 
 ### `jest.mock(moduleName, factory, options)`
 
-Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional.
-
-`moduleName` is resolved from the file that calls `jest.mock`. If a dependency is installed more than once, the mock applies to the resolved copy. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
-
-For example:
+Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional. For example:
 
 ```js title="banana.js"
 module.exports = () => 'banana';
@@ -280,6 +276,8 @@ const banana = require('../banana'); // banana will be explicitly mocked.
 
 banana(); // will return 'undefined' because the function is auto-mocked.
 ```
+
+`moduleName` is resolved from the calling file, so separately installed copies are mocked independently. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
 
 The second argument can be used to specify an explicit module factory that is being run instead of using Jest's automocking feature:
 

--- a/website/versioned_docs/version-29.7/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.7/JestObjectAPI.md
@@ -277,7 +277,7 @@ const banana = require('../banana'); // banana will be explicitly mocked.
 banana(); // will return 'undefined' because the function is auto-mocked.
 ```
 
-`moduleName` is resolved from the calling file, so separately installed copies are mocked independently. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
+`moduleName` is resolved from the calling file. Each installed copy is treated as a separate module, so mocking one copy does not affect other copies of the same package. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
 
 The second argument can be used to specify an explicit module factory that is being run instead of using Jest's automocking feature:
 

--- a/website/versioned_docs/version-29.7/JestObjectAPI.md
+++ b/website/versioned_docs/version-29.7/JestObjectAPI.md
@@ -263,7 +263,11 @@ test('should run example code', () => {
 
 ### `jest.mock(moduleName, factory, options)`
 
-Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional. For example:
+Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional.
+
+`moduleName` is resolved from the file that calls `jest.mock`. If a dependency is installed more than once, the mock applies to the resolved copy. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
+
+For example:
 
 ```js title="banana.js"
 module.exports = () => 'banana';

--- a/website/versioned_docs/version-29.7/ManualMocks.md
+++ b/website/versioned_docs/version-29.7/ManualMocks.md
@@ -37,9 +37,9 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 `jest.mock('config')` resolves `config` from the calling file. Each installed copy is a separate module, so mocking one copy does not mock other copies of the same package.
 
-For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or with nested dependencies in a regular installation.
+For example, a test helper with its own `node_modules/config` can mock that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or when dependencies are nested in a normal installation.
 
-Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both use the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
+Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both resolve to the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
 
 ## Examples
 

--- a/website/versioned_docs/version-29.7/ManualMocks.md
+++ b/website/versioned_docs/version-29.7/ManualMocks.md
@@ -35,11 +35,11 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 ## Mocking multiple copies of a module
 
-`jest.mock('config')` resolves `config` from the file that calls `jest.mock`. If a package is installed in more than one location, each resolved copy is a different module. Mocking one copy does not mock the others, even when they have the same package name.
+`jest.mock('config')` resolves `config` from the calling file. Each installed copy is a separate module, so mocking one copy does not mock other copies of the same package.
 
-For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link`, or with a physically installed helper that has a nested dependency.
+For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or with nested dependencies in a regular installation.
 
-Register the mock from a test file that resolves the same copy as the code under test. If the helper and the code under test should share one copy, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to make both resolve it. For example, mapping `^config$` to `<rootDir>/node_modules/config` makes both use the project's copy. Only combine the resolutions when both should use the same dependency; different installed versions can legitimately be separate modules.
+Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both use the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
 
 ## Examples
 

--- a/website/versioned_docs/version-29.7/ManualMocks.md
+++ b/website/versioned_docs/version-29.7/ManualMocks.md
@@ -33,6 +33,14 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 :::
 
+## Mocking multiple copies of a module
+
+`jest.mock('config')` resolves `config` from the file that calls `jest.mock`. If a package is installed in more than one location, each resolved copy is a different module. Mocking one copy does not mock the others, even when they have the same package name.
+
+For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link`, or with a physically installed helper that has a nested dependency.
+
+Register the mock from a test file that resolves the same copy as the code under test. If the helper and the code under test should share one copy, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to make both resolve it. For example, mapping `^config$` to `<rootDir>/node_modules/config` makes both use the project's copy. Only combine the resolutions when both should use the same dependency; different installed versions can legitimately be separate modules.
+
 ## Examples
 
 ```bash

--- a/website/versioned_docs/version-30.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-30.0/JestObjectAPI.md
@@ -263,11 +263,7 @@ test('should run example code', () => {
 
 ### `jest.mock(moduleName, factory, options)`
 
-Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional.
-
-`moduleName` is resolved from the file that calls `jest.mock`. If a dependency is installed more than once, the mock applies to the resolved copy. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
-
-For example:
+Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional. For example:
 
 ```js title="banana.js"
 module.exports = () => 'banana';
@@ -280,6 +276,8 @@ const banana = require('../banana'); // banana will be explicitly mocked.
 
 banana(); // will return 'undefined' because the function is auto-mocked.
 ```
+
+`moduleName` is resolved from the calling file, so separately installed copies are mocked independently. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
 
 The second argument can be used to specify an explicit module factory that is being run instead of using Jest's automocking feature:
 

--- a/website/versioned_docs/version-30.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-30.0/JestObjectAPI.md
@@ -277,7 +277,7 @@ const banana = require('../banana'); // banana will be explicitly mocked.
 banana(); // will return 'undefined' because the function is auto-mocked.
 ```
 
-`moduleName` is resolved from the calling file, so separately installed copies are mocked independently. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
+`moduleName` is resolved from the calling file. Each installed copy is treated as a separate module, so mocking one copy does not affect other copies of the same package. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
 
 The second argument can be used to specify an explicit module factory that is being run instead of using Jest's automocking feature:
 

--- a/website/versioned_docs/version-30.0/JestObjectAPI.md
+++ b/website/versioned_docs/version-30.0/JestObjectAPI.md
@@ -263,7 +263,11 @@ test('should run example code', () => {
 
 ### `jest.mock(moduleName, factory, options)`
 
-Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional. For example:
+Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional.
+
+`moduleName` is resolved from the file that calls `jest.mock`. If a dependency is installed more than once, the mock applies to the resolved copy. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
+
+For example:
 
 ```js title="banana.js"
 module.exports = () => 'banana';

--- a/website/versioned_docs/version-30.0/ManualMocks.md
+++ b/website/versioned_docs/version-30.0/ManualMocks.md
@@ -37,9 +37,9 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 `jest.mock('config')` resolves `config` from the calling file. Each installed copy is a separate module, so mocking one copy does not mock other copies of the same package.
 
-For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or with nested dependencies in a regular installation.
+For example, a test helper with its own `node_modules/config` can mock that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or when dependencies are nested in a normal installation.
 
-Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both use the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
+Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both resolve to the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
 
 ## Examples
 

--- a/website/versioned_docs/version-30.0/ManualMocks.md
+++ b/website/versioned_docs/version-30.0/ManualMocks.md
@@ -35,11 +35,11 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 ## Mocking multiple copies of a module
 
-`jest.mock('config')` resolves `config` from the file that calls `jest.mock`. If a package is installed in more than one location, each resolved copy is a different module. Mocking one copy does not mock the others, even when they have the same package name.
+`jest.mock('config')` resolves `config` from the calling file. Each installed copy is a separate module, so mocking one copy does not mock other copies of the same package.
 
-For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link`, or with a physically installed helper that has a nested dependency.
+For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or with nested dependencies in a regular installation.
 
-Register the mock from a test file that resolves the same copy as the code under test. If the helper and the code under test should share one copy, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to make both resolve it. For example, mapping `^config$` to `<rootDir>/node_modules/config` makes both use the project's copy. Only combine the resolutions when both should use the same dependency; different installed versions can legitimately be separate modules.
+Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both use the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
 
 ## Examples
 

--- a/website/versioned_docs/version-30.0/ManualMocks.md
+++ b/website/versioned_docs/version-30.0/ManualMocks.md
@@ -33,6 +33,14 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 :::
 
+## Mocking multiple copies of a module
+
+`jest.mock('config')` resolves `config` from the file that calls `jest.mock`. If a package is installed in more than one location, each resolved copy is a different module. Mocking one copy does not mock the others, even when they have the same package name.
+
+For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link`, or with a physically installed helper that has a nested dependency.
+
+Register the mock from a test file that resolves the same copy as the code under test. If the helper and the code under test should share one copy, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to make both resolve it. For example, mapping `^config$` to `<rootDir>/node_modules/config` makes both use the project's copy. Only combine the resolutions when both should use the same dependency; different installed versions can legitimately be separate modules.
+
 ## Examples
 
 ```bash

--- a/website/versioned_docs/version-30.4/JestObjectAPI.md
+++ b/website/versioned_docs/version-30.4/JestObjectAPI.md
@@ -263,11 +263,7 @@ test('should run example code', () => {
 
 ### `jest.mock(moduleName, factory, options)`
 
-Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional.
-
-`moduleName` is resolved from the file that calls `jest.mock`. If a dependency is installed more than once, the mock applies to the resolved copy. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
-
-For example:
+Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional. For example:
 
 ```js title="banana.js"
 module.exports = () => 'banana';
@@ -280,6 +276,8 @@ const banana = require('../banana'); // banana will be explicitly mocked.
 
 banana(); // will return 'undefined' because the function is auto-mocked.
 ```
+
+`moduleName` is resolved from the calling file, so separately installed copies are mocked independently. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
 
 The second argument can be used to specify an explicit module factory that is being run instead of using Jest's automocking feature:
 

--- a/website/versioned_docs/version-30.4/JestObjectAPI.md
+++ b/website/versioned_docs/version-30.4/JestObjectAPI.md
@@ -277,7 +277,7 @@ const banana = require('../banana'); // banana will be explicitly mocked.
 banana(); // will return 'undefined' because the function is auto-mocked.
 ```
 
-`moduleName` is resolved from the calling file, so separately installed copies are mocked independently. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
+`moduleName` is resolved from the calling file. Each installed copy is treated as a separate module, so mocking one copy does not affect other copies of the same package. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
 
 The second argument can be used to specify an explicit module factory that is being run instead of using Jest's automocking feature:
 

--- a/website/versioned_docs/version-30.4/JestObjectAPI.md
+++ b/website/versioned_docs/version-30.4/JestObjectAPI.md
@@ -263,7 +263,11 @@ test('should run example code', () => {
 
 ### `jest.mock(moduleName, factory, options)`
 
-Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional. For example:
+Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional.
+
+`moduleName` is resolved from the file that calls `jest.mock`. If a dependency is installed more than once, the mock applies to the resolved copy. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
+
+For example:
 
 ```js title="banana.js"
 module.exports = () => 'banana';

--- a/website/versioned_docs/version-30.4/ManualMocks.md
+++ b/website/versioned_docs/version-30.4/ManualMocks.md
@@ -37,9 +37,9 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 `jest.mock('config')` resolves `config` from the calling file. Each installed copy is a separate module, so mocking one copy does not mock other copies of the same package.
 
-For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or with nested dependencies in a regular installation.
+For example, a test helper with its own `node_modules/config` can mock that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or when dependencies are nested in a normal installation.
 
-Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both use the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
+Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both resolve to the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
 
 ## Examples
 

--- a/website/versioned_docs/version-30.4/ManualMocks.md
+++ b/website/versioned_docs/version-30.4/ManualMocks.md
@@ -35,11 +35,11 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 ## Mocking multiple copies of a module
 
-`jest.mock('config')` resolves `config` from the file that calls `jest.mock`. If a package is installed in more than one location, each resolved copy is a different module. Mocking one copy does not mock the others, even when they have the same package name.
+`jest.mock('config')` resolves `config` from the calling file. Each installed copy is a separate module, so mocking one copy does not mock other copies of the same package.
 
-For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link`, or with a physically installed helper that has a nested dependency.
+For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or with nested dependencies in a regular installation.
 
-Register the mock from a test file that resolves the same copy as the code under test. If the helper and the code under test should share one copy, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to make both resolve it. For example, mapping `^config$` to `<rootDir>/node_modules/config` makes both use the project's copy. Only combine the resolutions when both should use the same dependency; different installed versions can legitimately be separate modules.
+Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both use the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
 
 ## Examples
 

--- a/website/versioned_docs/version-30.4/ManualMocks.md
+++ b/website/versioned_docs/version-30.4/ManualMocks.md
@@ -33,6 +33,14 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 :::
 
+## Mocking multiple copies of a module
+
+`jest.mock('config')` resolves `config` from the file that calls `jest.mock`. If a package is installed in more than one location, each resolved copy is a different module. Mocking one copy does not mock the others, even when they have the same package name.
+
+For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link`, or with a physically installed helper that has a nested dependency.
+
+Register the mock from a test file that resolves the same copy as the code under test. If the helper and the code under test should share one copy, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to make both resolve it. For example, mapping `^config$` to `<rootDir>/node_modules/config` makes both use the project's copy. Only combine the resolutions when both should use the same dependency; different installed versions can legitimately be separate modules.
+
 ## Examples
 
 ```bash

--- a/website/versioned_docs/version-30.5/JestObjectAPI.md
+++ b/website/versioned_docs/version-30.5/JestObjectAPI.md
@@ -263,11 +263,7 @@ test('should run example code', () => {
 
 ### `jest.mock(moduleName, factory, options)`
 
-Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional.
-
-`moduleName` is resolved from the file that calls `jest.mock`. If a dependency is installed more than once, the mock applies to the resolved copy. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
-
-For example:
+Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional. For example:
 
 ```js title="banana.js"
 module.exports = () => 'banana';
@@ -280,6 +276,8 @@ const banana = require('../banana'); // banana will be explicitly mocked.
 
 banana(); // will return 'undefined' because the function is auto-mocked.
 ```
+
+`moduleName` is resolved from the calling file, so separately installed copies are mocked independently. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
 
 The second argument can be used to specify an explicit module factory that is being run instead of using Jest's automocking feature:
 

--- a/website/versioned_docs/version-30.5/JestObjectAPI.md
+++ b/website/versioned_docs/version-30.5/JestObjectAPI.md
@@ -277,7 +277,7 @@ const banana = require('../banana'); // banana will be explicitly mocked.
 banana(); // will return 'undefined' because the function is auto-mocked.
 ```
 
-`moduleName` is resolved from the calling file, so separately installed copies are mocked independently. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
+`moduleName` is resolved from the calling file. Each installed copy is treated as a separate module, so mocking one copy does not affect other copies of the same package. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
 
 The second argument can be used to specify an explicit module factory that is being run instead of using Jest's automocking feature:
 

--- a/website/versioned_docs/version-30.5/JestObjectAPI.md
+++ b/website/versioned_docs/version-30.5/JestObjectAPI.md
@@ -263,7 +263,11 @@ test('should run example code', () => {
 
 ### `jest.mock(moduleName, factory, options)`
 
-Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional. For example:
+Mocks a module with an auto-mocked version when it is being required. `factory` and `options` are optional.
+
+`moduleName` is resolved from the file that calls `jest.mock`. If a dependency is installed more than once, the mock applies to the resolved copy. See [Mocking multiple copies of a module](ManualMocks.md#mocking-multiple-copies-of-a-module).
+
+For example:
 
 ```js title="banana.js"
 module.exports = () => 'banana';

--- a/website/versioned_docs/version-30.5/ManualMocks.md
+++ b/website/versioned_docs/version-30.5/ManualMocks.md
@@ -37,9 +37,9 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 `jest.mock('config')` resolves `config` from the calling file. Each installed copy is a separate module, so mocking one copy does not mock other copies of the same package.
 
-For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or with nested dependencies in a regular installation.
+For example, a test helper with its own `node_modules/config` can mock that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or when dependencies are nested in a normal installation.
 
-Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both use the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
+Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both resolve to the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
 
 ## Examples
 

--- a/website/versioned_docs/version-30.5/ManualMocks.md
+++ b/website/versioned_docs/version-30.5/ManualMocks.md
@@ -35,11 +35,11 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 ## Mocking multiple copies of a module
 
-`jest.mock('config')` resolves `config` from the file that calls `jest.mock`. If a package is installed in more than one location, each resolved copy is a different module. Mocking one copy does not mock the others, even when they have the same package name.
+`jest.mock('config')` resolves `config` from the calling file. Each installed copy is a separate module, so mocking one copy does not mock other copies of the same package.
 
-For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link`, or with a physically installed helper that has a nested dependency.
+For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link` or with nested dependencies in a regular installation.
 
-Register the mock from a test file that resolves the same copy as the code under test. If the helper and the code under test should share one copy, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to make both resolve it. For example, mapping `^config$` to `<rootDir>/node_modules/config` makes both use the project's copy. Only combine the resolutions when both should use the same dependency; different installed versions can legitimately be separate modules.
+Register the mock from a test file that resolves the same copy as the code under test. Alternatively, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to map `^config$` to `<rootDir>/node_modules/config`, so both use the project's copy. Only use this mapping if both should share that dependency; the helper may need a different installed version.
 
 ## Examples
 

--- a/website/versioned_docs/version-30.5/ManualMocks.md
+++ b/website/versioned_docs/version-30.5/ManualMocks.md
@@ -33,6 +33,14 @@ If we want to mock Node's built-in modules (e.g.: `fs` or `path`), then explicit
 
 :::
 
+## Mocking multiple copies of a module
+
+`jest.mock('config')` resolves `config` from the file that calls `jest.mock`. If a package is installed in more than one location, each resolved copy is a different module. Mocking one copy does not mock the others, even when they have the same package name.
+
+For example, a test helper with its own `node_modules/config` can register a mock for that copy while the code under test loads the project's `node_modules/config`. This can happen with `npm link`, or with a physically installed helper that has a nested dependency.
+
+Register the mock from a test file that resolves the same copy as the code under test. If the helper and the code under test should share one copy, use [`moduleNameMapper`](Configuration.md#modulenamemapper-objectstring-string--arraystring) to make both resolve it. For example, mapping `^config$` to `<rootDir>/node_modules/config` makes both use the project's copy. Only combine the resolutions when both should use the same dependency; different installed versions can legitimately be separate modules.
+
 ## Examples
 
 ```bash


### PR DESCRIPTION
## Summary

Explain that `jest.mock` resolves from its calling file, so a helper and the code under test can use different copies of the same dependency. Document both workarounds and link the API reference to the guide. Apply the clarification to the current docs and all four published versions.

Closes #14378.

## Test plan

- Verified linked and physically installed helpers, mock registration from the consuming test, and `moduleNameMapper` on Node 22.22.0 and 25.7.0.
- Related runtime/resolver tests: 130 passed.
- Built the English website, checked the new links in all five documentation versions, and checked both updated pages in the browser.
- Full lint, type builds, `typecheck:tests`, copyright, and changelog checks passed.
