### PR TITLE
fix(jest-snapshot): stop walking a cyclic error cause chain forever

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - `[jest-core, jest-haste-map, jest-transform]` Keep `require('../package.json')` external when bundling, so `jest --version` and the transform and haste-map cache keys report the released version instead of the previous one ([#16422](https://github.com/jestjs/jest/pull/16422))
 - `[jest-each]` Escape a table row's keys before building the `$variable` interpolation `RegExp`, so a column name such as `count(*)` no longer fails the whole table with `Invalid regular expression`, and a `.` or `|` in a column name is matched literally ([#16345](https://github.com/jestjs/jest/pull/16345))
+- `[jest-snapshot]` Print `Cause: [Circular cause]` instead of looping forever when the error passed to `toThrowErrorMatchingSnapshot` or `toThrowErrorMatchingInlineSnapshot` has a cyclic `cause` chain ([#16429](https://github.com/jestjs/jest/pull/16429))
 
 ### Chore & Maintenance
 

--- a/packages/jest-snapshot/src/__tests__/throwMatcher.test.ts
+++ b/packages/jest-snapshot/src/__tests__/throwMatcher.test.ts
@@ -69,3 +69,64 @@ describe('throw matcher from promise', () => {
     );
   });
 });
+
+describe('cause chain', () => {
+  const snapshotOf = (received: unknown) => {
+    toThrowErrorMatchingSnapshot.call(mockedContext, received, undefined, true);
+
+    expect(mockedMatch).toHaveBeenCalledTimes(1);
+
+    return mockedMatch.mock.calls[0][0].received;
+  };
+
+  it('walks a chain of causes', () => {
+    const inner = new Error('inner');
+    const middle = new Error('middle', {cause: inner});
+
+    expect(snapshotOf(new Error('outer', {cause: middle}))).toBe(
+      'outer\nCause: middle\nCause: inner',
+    );
+  });
+
+  it('marks an error that is its own cause', () => {
+    const error: Error & {cause?: unknown} = new Error('outer');
+    error.cause = error;
+
+    expect(snapshotOf(error)).toBe('outer\nCause: [Circular cause]');
+  });
+
+  it('marks a cause chain that loops back to an earlier error', () => {
+    const outer: Error & {cause?: unknown} = new Error('outer');
+    const inner: Error & {cause?: unknown} = new Error('inner');
+    outer.cause = inner;
+    inner.cause = outer;
+
+    expect(snapshotOf(outer)).toBe(
+      'outer\nCause: inner\nCause: [Circular cause]',
+    );
+  });
+
+  it('marks a proxy that returns itself as its own cause', () => {
+    const target = new Error('proxied');
+    const proxy: Error = new Proxy(target, {
+      get: (object, property, receiver) =>
+        property === 'cause' ? proxy : Reflect.get(object, property, receiver),
+      has: (object, property) =>
+        property === 'cause' || Reflect.has(object, property),
+    });
+
+    expect(snapshotOf(new Error('outer', {cause: proxy}))).toBe(
+      'outer\nCause: proxied\nCause: [Circular cause]',
+    );
+  });
+
+  it.each([
+    ['an object tagged as an Error', {[Symbol.toStringTag]: 'Error'}],
+    ['a null prototype object', Object.assign(Object.create(null), {cause: 1})],
+    // eslint-disable-next-line no-new-wrappers, unicorn/new-for-builtins
+    ['a boxed primitive', new String('boxed')],
+    ['a number', 42],
+  ])('ignores a cause that is %s', (_name, cause) => {
+    expect(snapshotOf(new Error('outer', {cause}))).toBe('outer');
+  });
+});

--- a/packages/jest-snapshot/src/index.ts
+++ b/packages/jest-snapshot/src/index.ts
@@ -544,9 +544,17 @@ const _toThrowErrorMatchingSnapshot = (
   }
 
   let message = error.message;
+  // A `cause` chain can loop back on itself, so track what has been walked and
+  // mark the repeat like `jest-message-util` does instead of never terminating.
+  const seen = new Set<unknown>([error]);
   while ('cause' in error) {
     error = error.cause;
     if (isError(error) || error instanceof Error) {
+      if (seen.has(error)) {
+        message += '\nCause: [Circular cause]';
+        break;
+      }
+      seen.add(error);
       message += `\nCause: ${error.message}`;
     } else {
       if (typeof error === 'string') {


### PR DESCRIPTION
## Summary

`toThrowErrorMatchingSnapshot` and `toThrowErrorMatchingInlineSnapshot` build the string they hand to the snapshot state by following `error.cause` in a `while ('cause' in error)` loop that keeps no record of the errors it has already walked. If the cause chain loops back on itself the loop never ends: it appends `Cause: ...` until the message string reaches V8's maximum length, and the matcher dies with `RangeError: Invalid string length` instead of producing a snapshot. Wrapping code that sets `cause` from a value that can transitively be the error itself is enough to hit it.

Minimal reproduction:

```js
test('cyclic cause', () => {
  const error = new Error('outer');
  error.cause = error;

  expect(() => {
    throw error;
  }).toThrowErrorMatchingSnapshot();
});
```

Before this change that test fails after several seconds with:

```
RangeError: Invalid string length

  at message (packages/jest-snapshot/src/index.ts:550:36)
```

Root cause: the cause walk has no cycle guard, so a chain that revisits an error is followed forever. `jest-message-util` already guards the same shape of walk with a `seen` set and prints `[Circular cause]`; this makes the snapshot matchers behave the same way, so the example above now snapshots `outer\nCause: [Circular cause]`.

## Test plan

`packages/jest-snapshot/src/__tests__/throwMatcher.test.ts` gains a `cause chain` block. It asserts the exact string passed to `snapshotState.match` for:

- a plain three-error chain, so the existing multi-cause output is unchanged
- an error that is its own cause
- two errors that point at each other
- a `Proxy` that returns itself for `cause` (it is not an `Error.isError`, but it does pass `instanceof Error`, so the loop follows it)
- causes that are not errors and must be ignored: an object carrying `Symbol.toStringTag: 'Error'`, a null prototype object, a boxed `String`, and a number

Reverting only the change in `src/index.ts` turns the three cycle tests red with `RangeError: Invalid string length` at the `Cause:` append, and the rest stay green.

Other hostile inputs I ran against the patched walk, all of which behave exactly as they did before the change: a `cause` getter that throws (the getter's `TypeError` still propagates), a revoked `Proxy` (still throws from `instanceof`), `cause: undefined`, `cause: null`, a symbol cause, a string cause, a 5000-link acyclic chain, an `AggregateError` that is its own cause, and a plain error-like object that is its own cause.

`yarn jest packages/jest-snapshot` goes from 114 passed / 184 total to 122 passed / 192 total, with the same two suites failing before and after (`SnapshotResolver.test.ts` and `printSnapshot.test.ts` fail on my machine on an unmodified checkout too, over ANSI markers in stored snapshots).
